### PR TITLE
Add geometry extraction and complexity overlay for SVG inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ On top of that, three things most tracers don't do:
   `<rect>`/`<circle>` detection), tiny-feature warnings below cuttable size.
 - **Studio UI**: drag & drop / paste / samples, split & difference views with
   zoom/pan, a **node overlay** (toggle, `N`) that draws every path's anchor
-  points, Bézier handles and outlines so you can see the traced geometry's
-  complexity at a glance, per-stage timings, palette swatches, node/path/byte
-  stats, download / copy / data-URI export, dark & light themes, keyboard
-  shortcuts.
+  points, Bézier handles and outlines — color-coded by element kind (traced
+  paths vs. `rect`/`circle`/`ellipse` primitives, with a legend) so you can see
+  the traced geometry's complexity at a glance, per-stage timings, palette
+  swatches, node/path/byte stats, download / copy / data-URI export, dark &
+  light themes, keyboard shortcuts.
 - **Deterministic**: same image + same settings ⇒ byte-identical SVG.
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ On top of that, three things most tracers don't do:
   control, **path minification** (relative/H/V commands, collinear cleanup,
   `<rect>`/`<circle>` detection), tiny-feature warnings below cuttable size.
 - **Studio UI**: drag & drop / paste / samples, split & difference views with
-  zoom/pan, per-stage timings, palette swatches, node/path/byte stats,
-  download / copy / data-URI export, dark & light themes, keyboard shortcuts.
+  zoom/pan, a **node overlay** (toggle, `N`) that draws every path's anchor
+  points, Bézier handles and outlines so you can see the traced geometry's
+  complexity at a glance, per-stage timings, palette swatches, node/path/byte
+  stats, download / copy / data-URI export, dark & light themes, keyboard
+  shortcuts.
 - **Deterministic**: same image + same settings ⇒ byte-identical SVG.
 
 ## Quick start

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -18,7 +18,8 @@ src/
   App.vue                layout grid, keyboard shortcuts, theme binding
   store/appStore.ts       the single source of truth (Pinia setup store)
   worker/vectorize.worker.ts   installWorkerHandler(self) — the engine, off the main thread
-  lib/                    decode (image → RasterImage), download/copy, fidelity scoring, samples, format helpers
+  lib/                    decode (image → RasterImage), download/copy, fidelity scoring, samples, format helpers,
+                          overlay (per-element-kind colors/labels for the complexity overlay)
   components/             AppHeader, DropZone, SettingsPanel, MlTools, PreviewViewport, PreviewOverlay, StatsBar, ExportBar, ToastHost
   components/controls/    ControlRow / SliderRow / SelectRow / SwitchRow / ColorRow / TextRow
   styles/base.css         design tokens (dark + light), shared component classes

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -19,7 +19,7 @@ src/
   store/appStore.ts       the single source of truth (Pinia setup store)
   worker/vectorize.worker.ts   installWorkerHandler(self) — the engine, off the main thread
   lib/                    decode (image → RasterImage), download/copy, fidelity scoring, samples, format helpers
-  components/             AppHeader, DropZone, SettingsPanel, MlTools, PreviewViewport, StatsBar, ExportBar, ToastHost
+  components/             AppHeader, DropZone, SettingsPanel, MlTools, PreviewViewport, PreviewOverlay, StatsBar, ExportBar, ToastHost
   components/controls/    ControlRow / SliderRow / SelectRow / SwitchRow / ColorRow / TextRow
   styles/base.css         design tokens (dark + light), shared component classes
 ```

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -83,6 +83,10 @@ function onKeyDown(event: KeyboardEvent): void {
     case '0':
       viewport.value?.zoom100()
       break
+    case 'n':
+    case 'N':
+      viewport.value?.toggleNodes()
+      break
     default:
       break
   }

--- a/apps/web/src/components/PreviewOverlay.vue
+++ b/apps/web/src/components/PreviewOverlay.vue
@@ -2,12 +2,15 @@
 import type { PathCommand } from '@vectorizer/core'
 import type { SvgGeometry } from '@vectorizer/svg'
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { SHAPE_KIND_TOKEN } from '../lib/overlay'
 
 /**
  * Inspection overlay: draws the traced SVG's path outlines, on-curve anchor
  * points (small `x`) and Bézier control handles on a canvas above the preview,
- * so the density and shape of the geometry is visible at a glance. Purely a
- * read-out — it never captures pointer events.
+ * so the density and shape of the geometry is visible at a glance. Each element
+ * kind is tinted with its own color (traced paths vs. rect/circle/ellipse
+ * primitives), so simplified shapes stand out. Purely a read-out — it never
+ * captures pointer events.
  *
  * Everything is drawn in screen space and redrawn on any pan/zoom, so anchor
  * marks keep a constant on-screen size at every zoom level. Geometry points are
@@ -53,7 +56,7 @@ function countGeometry(geo: SvgGeometry | null): void {
   controlCount = 0
   if (!geo) return
   for (const shape of geo.shapes) {
-    for (const cmd of shape) {
+    for (const cmd of shape.commands) {
       if (cmd.type === 'Z') continue
       nodeCount++
       if (cmd.type === 'Q') controlCount += 1
@@ -127,82 +130,113 @@ function draw(): void {
   const my = (y: number): number => props.ty + y * sy
 
   const styles = getComputedStyle(el)
-  const accent = styles.getPropertyValue('--accent').trim() || '#6c7bff'
-  const accentStrong = styles.getPropertyValue('--accent-strong').trim() || '#8894ff'
+  const tokenCache = new Map<string, string>()
+  const tokenColor = (token: string): string => {
+    let c = tokenCache.get(token)
+    if (c === undefined) {
+      c = styles.getPropertyValue(token).trim() || '#6c7bff'
+      tokenCache.set(token, c)
+    }
+    return c
+  }
   const halo = props.dark ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.55)'
-
-  // Outlines — one path for the whole document.
-  const outline = new Path2D()
-  for (const shape of geo.shapes) replayOutline(outline, shape, sx, sy)
-  ctx.lineJoin = 'round'
-  ctx.lineCap = 'round'
-  ctx.strokeStyle = accent
-  ctx.globalAlpha = 0.85
-  ctx.lineWidth = OUTLINE_WIDTH
-  ctx.stroke(outline)
-  ctx.globalAlpha = 1
 
   const showNodes = nodeCount <= NODE_LIMIT
   const showHandles = showNodes && controlCount > 0 && controlCount <= HANDLE_LIMIT
 
-  // Bézier handles: lines tying each control point to its anchor, plus a small
-  // square at every control point (drawn on top, so distinct from the anchor
-  // crosses).
-  if (showHandles) {
-    const handles = new Path2D()
-    const dots: number[] = []
-    for (const shape of geo.shapes) {
+  // Group every shape into a per-color bucket keyed by its element kind, so all
+  // paths, all rects, etc. can each be stroked in one pass in their own hue.
+  const buckets = new Map<string, Bucket>()
+  const bucketFor = (color: string): Bucket => {
+    let b = buckets.get(color)
+    if (b === undefined) {
+      b = { outline: new Path2D(), handles: new Path2D(), dots: [], marks: new Path2D() }
+      buckets.set(color, b)
+    }
+    return b
+  }
+
+  for (const shape of geo.shapes) {
+    const b = bucketFor(tokenColor(SHAPE_KIND_TOKEN[shape.kind]))
+    replayOutline(b.outline, shape.commands, sx, sy)
+    if (showNodes) {
+      for (const cmd of shape.commands) {
+        if (cmd.type !== 'Z') addCross(b.marks, mx(cmd.x), my(cmd.y))
+      }
+    }
+    if (showHandles) {
       let cx = 0
       let cy = 0
-      for (const cmd of shape) {
+      for (const cmd of shape.commands) {
         if (cmd.type === 'M' || cmd.type === 'L') {
           cx = cmd.x
           cy = cmd.y
         } else if (cmd.type === 'Q') {
-          addHandle(handles, dots, mx(cx), my(cy), mx(cmd.x1), my(cmd.y1))
-          handles.moveTo(mx(cmd.x), my(cmd.y))
-          handles.lineTo(mx(cmd.x1), my(cmd.y1))
+          addHandle(b.handles, b.dots, mx(cx), my(cy), mx(cmd.x1), my(cmd.y1))
+          b.handles.moveTo(mx(cmd.x), my(cmd.y))
+          b.handles.lineTo(mx(cmd.x1), my(cmd.y1))
           cx = cmd.x
           cy = cmd.y
         } else if (cmd.type === 'C') {
-          addHandle(handles, dots, mx(cx), my(cy), mx(cmd.x1), my(cmd.y1))
-          addHandle(handles, dots, mx(cmd.x), my(cmd.y), mx(cmd.x2), my(cmd.y2))
+          addHandle(b.handles, b.dots, mx(cx), my(cy), mx(cmd.x1), my(cmd.y1))
+          addHandle(b.handles, b.dots, mx(cmd.x), my(cmd.y), mx(cmd.x2), my(cmd.y2))
           cx = cmd.x
           cy = cmd.y
         }
       }
     }
-    ctx.strokeStyle = accent
-    ctx.globalAlpha = 0.4
-    ctx.lineWidth = HANDLE_WIDTH
-    ctx.stroke(handles)
-    ctx.globalAlpha = 0.6
-    ctx.fillStyle = accent
-    const side = CONTROL_RADIUS * 2
-    for (let p = 0; p < dots.length; p += 2) {
-      ctx.fillRect(dots[p] - CONTROL_RADIUS, dots[p + 1] - CONTROL_RADIUS, side, side)
-    }
-    ctx.globalAlpha = 1
   }
 
-  // Anchor marks — small crosses, haloed so they read over any fill.
-  if (showNodes) {
-    const marks = new Path2D()
-    for (const shape of geo.shapes) {
-      for (const cmd of shape) {
-        if (cmd.type === 'Z') continue
-        addCross(marks, mx(cmd.x), my(cmd.y))
+  ctx.lineJoin = 'round'
+  ctx.lineCap = 'round'
+
+  // Outlines (bottom layer).
+  ctx.globalAlpha = 0.85
+  ctx.lineWidth = OUTLINE_WIDTH
+  for (const [color, b] of buckets) {
+    ctx.strokeStyle = color
+    ctx.stroke(b.outline)
+  }
+
+  // Bézier handles: lines to each control point, then a small square on it.
+  if (showHandles) {
+    const side = CONTROL_RADIUS * 2
+    for (const [color, b] of buckets) {
+      ctx.strokeStyle = color
+      ctx.globalAlpha = 0.4
+      ctx.lineWidth = HANDLE_WIDTH
+      ctx.stroke(b.handles)
+      ctx.fillStyle = color
+      ctx.globalAlpha = 0.6
+      for (let p = 0; p < b.dots.length; p += 2) {
+        ctx.fillRect(b.dots[p] - CONTROL_RADIUS, b.dots[p + 1] - CONTROL_RADIUS, side, side)
       }
     }
-    ctx.strokeStyle = halo
-    ctx.lineWidth = NODE_WIDTH + 1.5
-    ctx.stroke(marks)
-    ctx.strokeStyle = accentStrong
-    ctx.lineWidth = NODE_WIDTH
-    ctx.stroke(marks)
   }
 
+  // Anchor marks — small crosses on top, haloed so they read over any fill.
+  if (showNodes) {
+    for (const [color, b] of buckets) {
+      ctx.globalAlpha = 1
+      ctx.strokeStyle = halo
+      ctx.lineWidth = NODE_WIDTH + 1.5
+      ctx.stroke(b.marks)
+      ctx.strokeStyle = color
+      ctx.lineWidth = NODE_WIDTH
+      ctx.stroke(b.marks)
+    }
+  }
+
+  ctx.globalAlpha = 1
   if (props.clipX !== null) ctx.restore()
+}
+
+/** Per-color accumulation of everything drawn for one element kind. */
+interface Bucket {
+  outline: Path2D
+  handles: Path2D
+  dots: number[]
+  marks: Path2D
 }
 
 /** Add a handle line (anchor → control) and record the control point. */

--- a/apps/web/src/components/PreviewOverlay.vue
+++ b/apps/web/src/components/PreviewOverlay.vue
@@ -1,0 +1,269 @@
+<script setup lang="ts">
+import type { PathCommand } from '@vectorizer/core'
+import type { SvgGeometry } from '@vectorizer/svg'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+/**
+ * Inspection overlay: draws the traced SVG's path outlines, on-curve anchor
+ * points (small `x`) and Bézier control handles on a canvas above the preview,
+ * so the density and shape of the geometry is visible at a glance. Purely a
+ * read-out — it never captures pointer events.
+ *
+ * Everything is drawn in screen space and redrawn on any pan/zoom, so anchor
+ * marks keep a constant on-screen size at every zoom level. Geometry points are
+ * in viewBox units (== document px); the document is placed at
+ * `translate(tx, ty) scale(scale)`, so a point maps to screen as
+ * `tx + x * scale`, `ty + y * scale`.
+ */
+
+const props = defineProps<{
+  geometry: SvgGeometry | null
+  scale: number
+  tx: number
+  ty: number
+  docW: number
+  docH: number
+  /** Left screen edge to clip drawing from (split view); null ⇒ no clip. */
+  clipX: number | null
+  dark: boolean
+}>()
+
+// Constant on-screen sizing (CSS px).
+const NODE_HALF = 3
+const NODE_WIDTH = 1.25
+const OUTLINE_WIDTH = 1
+const HANDLE_WIDTH = 1
+const CONTROL_RADIUS = 1.6
+// Above these totals the overlay declutters: handles drop out first, then
+// anchor marks, leaving the outlines that still convey overall complexity.
+const HANDLE_LIMIT = 4000
+const NODE_LIMIT = 60000
+
+const canvas = ref<HTMLCanvasElement | null>(null)
+let observer: ResizeObserver | null = null
+let raf = 0
+
+// Anchor / control totals, refreshed when the geometry changes; drive the
+// declutter thresholds without re-walking the commands every frame.
+let nodeCount = 0
+let controlCount = 0
+
+function countGeometry(geo: SvgGeometry | null): void {
+  nodeCount = 0
+  controlCount = 0
+  if (!geo) return
+  for (const shape of geo.shapes) {
+    for (const cmd of shape) {
+      if (cmd.type === 'Z') continue
+      nodeCount++
+      if (cmd.type === 'Q') controlCount += 1
+      else if (cmd.type === 'C') controlCount += 2
+    }
+  }
+}
+
+function schedule(): void {
+  if (raf !== 0) return
+  raf = requestAnimationFrame(() => {
+    raf = 0
+    draw()
+  })
+}
+
+function replayOutline(path: Path2D, shape: readonly PathCommand[], sx: number, sy: number): void {
+  const mx = (x: number): number => props.tx + x * sx
+  const my = (y: number): number => props.ty + y * sy
+  for (const cmd of shape) {
+    switch (cmd.type) {
+      case 'M':
+        path.moveTo(mx(cmd.x), my(cmd.y))
+        break
+      case 'L':
+        path.lineTo(mx(cmd.x), my(cmd.y))
+        break
+      case 'Q':
+        path.quadraticCurveTo(mx(cmd.x1), my(cmd.y1), mx(cmd.x), my(cmd.y))
+        break
+      case 'C':
+        path.bezierCurveTo(mx(cmd.x1), my(cmd.y1), mx(cmd.x2), my(cmd.y2), mx(cmd.x), my(cmd.y))
+        break
+      case 'Z':
+        path.closePath()
+        break
+    }
+  }
+}
+
+function draw(): void {
+  const el = canvas.value
+  if (!el) return
+  const ctx = el.getContext('2d')
+  if (!ctx) return
+
+  const dpr = window.devicePixelRatio || 1
+  const cssW = el.clientWidth
+  const cssH = el.clientHeight
+  const bw = Math.max(1, Math.round(cssW * dpr))
+  const bh = Math.max(1, Math.round(cssH * dpr))
+  if (el.width !== bw) el.width = bw
+  if (el.height !== bh) el.height = bh
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  ctx.clearRect(0, 0, cssW, cssH)
+
+  const geo = props.geometry
+  if (!geo || geo.shapes.length === 0) return
+
+  if (props.clipX !== null) {
+    ctx.save()
+    ctx.beginPath()
+    ctx.rect(props.clipX, 0, Math.max(0, cssW - props.clipX), cssH)
+    ctx.clip()
+  }
+
+  // viewBox → document px (usually 1:1) folded into the screen scale.
+  const sx = props.scale * (props.docW > 0 ? props.docW / (geo.width || props.docW) : 1)
+  const sy = props.scale * (props.docH > 0 ? props.docH / (geo.height || props.docH) : 1)
+  const mx = (x: number): number => props.tx + x * sx
+  const my = (y: number): number => props.ty + y * sy
+
+  const styles = getComputedStyle(el)
+  const accent = styles.getPropertyValue('--accent').trim() || '#6c7bff'
+  const accentStrong = styles.getPropertyValue('--accent-strong').trim() || '#8894ff'
+  const halo = props.dark ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.55)'
+
+  // Outlines — one path for the whole document.
+  const outline = new Path2D()
+  for (const shape of geo.shapes) replayOutline(outline, shape, sx, sy)
+  ctx.lineJoin = 'round'
+  ctx.lineCap = 'round'
+  ctx.strokeStyle = accent
+  ctx.globalAlpha = 0.85
+  ctx.lineWidth = OUTLINE_WIDTH
+  ctx.stroke(outline)
+  ctx.globalAlpha = 1
+
+  const showNodes = nodeCount <= NODE_LIMIT
+  const showHandles = showNodes && controlCount > 0 && controlCount <= HANDLE_LIMIT
+
+  // Bézier handles: lines tying each control point to its anchor, plus a small
+  // square at every control point (drawn on top, so distinct from the anchor
+  // crosses).
+  if (showHandles) {
+    const handles = new Path2D()
+    const dots: number[] = []
+    for (const shape of geo.shapes) {
+      let cx = 0
+      let cy = 0
+      for (const cmd of shape) {
+        if (cmd.type === 'M' || cmd.type === 'L') {
+          cx = cmd.x
+          cy = cmd.y
+        } else if (cmd.type === 'Q') {
+          addHandle(handles, dots, mx(cx), my(cy), mx(cmd.x1), my(cmd.y1))
+          handles.moveTo(mx(cmd.x), my(cmd.y))
+          handles.lineTo(mx(cmd.x1), my(cmd.y1))
+          cx = cmd.x
+          cy = cmd.y
+        } else if (cmd.type === 'C') {
+          addHandle(handles, dots, mx(cx), my(cy), mx(cmd.x1), my(cmd.y1))
+          addHandle(handles, dots, mx(cmd.x), my(cmd.y), mx(cmd.x2), my(cmd.y2))
+          cx = cmd.x
+          cy = cmd.y
+        }
+      }
+    }
+    ctx.strokeStyle = accent
+    ctx.globalAlpha = 0.4
+    ctx.lineWidth = HANDLE_WIDTH
+    ctx.stroke(handles)
+    ctx.globalAlpha = 0.6
+    ctx.fillStyle = accent
+    const side = CONTROL_RADIUS * 2
+    for (let p = 0; p < dots.length; p += 2) {
+      ctx.fillRect(dots[p] - CONTROL_RADIUS, dots[p + 1] - CONTROL_RADIUS, side, side)
+    }
+    ctx.globalAlpha = 1
+  }
+
+  // Anchor marks — small crosses, haloed so they read over any fill.
+  if (showNodes) {
+    const marks = new Path2D()
+    for (const shape of geo.shapes) {
+      for (const cmd of shape) {
+        if (cmd.type === 'Z') continue
+        addCross(marks, mx(cmd.x), my(cmd.y))
+      }
+    }
+    ctx.strokeStyle = halo
+    ctx.lineWidth = NODE_WIDTH + 1.5
+    ctx.stroke(marks)
+    ctx.strokeStyle = accentStrong
+    ctx.lineWidth = NODE_WIDTH
+    ctx.stroke(marks)
+  }
+
+  if (props.clipX !== null) ctx.restore()
+}
+
+/** Add a handle line (anchor → control) and record the control point. */
+function addHandle(
+  lines: Path2D,
+  dots: number[],
+  ax: number,
+  ay: number,
+  cx: number,
+  cy: number,
+): void {
+  lines.moveTo(ax, ay)
+  lines.lineTo(cx, cy)
+  dots.push(cx, cy)
+}
+
+function addCross(path: Path2D, x: number, y: number): void {
+  path.moveTo(x - NODE_HALF, y - NODE_HALF)
+  path.lineTo(x + NODE_HALF, y + NODE_HALF)
+  path.moveTo(x - NODE_HALF, y + NODE_HALF)
+  path.lineTo(x + NODE_HALF, y - NODE_HALF)
+}
+
+watch(
+  () => props.geometry,
+  (geo) => {
+    countGeometry(geo)
+    schedule()
+  },
+  { immediate: true },
+)
+
+watch(
+  () => [props.scale, props.tx, props.ty, props.docW, props.docH, props.clipX, props.dark],
+  schedule,
+)
+
+onMounted(() => {
+  observer = new ResizeObserver(schedule)
+  if (canvas.value) observer.observe(canvas.value)
+  schedule()
+})
+
+onBeforeUnmount(() => {
+  observer?.disconnect()
+  observer = null
+  if (raf !== 0) cancelAnimationFrame(raf)
+})
+</script>
+
+<template>
+  <canvas ref="canvas" class="overlay" aria-hidden="true" />
+</template>
+
+<style scoped>
+.overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 2;
+}
+</style>

--- a/apps/web/src/components/PreviewViewport.vue
+++ b/apps/web/src/components/PreviewViewport.vue
@@ -2,9 +2,10 @@
 import { clamp } from '@vectorizer/core'
 import type { RasterImage } from '@vectorizer/core'
 import { extractGeometry } from '@vectorizer/svg'
-import type { SvgGeometry } from '@vectorizer/svg'
+import type { SvgElementKind, SvgGeometry } from '@vectorizer/svg'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { formatCount, STAGE_LABELS } from '../lib/format'
+import { SHAPE_KIND_LABEL, SHAPE_KIND_TOKEN } from '../lib/overlay'
 import { useAppStore } from '../store/appStore'
 import PreviewOverlay from './PreviewOverlay.vue'
 
@@ -86,6 +87,31 @@ const overlayClipX = computed(() => (view.value === 'split' ? dividerX.value : n
 function toggleNodes(): void {
   showNodes.value = !showNodes.value
 }
+
+// Per-kind tally for the overlay legend: how many of each element kind, sorted
+// most-common first, each with the color the overlay tints it.
+interface LegendItem {
+  kind: SvgElementKind
+  count: number
+  token: string
+  label: string
+}
+const overlayLegend = computed<LegendItem[]>(() => {
+  const geo = geometry.value
+  if (!geo) return []
+  const counts = new Map<SvgElementKind, number>()
+  for (const shape of geo.shapes) {
+    counts.set(shape.kind, (counts.get(shape.kind) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .map(([kind, count]) => ({
+      kind,
+      count,
+      token: SHAPE_KIND_TOKEN[kind],
+      label: SHAPE_KIND_LABEL[kind],
+    }))
+    .toSorted((a, b) => b.count - a.count)
+})
 
 const VIEWS: ReadonlyArray<{ id: ViewMode; label: string; key: string }> = [
   { id: 'split', label: 'Split', key: '1' },
@@ -504,11 +530,13 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut, toggleNodes })
         <kbd>Enter</kbd> apply · <kbd>Esc</kbd> cancel
       </span>
 
-      <!-- Complexity readout -->
-      <span v-if="showNodes && hasResult && store.result" class="nodes-chip chip chip--accent">
-        {{ formatCount(store.result.stats.pathCount) }} paths ·
-        {{ formatCount(store.result.stats.nodeCount) }} nodes
-      </span>
+      <!-- Complexity readout: a per-element-kind legend, colored to match the overlay -->
+      <div v-if="showNodes && overlayLegend.length" class="nodes-chip chip">
+        <span v-for="item in overlayLegend" :key="item.kind" class="legend-item">
+          <span class="legend-dot" :style="{ background: `var(${item.token})` }" />
+          {{ formatCount(item.count) }} {{ item.label }}{{ item.count === 1 ? '' : 's' }}
+        </span>
+      </div>
 
       <!-- Worker error card -->
       <div v-if="store.error && !store.busy" class="error-card card">
@@ -804,7 +832,23 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut, toggleNodes })
   right: 10px;
   bottom: 10px;
   z-index: 5;
+  height: auto;
+  padding: 3px 9px;
+  gap: 9px;
   pointer-events: none;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-2);
+}
+
+.legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
 }
 
 .error-card {

--- a/apps/web/src/components/PreviewViewport.vue
+++ b/apps/web/src/components/PreviewViewport.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { clamp } from '@vectorizer/core'
 import type { RasterImage } from '@vectorizer/core'
+import { extractGeometry } from '@vectorizer/svg'
+import type { SvgGeometry } from '@vectorizer/svg'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { STAGE_LABELS } from '../lib/format'
+import { formatCount, STAGE_LABELS } from '../lib/format'
 import { useAppStore } from '../store/appStore'
+import PreviewOverlay from './PreviewOverlay.vue'
 
 type ViewMode = 'split' | 'result' | 'original' | 'diff'
 
@@ -19,6 +22,7 @@ const tx = ref(0)
 const ty = ref(0)
 const splitFrac = ref(0.5)
 const checker = ref(true)
+const showNodes = ref(false)
 let hasUserTransformed = false
 let resizeObserver: ResizeObserver | null = null
 
@@ -66,6 +70,22 @@ const svgLayerStyle = computed(() =>
 )
 
 const dividerX = computed(() => tx.value + splitFrac.value * docW.value * scale.value)
+
+// --------------------------- Complexity overlay --------------------------
+// Path anchors, control handles and outlines decoded from the result SVG, so
+// their density shows the geometric complexity. Parsed only while the toggle is
+// on (and only when the SVG layer is visible).
+const geometry = computed<SvgGeometry | null>(() =>
+  showNodes.value && showSvg.value && store.result ? extractGeometry(store.result.svg) : null,
+)
+
+// Clip the overlay to the SVG side of the split so it does not bleed over the
+// original image; unclipped in the full result view.
+const overlayClipX = computed(() => (view.value === 'split' ? dividerX.value : null))
+
+function toggleNodes(): void {
+  showNodes.value = !showNodes.value
+}
 
 const VIEWS: ReadonlyArray<{ id: ViewMode; label: string; key: string }> = [
   { id: 'split', label: 'Split', key: '1' },
@@ -306,7 +326,7 @@ const progressLabel = computed(() => {
 
 const zoomReadout = computed(() => `${Math.round(scale.value * 100)}%`)
 
-defineExpose({ setView, fit, zoom100, zoomIn, zoomOut })
+defineExpose({ setView, fit, zoom100, zoomIn, zoomOut, toggleNodes })
 </script>
 
 <template>
@@ -360,6 +380,30 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut })
           <svg viewBox="0 0 14 14" width="12" height="12" aria-hidden="true">
             <path d="M0 0h7v7H0zM7 7h7v7H7z" fill="currentColor" opacity="0.85" />
             <path d="M7 0h7v7H7zM0 7h7v7H0z" fill="currentColor" opacity="0.25" />
+          </svg>
+        </button>
+        <button
+          class="btn btn-ghost btn-icon btn-sm"
+          :class="{ 'is-on': showNodes }"
+          :disabled="!hasResult"
+          title="Show path nodes & outlines (N)"
+          aria-label="Show path nodes and outlines"
+          :aria-pressed="showNodes"
+          @click="toggleNodes"
+        >
+          <svg viewBox="0 0 14 14" width="12" height="12" aria-hidden="true">
+            <path
+              d="M2 11 6 4l6 3.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.2"
+              opacity="0.7"
+            />
+            <path
+              d="M1 10l2 2M3 10l-2 2M5 3l2 2M7 3l-2 2M11 6.5l2 2M13 6.5l-2 2"
+              stroke="currentColor"
+              stroke-width="1.2"
+            />
           </svg>
         </button>
       </div>
@@ -419,6 +463,19 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut })
         </div>
       </div>
 
+      <!-- Complexity overlay (screen space, above the SVG layer) -->
+      <PreviewOverlay
+        v-if="geometry"
+        :geometry="geometry"
+        :scale="scale"
+        :tx="tx"
+        :ty="ty"
+        :doc-w="docW"
+        :doc-h="docH"
+        :clip-x="overlayClipX"
+        :dark="store.theme === 'dark'"
+      />
+
       <!-- Split divider (screen space) -->
       <div
         v-if="view === 'split' && hasResult && image"
@@ -445,6 +502,12 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut })
       <span v-if="store.magicActive" class="magic-chip chip chip--accent">
         {{ store.magicPoints.length }} point{{ store.magicPoints.length === 1 ? '' : 's' }} ·
         <kbd>Enter</kbd> apply · <kbd>Esc</kbd> cancel
+      </span>
+
+      <!-- Complexity readout -->
+      <span v-if="showNodes && hasResult && store.result" class="nodes-chip chip chip--accent">
+        {{ formatCount(store.result.stats.pathCount) }} paths ·
+        {{ formatCount(store.result.stats.nodeCount) }} nodes
       </span>
 
       <!-- Worker error card -->
@@ -734,6 +797,14 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut })
   transform: translateX(-50%);
   bottom: 10px;
   z-index: 5;
+}
+
+.nodes-chip {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  z-index: 5;
+  pointer-events: none;
 }
 
 .error-card {

--- a/apps/web/src/lib/overlay.ts
+++ b/apps/web/src/lib/overlay.ts
@@ -1,0 +1,28 @@
+import type { SvgElementKind } from '@vectorizer/svg'
+
+/**
+ * Color the complexity overlay tints each SVG element kind with, as a design
+ * token name (resolved to a real color by the canvas, used directly as
+ * `var(--…)` by the legend). Traced `<path>` geometry keeps the accent; compact
+ * primitives each get a distinct hue so they stand out from the traced bulk.
+ */
+export const SHAPE_KIND_TOKEN: Record<SvgElementKind, string> = {
+  path: '--accent',
+  line: '--accent',
+  polyline: '--accent',
+  rect: '--success',
+  polygon: '--success',
+  circle: '--warn',
+  ellipse: '--danger',
+}
+
+/** Singular display label per element kind (pluralized with a trailing `s`). */
+export const SHAPE_KIND_LABEL: Record<SvgElementKind, string> = {
+  path: 'path',
+  rect: 'rect',
+  circle: 'circle',
+  ellipse: 'ellipse',
+  line: 'line',
+  polyline: 'polyline',
+  polygon: 'polygon',
+}

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -208,10 +208,16 @@ export interface SvgAnalysis {
   height: number | null // from viewBox
 }
 export function analyzeSvg(svg: string): SvgAnalysis
+export type SvgElementKind =
+  'path' | 'rect' | 'circle' | 'ellipse' | 'line' | 'polyline' | 'polygon'
+export interface SvgGeometryShape {
+  kind: SvgElementKind // source element, so an overlay can tint primitives apart
+  commands: PathCommand[] // absolute M/L/Q/C/Z for this element
+}
 export interface SvgGeometry {
   width: number | null // viewBox size (overlay coordinate space)
   height: number | null
-  shapes: PathCommand[][] // one absolute command list per drawable element, in document order
+  shapes: SvgGeometryShape[] // one per drawable element, in document order
 }
 // Decode SVG text back into the absolute path model for inspection overlays
 // (anchor points, Bézier handles, outlines). Regex-based, no DOM; exact on our

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -208,6 +208,17 @@ export interface SvgAnalysis {
   height: number | null // from viewBox
 }
 export function analyzeSvg(svg: string): SvgAnalysis
+export interface SvgGeometry {
+  width: number | null // viewBox size (overlay coordinate space)
+  height: number | null
+  shapes: PathCommand[][] // one absolute command list per drawable element, in document order
+}
+// Decode SVG text back into the absolute path model for inspection overlays
+// (anchor points, Bézier handles, outlines). Regex-based, no DOM; exact on our
+// serializer output, best-effort on foreign SVGs. Paths resolve relative/H/V/S/T
+// shorthands to absolute M/L/Q/C/Z; rect/circle/ellipse/line/polyline/polygon
+// convert to equivalent commands (round primitives via the 4-Bézier kappa arc).
+export function extractGeometry(svg: string): SvgGeometry
 ```
 
 Serializer requirements:

--- a/packages/svg/src/geometry.ts
+++ b/packages/svg/src/geometry.ts
@@ -1,0 +1,339 @@
+/**
+ * Geometry extraction — turn SVG text back into the absolute path model, so a
+ * UI can draw an inspection overlay (anchor points, Bézier handles, outlines)
+ * that mirrors the exact nodes in the document. Regex/string-based, no DOM, so
+ * it runs in Node and workers like {@link analyzeSvg}. Best-effort on foreign
+ * SVGs; exact on our own serializer output.
+ *
+ * Every drawable element becomes one `PathCommand[]` in absolute coordinates:
+ * `<path>` data is parsed (absolute/relative, `H`/`V`/`S`/`T` shorthands
+ * resolved), and `<rect>`/`<circle>`/`<ellipse>`/`<line>`/`<polyline>`/`<polygon>`
+ * are converted to the equivalent commands (circles/ellipses via the standard
+ * four-Bézier arc approximation).
+ */
+
+import type { PathCommand } from '@vectorizer/core'
+
+export interface SvgGeometry {
+  /** viewBox width/height (the overlay coordinate space); null when absent. */
+  width: number | null
+  height: number | null
+  /** Absolute path commands per drawable element, in document order. */
+  shapes: PathCommand[][]
+}
+
+/** Control-point offset that approximates a quarter circle with one cubic. */
+const KAPPA = 0.5522847498307936
+
+/** A path-data token: a command letter or a numeric operand. */
+interface Token {
+  letter?: string
+  value?: number
+}
+
+// A command letter, or an SVG number (optional sign, decimal, exponent).
+const TOKEN_RE = /([MLHVCSQTAZmlhvcsqtaz])|([+-]?(?:\d*\.\d+|\d+\.?)(?:[eE][+-]?\d+)?)/g
+
+function tokenizePath(d: string): Token[] {
+  const tokens: Token[] = []
+  for (const m of d.matchAll(TOKEN_RE)) {
+    if (m[1] !== undefined) tokens.push({ letter: m[1] })
+    else tokens.push({ value: Number(m[2]) })
+  }
+  return tokens
+}
+
+/**
+ * Parse a `d` value into absolute `M`/`L`/`Q`/`C`/`Z` commands. `H`/`V` become
+ * `L`; `S`/`T` become `C`/`Q` with the reflected control point; `A` collapses to
+ * a line to its endpoint (our serializer never emits arcs).
+ */
+function parsePathData(d: string): PathCommand[] {
+  const tokens = tokenizePath(d)
+  const out: PathCommand[] = []
+  let i = 0
+  let curX = 0
+  let curY = 0
+  let startX = 0
+  let startY = 0
+  // Last cubic/quadratic control points (absolute), for S/T reflection.
+  let cCtrlX = 0
+  let cCtrlY = 0
+  let qCtrlX = 0
+  let qCtrlY = 0
+  let prev = ''
+  let cmd = ''
+
+  // Read the next operand; a missing one (malformed or a following letter)
+  // yields 0 without consuming the token.
+  const num = (): number => {
+    if (i < tokens.length && tokens[i].value !== undefined) return tokens[i++].value as number
+    return 0
+  }
+
+  while (i < tokens.length) {
+    const tk = tokens[i]
+    if (tk.letter !== undefined) {
+      cmd = tk.letter
+      i++
+      if (cmd === 'Z' || cmd === 'z') {
+        out.push({ type: 'Z' })
+        curX = startX
+        curY = startY
+        prev = 'Z'
+        cmd = ''
+        continue
+      }
+    } else {
+      if (cmd === '') {
+        i++
+        continue
+      }
+      // Repeated operands reuse the last command; a repeated M/m draws lines.
+      if (cmd === 'M') cmd = 'L'
+      else if (cmd === 'm') cmd = 'l'
+    }
+
+    const rel = cmd >= 'a'
+    const kind = cmd.toUpperCase()
+    const bx = rel ? curX : 0
+    const by = rel ? curY : 0
+
+    switch (kind) {
+      case 'M': {
+        const x = num() + bx
+        const y = num() + by
+        out.push({ type: 'M', x, y })
+        curX = x
+        curY = y
+        startX = x
+        startY = y
+        prev = 'M'
+        break
+      }
+      case 'L': {
+        const x = num() + bx
+        const y = num() + by
+        out.push({ type: 'L', x, y })
+        curX = x
+        curY = y
+        prev = 'L'
+        break
+      }
+      case 'H': {
+        const x = num() + bx
+        out.push({ type: 'L', x, y: curY })
+        curX = x
+        prev = 'L'
+        break
+      }
+      case 'V': {
+        const y = num() + by
+        out.push({ type: 'L', x: curX, y })
+        curY = y
+        prev = 'L'
+        break
+      }
+      case 'Q': {
+        const x1 = num() + bx
+        const y1 = num() + by
+        const x = num() + bx
+        const y = num() + by
+        out.push({ type: 'Q', x1, y1, x, y })
+        qCtrlX = x1
+        qCtrlY = y1
+        curX = x
+        curY = y
+        prev = 'Q'
+        break
+      }
+      case 'T': {
+        const reflect = prev === 'Q'
+        const x1 = reflect ? 2 * curX - qCtrlX : curX
+        const y1 = reflect ? 2 * curY - qCtrlY : curY
+        const x = num() + bx
+        const y = num() + by
+        out.push({ type: 'Q', x1, y1, x, y })
+        qCtrlX = x1
+        qCtrlY = y1
+        curX = x
+        curY = y
+        prev = 'Q'
+        break
+      }
+      case 'C': {
+        const x1 = num() + bx
+        const y1 = num() + by
+        const x2 = num() + bx
+        const y2 = num() + by
+        const x = num() + bx
+        const y = num() + by
+        out.push({ type: 'C', x1, y1, x2, y2, x, y })
+        cCtrlX = x2
+        cCtrlY = y2
+        curX = x
+        curY = y
+        prev = 'C'
+        break
+      }
+      case 'S': {
+        const reflect = prev === 'C'
+        const x1 = reflect ? 2 * curX - cCtrlX : curX
+        const y1 = reflect ? 2 * curY - cCtrlY : curY
+        const x2 = num() + bx
+        const y2 = num() + by
+        const x = num() + bx
+        const y = num() + by
+        out.push({ type: 'C', x1, y1, x2, y2, x, y })
+        cCtrlX = x2
+        cCtrlY = y2
+        curX = x
+        curY = y
+        prev = 'C'
+        break
+      }
+      case 'A': {
+        // rx ry x-axis-rotation large-arc sweep x y — endpoint only.
+        num()
+        num()
+        num()
+        num()
+        num()
+        const x = num() + bx
+        const y = num() + by
+        out.push({ type: 'L', x, y })
+        curX = x
+        curY = y
+        prev = 'A'
+        break
+      }
+      default:
+        i++
+        break
+    }
+  }
+
+  return out
+}
+
+/** Value of a `"…"`/`'…'` attribute in an element's attribute text. */
+function attr(attrs: string, name: string): string | null {
+  const m = new RegExp(`(?<![\\w-])${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`).exec(attrs)
+  if (m === null) return null
+  return m[1] ?? m[2] ?? ''
+}
+
+/** Numeric attribute value; missing or unparsable ⇒ 0. */
+function attrNum(attrs: string, name: string): number {
+  const raw = attr(attrs, name)
+  if (raw === null) return 0
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : 0
+}
+
+/** Rectangle as a closed 4-line subpath (corner radii ignored). */
+function rectCommands(attrs: string): PathCommand[] {
+  const x = attrNum(attrs, 'x')
+  const y = attrNum(attrs, 'y')
+  const w = attrNum(attrs, 'width')
+  const h = attrNum(attrs, 'height')
+  if (w <= 0 || h <= 0) return []
+  return [
+    { type: 'M', x, y },
+    { type: 'L', x: x + w, y },
+    { type: 'L', x: x + w, y: y + h },
+    { type: 'L', x, y: y + h },
+    { type: 'Z' },
+  ]
+}
+
+/** Ellipse (or circle) as four cubic Béziers — the standard kappa approximation. */
+function ellipseCommands(cx: number, cy: number, rx: number, ry: number): PathCommand[] {
+  if (rx <= 0 || ry <= 0) return []
+  const ox = rx * KAPPA
+  const oy = ry * KAPPA
+  return [
+    { type: 'M', x: cx + rx, y: cy },
+    { type: 'C', x1: cx + rx, y1: cy + oy, x2: cx + ox, y2: cy + ry, x: cx, y: cy + ry },
+    { type: 'C', x1: cx - ox, y1: cy + ry, x2: cx - rx, y2: cy + oy, x: cx - rx, y: cy },
+    { type: 'C', x1: cx - rx, y1: cy - oy, x2: cx - ox, y2: cy - ry, x: cx, y: cy - ry },
+    { type: 'C', x1: cx + ox, y1: cy - ry, x2: cx + rx, y2: cy - oy, x: cx + rx, y: cy },
+    { type: 'Z' },
+  ]
+}
+
+/** Parse a `points` list into an open (polyline) or closed (polygon) subpath. */
+function pointsCommands(attrs: string, close: boolean): PathCommand[] {
+  const raw = attr(attrs, 'points')
+  if (raw === null) return []
+  const nums: number[] = []
+  for (const m of raw.matchAll(/[+-]?(?:\d*\.\d+|\d+\.?)(?:[eE][+-]?\d+)?/g)) {
+    nums.push(Number(m[0]))
+  }
+  const out: PathCommand[] = []
+  for (let p = 0; p + 1 < nums.length; p += 2) {
+    out.push({ type: p === 0 ? 'M' : 'L', x: nums[p], y: nums[p + 1] })
+  }
+  if (close && out.length > 0) out.push({ type: 'Z' })
+  return out
+}
+
+function elementCommands(tag: string, attrs: string): PathCommand[] {
+  switch (tag) {
+    case 'path': {
+      const d = attr(attrs, 'd')
+      return d === null ? [] : parsePathData(d)
+    }
+    case 'rect':
+      return rectCommands(attrs)
+    case 'circle': {
+      const r = attrNum(attrs, 'r')
+      return ellipseCommands(attrNum(attrs, 'cx'), attrNum(attrs, 'cy'), r, r)
+    }
+    case 'ellipse':
+      return ellipseCommands(
+        attrNum(attrs, 'cx'),
+        attrNum(attrs, 'cy'),
+        attrNum(attrs, 'rx'),
+        attrNum(attrs, 'ry'),
+      )
+    case 'line':
+      return [
+        { type: 'M', x: attrNum(attrs, 'x1'), y: attrNum(attrs, 'y1') },
+        { type: 'L', x: attrNum(attrs, 'x2'), y: attrNum(attrs, 'y2') },
+      ]
+    case 'polyline':
+      return pointsCommands(attrs, false)
+    case 'polygon':
+      return pointsCommands(attrs, true)
+    default:
+      return []
+  }
+}
+
+function viewBoxSize(svg: string): { width: number | null; height: number | null } {
+  const m = /(?<![\w-])viewBox\s*=\s*(?:"([^"]*)"|'([^']*)')/.exec(svg)
+  if (m === null) return { width: null, height: null }
+  const parts = (m[1] ?? m[2] ?? '').trim().split(/[\s,]+/)
+  if (parts.length < 4) return { width: null, height: null }
+  const w = Number(parts[2])
+  const h = Number(parts[3])
+  return {
+    width: Number.isFinite(w) ? w : null,
+    height: Number.isFinite(h) ? h : null,
+  }
+}
+
+/**
+ * Extract per-shape absolute path geometry from SVG text, preserving document
+ * order. Empty shapes are dropped.
+ */
+export function extractGeometry(svg: string): SvgGeometry {
+  const { width, height } = viewBoxSize(svg)
+  const shapes: PathCommand[][] = []
+  for (const m of svg.matchAll(/<(path|rect|circle|ellipse|line|polyline|polygon)\b([^>]*)>/g)) {
+    const commands = elementCommands(m[1], m[2])
+    if (commands.length > 0) shapes.push(commands)
+  }
+  return { width, height, shapes }
+}

--- a/packages/svg/src/geometry.ts
+++ b/packages/svg/src/geometry.ts
@@ -5,21 +5,39 @@
  * it runs in Node and workers like {@link analyzeSvg}. Best-effort on foreign
  * SVGs; exact on our own serializer output.
  *
- * Every drawable element becomes one `PathCommand[]` in absolute coordinates:
- * `<path>` data is parsed (absolute/relative, `H`/`V`/`S`/`T` shorthands
- * resolved), and `<rect>`/`<circle>`/`<ellipse>`/`<line>`/`<polyline>`/`<polygon>`
- * are converted to the equivalent commands (circles/ellipses via the standard
- * four-Bézier arc approximation).
+ * Every drawable element becomes one shape whose `commands` are absolute
+ * coordinates: `<path>` data is parsed (absolute/relative, `H`/`V`/`S`/`T`
+ * shorthands resolved), and `<rect>`/`<circle>`/`<ellipse>`/`<line>`/
+ * `<polyline>`/`<polygon>` are converted to the equivalent commands
+ * (circles/ellipses via the standard four-Bézier arc approximation). Each shape
+ * keeps its source element `kind`, so an overlay can tint primitives apart from
+ * traced paths.
  */
 
 import type { PathCommand } from '@vectorizer/core'
+
+/** Source element a shape came from. */
+export type SvgElementKind =
+  | 'path'
+  | 'rect'
+  | 'circle'
+  | 'ellipse'
+  | 'line'
+  | 'polyline'
+  | 'polygon'
+
+export interface SvgGeometryShape {
+  kind: SvgElementKind
+  /** Absolute path commands for this element. */
+  commands: PathCommand[]
+}
 
 export interface SvgGeometry {
   /** viewBox width/height (the overlay coordinate space); null when absent. */
   width: number | null
   height: number | null
-  /** Absolute path commands per drawable element, in document order. */
-  shapes: PathCommand[][]
+  /** One entry per drawable element, in document order. */
+  shapes: SvgGeometryShape[]
 }
 
 /** Control-point offset that approximates a quarter circle with one cubic. */
@@ -278,7 +296,7 @@ function pointsCommands(attrs: string, close: boolean): PathCommand[] {
   return out
 }
 
-function elementCommands(tag: string, attrs: string): PathCommand[] {
+function elementCommands(tag: SvgElementKind, attrs: string): PathCommand[] {
   switch (tag) {
     case 'path': {
       const d = attr(attrs, 'd')
@@ -330,10 +348,11 @@ function viewBoxSize(svg: string): { width: number | null; height: number | null
  */
 export function extractGeometry(svg: string): SvgGeometry {
   const { width, height } = viewBoxSize(svg)
-  const shapes: PathCommand[][] = []
+  const shapes: SvgGeometryShape[] = []
   for (const m of svg.matchAll(/<(path|rect|circle|ellipse|line|polyline|polygon)\b([^>]*)>/g)) {
-    const commands = elementCommands(m[1], m[2])
-    if (commands.length > 0) shapes.push(commands)
+    const kind = m[1] as SvgElementKind
+    const commands = elementCommands(kind, m[2])
+    if (commands.length > 0) shapes.push({ kind, commands })
   }
   return { width, height, shapes }
 }

--- a/packages/svg/src/index.ts
+++ b/packages/svg/src/index.ts
@@ -1,7 +1,7 @@
 export { analyzeSvg } from './analyze'
 export type { SvgAnalysis } from './analyze'
 export { extractGeometry } from './geometry'
-export type { SvgGeometry } from './geometry'
+export type { SvgElementKind, SvgGeometry, SvgGeometryShape } from './geometry'
 export { buildPathData, formatNumber } from './pathdata'
 export { optimizePathData } from './optimize'
 export { cleanCommands } from './clean'

--- a/packages/svg/src/index.ts
+++ b/packages/svg/src/index.ts
@@ -1,5 +1,7 @@
 export { analyzeSvg } from './analyze'
 export type { SvgAnalysis } from './analyze'
+export { extractGeometry } from './geometry'
+export type { SvgGeometry } from './geometry'
 export { buildPathData, formatNumber } from './pathdata'
 export { optimizePathData } from './optimize'
 export { cleanCommands } from './clean'

--- a/packages/svg/test/geometry.test.ts
+++ b/packages/svg/test/geometry.test.ts
@@ -1,0 +1,141 @@
+import type { PathCommand } from '@vectorizer/core'
+import { countPathNodes } from '@vectorizer/core'
+import { describe, expect, it } from 'vitest'
+import { extractGeometry, serializeSvg } from '../src/index'
+import type { SvgDocument } from '../src/index'
+
+const triangle: PathCommand[] = [
+  { type: 'M', x: 1, y: 1 },
+  { type: 'L', x: 9, y: 1 },
+  { type: 'L', x: 5, y: 9 },
+  { type: 'Z' },
+]
+
+describe('extractGeometry on serializer output', () => {
+  it('round-trips absolute path commands', () => {
+    const doc: SvgDocument = {
+      width: 10,
+      height: 10,
+      unit: 'px',
+      shapes: [{ commands: triangle, fill: '#123456' }],
+    }
+    const geo = extractGeometry(serializeSvg(doc, { precision: 0 }))
+    expect(geo.width).toBe(10)
+    expect(geo.height).toBe(10)
+    expect(geo.shapes).toHaveLength(1)
+    expect(geo.shapes[0]).toEqual(triangle)
+  })
+
+  it('resolves optimized (relative/H/V) paths to the same absolute geometry', () => {
+    const doc: SvgDocument = {
+      width: 10,
+      height: 10,
+      unit: 'px',
+      shapes: [{ commands: triangle, fill: '#123456' }],
+    }
+    const absolute = serializeSvg(doc, { precision: 0 })
+    const optimized = serializeSvg(doc, { precision: 0, optimizePaths: true })
+    // The optimizer picks shorthand commands, so the two strings differ …
+    expect(optimized).not.toBe(absolute)
+    // … but the decoded geometry is identical.
+    expect(extractGeometry(optimized).shapes[0]).toEqual(extractGeometry(absolute).shapes[0])
+  })
+
+  it('decodes an exact <rect> primitive back to its four corners', () => {
+    const square: PathCommand[] = [
+      { type: 'M', x: 0, y: 0 },
+      { type: 'L', x: 10, y: 0 },
+      { type: 'L', x: 10, y: 10 },
+      { type: 'L', x: 0, y: 10 },
+      { type: 'Z' },
+    ]
+    const svg = serializeSvg(
+      { width: 10, height: 10, unit: 'px', shapes: [{ commands: square, fill: '#000000' }] },
+      { precision: 0, optimizePaths: true },
+    )
+    expect(svg).toContain('<rect')
+    const geo = extractGeometry(svg)
+    expect(geo.shapes).toHaveLength(1)
+    expect(countPathNodes(geo.shapes[0])).toBe(4)
+    expect(geo.shapes[0]).toEqual(square)
+  })
+
+  it('keeps document order across mixed elements', () => {
+    const svg =
+      '<svg viewBox="0 0 20 20"><rect x="1" y="2" width="3" height="4"/>' +
+      '<path d="M5 5 L6 6"/></svg>'
+    const geo = extractGeometry(svg)
+    expect(geo.shapes).toHaveLength(2)
+    expect(geo.shapes[0][0]).toEqual({ type: 'M', x: 1, y: 2 })
+    expect(geo.shapes[1][0]).toEqual({ type: 'M', x: 5, y: 5 })
+  })
+})
+
+describe('extractGeometry path-data parsing', () => {
+  it('resolves relative, H/V and Z commands', () => {
+    const geo = extractGeometry('<svg viewBox="0 0 10 10"><path d="M1 1 h8 l-4 8 Z"/></svg>')
+    expect(geo.shapes[0]).toEqual(triangle)
+  })
+
+  it('treats extra coordinate pairs after M as implicit line-tos', () => {
+    const geo = extractGeometry('<svg viewBox="0 0 4 4"><path d="M0 0 1 1 2 2"/></svg>')
+    expect(geo.shapes[0]).toEqual([
+      { type: 'M', x: 0, y: 0 },
+      { type: 'L', x: 1, y: 1 },
+      { type: 'L', x: 2, y: 2 },
+    ])
+  })
+
+  it('reflects the control point for smooth quadratics (T)', () => {
+    const geo = extractGeometry('<svg viewBox="0 0 4 4"><path d="M0 0 Q1 1 2 0 T4 0"/></svg>')
+    expect(geo.shapes[0]).toEqual([
+      { type: 'M', x: 0, y: 0 },
+      { type: 'Q', x1: 1, y1: 1, x: 2, y: 0 },
+      { type: 'Q', x1: 3, y1: -1, x: 4, y: 0 },
+    ])
+  })
+
+  it('reflects the control point for smooth cubics (S)', () => {
+    const geo = extractGeometry(
+      '<svg viewBox="0 0 8 8"><path d="M0 0 C1 1 2 1 3 0 S5 -1 6 0"/></svg>',
+    )
+    expect(geo.shapes[0]).toEqual([
+      { type: 'M', x: 0, y: 0 },
+      { type: 'C', x1: 1, y1: 1, x2: 2, y2: 1, x: 3, y: 0 },
+      { type: 'C', x1: 4, y1: -1, x2: 5, y2: -1, x: 6, y: 0 },
+    ])
+  })
+})
+
+describe('extractGeometry primitive conversion', () => {
+  it('converts a circle to four cubic segments through the cardinal points', () => {
+    const geo = extractGeometry('<svg viewBox="0 0 20 20"><circle cx="10" cy="10" r="5"/></svg>')
+    const cmds = geo.shapes[0]
+    // M + 4 C + Z, i.e. four on-curve segment ends plus the start anchor.
+    expect(cmds.map((c) => c.type)).toEqual(['M', 'C', 'C', 'C', 'C', 'Z'])
+    expect(cmds[0]).toMatchObject({ x: 15, y: 10 })
+    const ends = cmds.filter((c) => c.type === 'C').map((c) => ({ x: c.x, y: c.y }))
+    expect(ends).toEqual([
+      { x: 10, y: 15 },
+      { x: 5, y: 10 },
+      { x: 10, y: 5 },
+      { x: 15, y: 10 },
+    ])
+  })
+
+  it('converts polyline (open) and polygon (closed) points', () => {
+    const line = extractGeometry('<svg viewBox="0 0 9 9"><polyline points="0,0 3,3 6,0"/></svg>')
+    expect(line.shapes[0].some((c) => c.type === 'Z')).toBe(false)
+    const poly = extractGeometry('<svg viewBox="0 0 9 9"><polygon points="0,0 3,3 6,0"/></svg>')
+    expect(poly.shapes[0].at(-1)).toEqual({ type: 'Z' })
+  })
+
+  it('drops degenerate shapes and reports viewBox dimensions', () => {
+    const geo = extractGeometry(
+      '<svg viewBox="0 0 30 40"><rect x="0" y="0" width="0" height="5"/><path d=""/></svg>',
+    )
+    expect(geo.shapes).toHaveLength(0)
+    expect(geo.width).toBe(30)
+    expect(geo.height).toBe(40)
+  })
+})

--- a/packages/svg/test/geometry.test.ts
+++ b/packages/svg/test/geometry.test.ts
@@ -23,7 +23,8 @@ describe('extractGeometry on serializer output', () => {
     expect(geo.width).toBe(10)
     expect(geo.height).toBe(10)
     expect(geo.shapes).toHaveLength(1)
-    expect(geo.shapes[0]).toEqual(triangle)
+    expect(geo.shapes[0].kind).toBe('path')
+    expect(geo.shapes[0].commands).toEqual(triangle)
   })
 
   it('resolves optimized (relative/H/V) paths to the same absolute geometry', () => {
@@ -38,10 +39,12 @@ describe('extractGeometry on serializer output', () => {
     // The optimizer picks shorthand commands, so the two strings differ …
     expect(optimized).not.toBe(absolute)
     // … but the decoded geometry is identical.
-    expect(extractGeometry(optimized).shapes[0]).toEqual(extractGeometry(absolute).shapes[0])
+    expect(extractGeometry(optimized).shapes[0].commands).toEqual(
+      extractGeometry(absolute).shapes[0].commands,
+    )
   })
 
-  it('decodes an exact <rect> primitive back to its four corners', () => {
+  it('decodes an exact <rect> primitive back to its four corners, tagged rect', () => {
     const square: PathCommand[] = [
       { type: 'M', x: 0, y: 0 },
       { type: 'L', x: 10, y: 0 },
@@ -56,30 +59,31 @@ describe('extractGeometry on serializer output', () => {
     expect(svg).toContain('<rect')
     const geo = extractGeometry(svg)
     expect(geo.shapes).toHaveLength(1)
-    expect(countPathNodes(geo.shapes[0])).toBe(4)
-    expect(geo.shapes[0]).toEqual(square)
+    expect(geo.shapes[0].kind).toBe('rect')
+    expect(countPathNodes(geo.shapes[0].commands)).toBe(4)
+    expect(geo.shapes[0].commands).toEqual(square)
   })
 
-  it('keeps document order across mixed elements', () => {
+  it('keeps document order and per-element kinds across mixed elements', () => {
     const svg =
       '<svg viewBox="0 0 20 20"><rect x="1" y="2" width="3" height="4"/>' +
       '<path d="M5 5 L6 6"/></svg>'
     const geo = extractGeometry(svg)
-    expect(geo.shapes).toHaveLength(2)
-    expect(geo.shapes[0][0]).toEqual({ type: 'M', x: 1, y: 2 })
-    expect(geo.shapes[1][0]).toEqual({ type: 'M', x: 5, y: 5 })
+    expect(geo.shapes.map((s) => s.kind)).toEqual(['rect', 'path'])
+    expect(geo.shapes[0].commands[0]).toEqual({ type: 'M', x: 1, y: 2 })
+    expect(geo.shapes[1].commands[0]).toEqual({ type: 'M', x: 5, y: 5 })
   })
 })
 
 describe('extractGeometry path-data parsing', () => {
   it('resolves relative, H/V and Z commands', () => {
     const geo = extractGeometry('<svg viewBox="0 0 10 10"><path d="M1 1 h8 l-4 8 Z"/></svg>')
-    expect(geo.shapes[0]).toEqual(triangle)
+    expect(geo.shapes[0].commands).toEqual(triangle)
   })
 
   it('treats extra coordinate pairs after M as implicit line-tos', () => {
     const geo = extractGeometry('<svg viewBox="0 0 4 4"><path d="M0 0 1 1 2 2"/></svg>')
-    expect(geo.shapes[0]).toEqual([
+    expect(geo.shapes[0].commands).toEqual([
       { type: 'M', x: 0, y: 0 },
       { type: 'L', x: 1, y: 1 },
       { type: 'L', x: 2, y: 2 },
@@ -88,7 +92,7 @@ describe('extractGeometry path-data parsing', () => {
 
   it('reflects the control point for smooth quadratics (T)', () => {
     const geo = extractGeometry('<svg viewBox="0 0 4 4"><path d="M0 0 Q1 1 2 0 T4 0"/></svg>')
-    expect(geo.shapes[0]).toEqual([
+    expect(geo.shapes[0].commands).toEqual([
       { type: 'M', x: 0, y: 0 },
       { type: 'Q', x1: 1, y1: 1, x: 2, y: 0 },
       { type: 'Q', x1: 3, y1: -1, x: 4, y: 0 },
@@ -99,7 +103,7 @@ describe('extractGeometry path-data parsing', () => {
     const geo = extractGeometry(
       '<svg viewBox="0 0 8 8"><path d="M0 0 C1 1 2 1 3 0 S5 -1 6 0"/></svg>',
     )
-    expect(geo.shapes[0]).toEqual([
+    expect(geo.shapes[0].commands).toEqual([
       { type: 'M', x: 0, y: 0 },
       { type: 'C', x1: 1, y1: 1, x2: 2, y2: 1, x: 3, y: 0 },
       { type: 'C', x1: 4, y1: -1, x2: 5, y2: -1, x: 6, y: 0 },
@@ -110,7 +114,8 @@ describe('extractGeometry path-data parsing', () => {
 describe('extractGeometry primitive conversion', () => {
   it('converts a circle to four cubic segments through the cardinal points', () => {
     const geo = extractGeometry('<svg viewBox="0 0 20 20"><circle cx="10" cy="10" r="5"/></svg>')
-    const cmds = geo.shapes[0]
+    expect(geo.shapes[0].kind).toBe('circle')
+    const cmds = geo.shapes[0].commands
     // M + 4 C + Z, i.e. four on-curve segment ends plus the start anchor.
     expect(cmds.map((c) => c.type)).toEqual(['M', 'C', 'C', 'C', 'C', 'Z'])
     expect(cmds[0]).toMatchObject({ x: 15, y: 10 })
@@ -125,9 +130,11 @@ describe('extractGeometry primitive conversion', () => {
 
   it('converts polyline (open) and polygon (closed) points', () => {
     const line = extractGeometry('<svg viewBox="0 0 9 9"><polyline points="0,0 3,3 6,0"/></svg>')
-    expect(line.shapes[0].some((c) => c.type === 'Z')).toBe(false)
+    expect(line.shapes[0].kind).toBe('polyline')
+    expect(line.shapes[0].commands.some((c) => c.type === 'Z')).toBe(false)
     const poly = extractGeometry('<svg viewBox="0 0 9 9"><polygon points="0,0 3,3 6,0"/></svg>')
-    expect(poly.shapes[0].at(-1)).toEqual({ type: 'Z' })
+    expect(poly.shapes[0].kind).toBe('polygon')
+    expect(poly.shapes[0].commands.at(-1)).toEqual({ type: 'Z' })
   })
 
   it('drops degenerate shapes and reports viewBox dimensions', () => {


### PR DESCRIPTION
Adds an inspection overlay that visualizes the geometric complexity of traced SVG output by displaying path outlines, anchor points, and Bézier control handles directly on the preview canvas.

## Summary

This PR introduces geometry extraction from SVG text and a visual overlay component that helps users understand the density and structure of the vectorized output. The overlay decodes SVG elements back into absolute path commands and renders them with per-element-kind color coding, making it easy to spot where the tracer has created complex geometry or where primitives (rect/circle/ellipse) were detected and optimized.

## Key Changes

- **Geometry extraction** (`packages/svg/src/geometry.ts`): New module that parses SVG text (regex-based, no DOM) and converts all drawable elements to absolute path commands
  - Handles `<path>` data parsing with full support for relative/absolute commands, H/V/S/T shorthands, and arc flattening
  - Converts primitives (`<rect>`, `<circle>`, `<ellipse>`, `<line>`, `<polyline>`, `<polygon>`) to equivalent path commands
  - Circles/ellipses use the standard four-Bézier arc approximation (KAPPA constant)
  - Preserves element kind for each shape so overlays can tint primitives distinctly

- **Preview overlay component** (`apps/web/src/components/PreviewOverlay.vue`): Canvas-based visualization layer
  - Renders path outlines, anchor marks (small crosses), and Bézier control handles
  - Declutters automatically when geometry exceeds thresholds (handles drop first, then anchors, leaving outlines)
  - Respects pan/zoom transforms and maintains constant on-screen sizing for marks
  - Clips to split-view divider when in split mode
  - Groups shapes by element kind for efficient per-color rendering

- **UI integration** (`apps/web/src/components/PreviewViewport.vue`):
  - Added "Show path nodes & outlines" toggle button (keyboard shortcut: N)
  - Displays legend chip showing per-kind element counts with matching overlay colors
  - Geometry computed only when toggle is on and SVG layer is visible

- **Overlay styling** (`apps/web/src/lib/overlay.ts`): Color token mapping for each element kind
  - Traced paths/lines use accent color
  - Rects/polygons use success color
  - Circles use warn color
  - Ellipses use danger color

- **Tests** (`packages/svg/test/geometry.test.ts`): Comprehensive coverage of path parsing, primitive conversion, and round-trip serialization

- **Exports & documentation**: Updated package exports and CONTRACTS.md with new public API

## Implementation Details

- Geometry extraction is regex/string-based (no DOM), so it runs in Node and workers like `analyzeSvg`
- Best-effort on foreign SVGs; exact on the serializer's own output
- Path parsing handles malformed input gracefully (missing operands default to 0)
- Control point reflection for S/T commands computed on-the-fly during parsing
- Canvas rendering uses Path2D for efficient batching and per-color stroke passes
- ResizeObserver and requestAnimationFrame for responsive, performant redraws

https://claude.ai/code/session_016phpGsEfQKm8Yh5vtqLP9V