### PR TITLE
Add mobile layout with collapsible pinned result

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -13,6 +13,9 @@ const store = useAppStore()
 const viewport = ref<InstanceType<typeof PreviewViewport> | null>(null)
 const dropZone = ref<InstanceType<typeof DropZone> | null>(null)
 
+// Mobile only: collapse the pinned result to give the command panel more room.
+const resultHidden = ref(false)
+
 // Reflect the theme on <html> so the token overrides in base.css apply.
 watchEffect(() => {
   document.documentElement.dataset.theme = store.theme
@@ -97,12 +100,38 @@ onBeforeUnmount(() => {
 <template>
   <div class="app">
     <AppHeader />
-    <div class="body">
+    <div class="body" :class="{ 'result-collapsed': resultHidden }">
       <SettingsPanel />
       <main class="main">
         <PreviewViewport ref="viewport" />
         <StatsBar />
       </main>
+      <button
+        v-if="store.hasImage"
+        class="result-toggle"
+        type="button"
+        :aria-expanded="!resultHidden"
+        @click="resultHidden = !resultHidden"
+      >
+        <svg
+          class="chev"
+          :class="{ 'is-down': resultHidden }"
+          viewBox="0 0 16 16"
+          width="12"
+          height="12"
+          aria-hidden="true"
+        >
+          <path
+            d="M4 10l4-4 4 4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        {{ resultHidden ? 'Show preview' : 'Hide preview' }}
+      </button>
       <DropZone ref="dropZone" />
     </div>
     <ToastHost />
@@ -131,5 +160,67 @@ onBeforeUnmount(() => {
   flex: 1;
   min-width: 0;
   min-height: 0;
+}
+
+/* The result toggle is a mobile-only affordance; hidden on the desktop split. */
+.result-toggle {
+  display: none;
+}
+
+/* Mobile: stack a pinned result on top of an independently scrolling command
+   panel, with a slim bar to collapse the result when the controls need room. */
+@media (max-width: 768px) {
+  .body {
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .main {
+    /* Pin the result above the settings panel (which is first in DOM order). */
+    order: -2;
+    flex: 0 0 auto;
+    height: 48vh;
+    min-height: 220px;
+  }
+
+  .result-toggle {
+    order: -1;
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    width: 100%;
+    height: 30px;
+    padding: 0;
+    border: none;
+    border-top: 1px solid var(--border);
+    background: var(--bg-1);
+    color: var(--text-2);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  .result-toggle:hover {
+    color: var(--text-1);
+  }
+
+  .result-toggle .chev {
+    transition: transform 0.15s ease;
+  }
+
+  .result-toggle .chev.is-down {
+    transform: rotate(180deg);
+  }
+
+  .body.result-collapsed .main {
+    display: none;
+  }
+
+  /* With the result gone the app header already delimits the toggle. */
+  .body.result-collapsed .result-toggle {
+    border-top-color: transparent;
+  }
 }
 </style>

--- a/apps/web/src/components/PreviewViewport.vue
+++ b/apps/web/src/components/PreviewViewport.vue
@@ -481,6 +481,19 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut })
   flex: 0 0 auto;
 }
 
+/* Mobile: the viewport fills the pinned result region (.main sets its height).
+   Let the toolbar wrap so its controls never overflow a narrow screen. */
+@media (max-width: 768px) {
+  .toolbar {
+    height: auto;
+    min-height: 38px;
+    flex-wrap: wrap;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    row-gap: 5px;
+  }
+}
+
 .tabs {
   display: flex;
   gap: 2px;

--- a/apps/web/src/components/SettingsPanel.vue
+++ b/apps/web/src/components/SettingsPanel.vue
@@ -625,6 +625,17 @@ function isActiveSuggestion(sug: PaletteSuggestion): boolean {
   gap: 14px;
 }
 
+/* Mobile: the command fills the space beneath the pinned result and scrolls
+   on its own (the toggle bar above it provides the visual separation). */
+@media (max-width: 768px) {
+  .panel {
+    width: 100%;
+    flex: 1;
+    min-height: 0;
+    border-right: none;
+  }
+}
+
 .group {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/components/StatsBar.vue
+++ b/apps/web/src/components/StatsBar.vue
@@ -300,4 +300,24 @@ async function copySwatch(hex: string): Promise<void> {
 .spacer {
   flex: 1;
 }
+
+/* Mobile: wrap the clusters instead of overflowing off-screen, and keep the
+   export actions on their own full-width row so Download stays reachable. */
+@media (max-width: 768px) {
+  .stats {
+    height: auto;
+    flex-wrap: wrap;
+    row-gap: 8px;
+    padding: 8px 10px;
+  }
+
+  .spacer {
+    flex-basis: 100%;
+    height: 0;
+  }
+
+  .export {
+    flex-wrap: wrap;
+  }
+}
 </style>

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -86,6 +86,66 @@ try {
     return { svg, stats }
   }
 
+  // Verify the mobile layout: a pinned result above an independently scrolling
+  // command panel, plus a toggle that hides/restores the result (see the
+  // ≤768px media queries in the SFCs and the toggle in App.vue).
+  async function checkMobileLayout() {
+    const mobile = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      deviceScaleFactor: 2,
+      isMobile: true,
+      hasTouch: true,
+    })
+    try {
+      const mp = await mobile.newPage()
+      await mp.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'domcontentloaded' })
+      await mp.waitForSelector('.sample-card', { timeout: 20000 })
+      await mp.locator('.sample-card').nth(0).click()
+      await mp.waitForSelector('.layer-svg svg', { timeout: 120000 })
+      await mp.waitForTimeout(800)
+
+      const layout = await mp.evaluate(() => {
+        const main = document.querySelector('.main')?.getBoundingClientRect()
+        const panel = document.querySelector('.panel')?.getBoundingClientRect()
+        const scroll = document.querySelector('.panel-scroll')
+        return {
+          resultVisible: !!main && main.height > 0,
+          resultAbovePanel: main && panel ? main.top < panel.top : false,
+          commandScrolls: scroll ? scroll.scrollHeight > scroll.clientHeight + 1 : false,
+          noHorizontalOverflow: document.documentElement.scrollWidth <= window.innerWidth,
+        }
+      })
+      if (!layout.resultVisible) fail('mobile: result should be visible by default')
+      if (!layout.resultAbovePanel) fail('mobile: result should sit above the command panel')
+      if (!layout.commandScrolls) fail('mobile: command panel should scroll independently')
+      if (!layout.noHorizontalOverflow) fail('mobile: layout overflows horizontally')
+      await mp.screenshot({ path: join(artifactsDir, 'mobile.png') })
+
+      // The toggle hides the result to free space for the controls…
+      await mp.locator('.result-toggle').click()
+      await mp.waitForTimeout(300)
+      const hidden = await mp.evaluate(
+        () => (document.querySelector('.main')?.getClientRects().length ?? 0) === 0,
+      )
+      if (!hidden) fail('mobile: toggle should hide the result')
+
+      // …and restores it.
+      await mp.locator('.result-toggle').click()
+      await mp.waitForTimeout(300)
+      const restored = await mp.evaluate(
+        () => (document.querySelector('.main')?.getBoundingClientRect().height ?? 0) > 0,
+      )
+      if (!restored) fail('mobile: toggle should restore the result')
+
+      console.log('  mobile: result pinned ✓  above-command ✓  command-scrolls ✓  toggle ✓')
+    } finally {
+      await mobile.close()
+    }
+  }
+
+  console.log('E2E: mobile layout — pinned result + toggle (390×844)…')
+  await checkMobileLayout()
+
   console.log('E2E: sample "Badge" (color, stacked)…')
   const badge = await loadSampleAndTrace(0, 'badge')
   if (!badge.svg.includes('<path')) fail('badge produced no paths')


### PR DESCRIPTION
Implements a mobile-optimized layout for screens ≤768px that stacks the preview result above the command panel with an independent scroll area, plus a toggle button to collapse the result and free space for controls.

## Changes

- **App.vue**: Added `resultHidden` state and a collapsible result toggle button that appears only on mobile. The toggle shows/hides the `.main` preview area and rotates a chevron icon. Applied `result-collapsed` class to `.body` to hide the result when toggled.

- **Mobile layout (≤768px media queries)**:
  - `.body`: Changed to `flex-direction: column` with `overflow: hidden` to enable independent scrolling regions
  - `.main`: Pinned to top with fixed 48vh height (min 220px), reordered above settings panel using `order: -2`
  - `.result-toggle`: New 30px bar between result and command panel with chevron icon and toggle text, reordered with `order: -1`
  - `.panel` (SettingsPanel): Takes remaining space and scrolls independently; removed right border on mobile
  - `.toolbar` (PreviewViewport): Wraps controls to prevent horizontal overflow on narrow screens
  - `.stats` (StatsBar): Wraps clusters and keeps export actions on full-width row for reachability

- **E2E tests**: Added `checkMobileLayout()` test that verifies the mobile layout with a 390×844 viewport, confirms result is pinned above the command panel, validates independent scrolling, and tests the toggle functionality.

## Implementation Details

The mobile layout uses CSS `order` to reorder flex children without changing DOM order, keeping the result visually above the command panel while maintaining semantic HTML structure. The toggle button's chevron rotates 180° when collapsed for clear visual feedback. The result region has a minimum height to ensure the preview remains usable even on small screens.

https://claude.ai/code/session_019hPBTGUu4XeowuCVCRwbpX