### PR TITLE
feat: on-device ML pre-pass (edge + cleanup) with dataset & training pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,9 @@ dataset-out/
 *.onnx
 !apps/web/public/models/*.onnx
 
+# Training scratch: checkpoints (.pt) and preview montages (scripts/train)
+scripts/train/checkpoints/
+
 # Python (scripts/train) — training env and caches
 __pycache__/
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -154,5 +154,10 @@ e2e-artifacts/
 # Generated ML training datasets (scripts/dataset)
 dataset-out/
 
+# ML model weights: keep scratch/training weights out of git, but track the
+# project's own shipped model — served same-origin from the app's static assets.
+*.onnx
+!apps/web/public/models/*.onnx
+
 # Design plans and roadmaps are tracked, never ignored.
 !plans/

--- a/.gitignore
+++ b/.gitignore
@@ -151,5 +151,8 @@ dist/
 # Local E2E artifacts
 e2e-artifacts/
 
+# Generated ML training datasets (scripts/dataset)
+dataset-out/
+
 # Design plans and roadmaps are tracked, never ignored.
 !plans/

--- a/.gitignore
+++ b/.gitignore
@@ -159,5 +159,10 @@ dataset-out/
 *.onnx
 !apps/web/public/models/*.onnx
 
+# Python (scripts/train) — training env and caches
+__pycache__/
+*.pyc
+.venv/
+
 # Design plans and roadmaps are tracked, never ignored.
 !plans/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ where, how to run and verify things, and the conventions that apply everywhere.
 Reference material worth opening when you need the map rather than the rules: [`ARCHITECTURE.md`](ARCHITECTURE.md)
 (whole repo), [`packages/trace/ARCHITECTURE.md`](packages/trace/ARCHITECTURE.md) (the tracer),
 [`docs/CONTRACTS.md`](docs/CONTRACTS.md) (exact package APIs), [`docs/REFERENCES.md`](docs/REFERENCES.md)
-(algorithm & model sources).
+(algorithm & model sources), and [`docs/ML_STRATEGY.md`](docs/ML_STRATEGY.md) (ML & dataset roadmap: where ML fits, how
+determinism is scoped for WebGPU, and how to build a training set).
 
 ## Project overview
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,6 +4,11 @@ Whole-repo reference: what exists and where. The **rules** for changing it live 
 before editing. Exact exported signatures live in [`docs/CONTRACTS.md`](docs/CONTRACTS.md); this map describes structure
 and intent, not every file.
 
+![How Vectorizer works — the runtime pipeline, the optional on-device edge pre-pass, and the offline training loop that produces its model](docs/how-it-works.svg)
+
+_Raster → clean SVG through the deterministic core; the optional edge pre-pass (Tier 2) is discretized before the tracer,
+so output stays byte-identical without it. Animated SVG — open it in a browser to see the flow._
+
 ## Shape
 
 ```

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ npm-workspaces monorepo, strict TypeScript, zero runtime dependencies in the
 algorithm packages. The pipeline runs in a Web Worker with cooperative
 cancellation (latest settings win; stale runs abort between stages).
 
+![How Vectorizer works](docs/how-it-works.svg)
+
 | Package              | Role                                                                                                                                                                                    |
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@vectorizer/core`   | Shared types, settings schema + profiles, Oklab color math, geometry, deterministic PRNG                                                                                                |

--- a/README.md
+++ b/README.md
@@ -145,3 +145,7 @@ samples, saves the SVGs to `e2e-artifacts/` and refreshes `docs/screenshot.png`.
 - Semantic layering with SAM masks (object-per-layer SVG)
 - Differentiable refinement pass (WebGPU) against the source image
 - i18n (FR first)
+
+The ML approach behind several of these — shape/primitive fitting, semantic layering, the differentiable refinement pass —
+and how a training dataset would be produced (and how determinism is scoped so WebGPU stays allowed) is written up in
+[`docs/ML_STRATEGY.md`](docs/ML_STRATEGY.md).

--- a/apps/web/public/models/README.md
+++ b/apps/web/public/models/README.md
@@ -15,6 +15,14 @@ it here as `edge-prepass.onnx`. `MODEL_REGISTRY['edge-prepass']` already points 
 resolves that against its deploy base. Until the file exists, `EdgeEnhancer.create()` fails soft and the app traces
 classically.
 
+## cleanup.onnx
+
+The learned cleanup pre-pass (see [`../../../../docs/CLEANUP_PREPASS.md`](../../../../docs/CLEANUP_PREPASS.md)) — an
+image→image denoise/deblock that the studio's **Clean up (ML)** button runs before tracing, in any mode. Not committed yet
+— train it with `python scripts/train/pipeline.py --task cleanup` (same dataset as the edge model) and drop the ONNX here
+as `cleanup.onnx`. `MODEL_REGISTRY.cleanup` already points at `models/cleanup.onnx`. Until the file exists,
+`CleanupEnhancer.create()` fails soft and the working image is left untouched.
+
 `*.onnx` here is force-tracked (the repo's root `.gitignore` keeps scratch weights out but allows this directory). The
 binary is a few MB; if the repo accumulates several models, track them with **Git LFS** (`git lfs track
 "apps/web/public/models/*.onnx"`) to keep clones lean.

--- a/apps/web/public/models/README.md
+++ b/apps/web/public/models/README.md
@@ -1,0 +1,20 @@
+# App models
+
+Project-owned ML weights that ship **with the app**, served same-origin (no CORS, no third-party host). Vite copies
+`apps/web/public/` verbatim into the build, so a file here at `models/<name>.onnx` is served at
+`${import.meta.env.BASE_URL}models/<name>.onnx` on the deployed site.
+
+This is deliberately different from the third-party models (`u2netp`, SlimSAM), which are fetched at runtime from their
+upstream mirrors. Models the project trains itself live here instead.
+
+## edge-prepass.onnx
+
+The learned edge pre-pass (see [`../../../../docs/EDGE_PREPASS.md`](../../../../docs/EDGE_PREPASS.md)). Not committed yet
+— train it on data from [`../../../../scripts/dataset`](../../../../scripts/dataset/README.md), export to ONNX, and drop
+it here as `edge-prepass.onnx`. `MODEL_REGISTRY['edge-prepass']` already points at `models/edge-prepass.onnx`; the app
+resolves that against its deploy base. Until the file exists, `EdgeEnhancer.create()` fails soft and the app traces
+classically.
+
+`*.onnx` here is force-tracked (the repo's root `.gitignore` keeps scratch weights out but allows this directory). The
+binary is a few MB; if the repo accumulates several models, track them with **Git LFS** (`git lfs track
+"apps/web/public/models/*.onnx"`) to keep clones lean.

--- a/apps/web/src/components/MlTools.vue
+++ b/apps/web/src/components/MlTools.vue
@@ -27,6 +27,7 @@ const mlReady = computed(() => store.mlState.availability?.available === true)
 const removeBusy = computed(() => store.mlState.removeBg.busy)
 const magicBusy = computed(() => store.mlState.magic.busy)
 const edgeBusy = computed(() => store.mlState.edge.busy)
+const cleanupBusy = computed(() => store.mlState.cleanup.busy)
 
 async function refreshUsage(): Promise<void> {
   try {
@@ -72,7 +73,9 @@ onMounted(() => {
       <div class="tool">
         <button
           class="btn tool-btn"
-          :disabled="!store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy"
+          :disabled="
+            !store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy || cleanupBusy
+          "
           :title="mlReady ? 'Remove the background with a local U²-Net model' : backendBadge.title"
           @click="store.removeBackground()"
         >
@@ -111,8 +114,64 @@ onMounted(() => {
       <div class="tool">
         <button
           class="btn tool-btn"
+          :disabled="
+            !store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy || cleanupBusy
+          "
+          :title="
+            mlReady
+              ? 'ML cleanup — denoise / deblock the image before tracing (all modes; needs the cleanup model)'
+              : backendBadge.title
+          "
+          @click="store.cleanUp()"
+        >
+          <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+            <path
+              d="M9.5 2.5 11 5.5 14 7l-3 1.5L9.5 11.5 8 8.5 5 7l3-1.5z"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.3"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M3.5 10.5 4.4 12.3 6 13l-1.6.8L3.5 15.5 2.7 13.8 1 13l1.7-.7z"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.1"
+              stroke-linejoin="round"
+              opacity="0.7"
+            />
+          </svg>
+          {{ cleanupBusy ? 'Cleaning up…' : 'Clean up (ML)' }}
+        </button>
+        <div
+          v-if="cleanupBusy"
+          class="progress"
+          role="progressbar"
+          :aria-label="store.mlState.cleanup.phase"
+        >
+          <div
+            class="progress-fill"
+            :class="{ indeterminate: store.mlState.cleanup.progress === null }"
+            :style="
+              store.mlState.cleanup.progress !== null
+                ? { width: `${store.mlState.cleanup.progress * 100}%` }
+                : {}
+            "
+          />
+        </div>
+        <p v-if="cleanupBusy" class="phase">{{ store.mlState.cleanup.phase }}</p>
+        <p v-else class="phase instructions">
+          Rewrites pixels for the tracer · needs the cleanup model.
+        </p>
+      </div>
+
+      <div class="tool">
+        <button
+          class="btn tool-btn"
           :class="{ 'is-active': store.magicActive }"
-          :disabled="!store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy"
+          :disabled="
+            !store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy || cleanupBusy
+          "
           :title="mlReady ? 'Click regions to keep or exclude (SlimSAM)' : backendBadge.title"
           :aria-pressed="store.magicActive"
           @click="store.toggleMagicSelect()"
@@ -152,7 +211,9 @@ onMounted(() => {
         <button
           class="btn tool-btn"
           :class="{ 'is-active': store.edgePrepass }"
-          :disabled="!store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy"
+          :disabled="
+            !store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy || cleanupBusy
+          "
           :title="
             mlReady
               ? 'ML edge pre-pass — protects thin features from despeckling on noisy input (all modes)'

--- a/apps/web/src/components/MlTools.vue
+++ b/apps/web/src/components/MlTools.vue
@@ -155,7 +155,7 @@ onMounted(() => {
           :disabled="!store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy"
           :title="
             mlReady
-              ? 'ML edge pre-pass — sharpens B&W / centerline tracing on noisy input'
+              ? 'ML edge pre-pass — protects thin features from despeckling on noisy input (all modes)'
               : backendBadge.title
           "
           :aria-pressed="store.edgePrepass"
@@ -203,7 +203,7 @@ onMounted(() => {
         </div>
         <p v-if="edgeBusy" class="phase">{{ store.mlState.edge.phase }}</p>
         <p v-else-if="store.edgePrepass" class="phase instructions">
-          Applies to B&amp;W &amp; centerline modes · needs the edge-prepass model.
+          Applies to every mode · needs the edge-prepass model.
         </p>
       </div>
 

--- a/apps/web/src/components/MlTools.vue
+++ b/apps/web/src/components/MlTools.vue
@@ -26,6 +26,7 @@ const backendBadge = computed(() => {
 const mlReady = computed(() => store.mlState.availability?.available === true)
 const removeBusy = computed(() => store.mlState.removeBg.busy)
 const magicBusy = computed(() => store.mlState.magic.busy)
+const edgeBusy = computed(() => store.mlState.edge.busy)
 
 async function refreshUsage(): Promise<void> {
   try {
@@ -71,7 +72,7 @@ onMounted(() => {
       <div class="tool">
         <button
           class="btn tool-btn"
-          :disabled="!store.hasImage || !mlReady || removeBusy || magicBusy"
+          :disabled="!store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy"
           :title="mlReady ? 'Remove the background with a local U²-Net model' : backendBadge.title"
           @click="store.removeBackground()"
         >
@@ -111,7 +112,7 @@ onMounted(() => {
         <button
           class="btn tool-btn"
           :class="{ 'is-active': store.magicActive }"
-          :disabled="!store.hasImage || !mlReady || removeBusy || magicBusy"
+          :disabled="!store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy"
           :title="mlReady ? 'Click regions to keep or exclude (SlimSAM)' : backendBadge.title"
           :aria-pressed="store.magicActive"
           @click="store.toggleMagicSelect()"
@@ -144,6 +145,65 @@ onMounted(() => {
         <p v-else-if="store.magicActive" class="phase instructions">
           click = keep · alt / right-click = exclude · <kbd>Enter</kbd> apply ·
           <kbd>Esc</kbd> cancel
+        </p>
+      </div>
+
+      <div class="tool">
+        <button
+          class="btn tool-btn"
+          :class="{ 'is-active': store.edgePrepass }"
+          :disabled="!store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy"
+          :title="
+            mlReady
+              ? 'ML edge pre-pass — sharpens B&W / centerline tracing on noisy input'
+              : backendBadge.title
+          "
+          :aria-pressed="store.edgePrepass"
+          @click="store.setEdgePrepass(!store.edgePrepass)"
+        >
+          <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+            <rect
+              x="2.5"
+              y="2.5"
+              width="11"
+              height="11"
+              rx="2"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.3"
+              stroke-dasharray="2 1.6"
+              opacity="0.5"
+            />
+            <path
+              d="M2.5 10.5 6 7l3 2.5L13.5 5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          {{ store.edgePrepass ? 'Edge pre-pass — on' : 'Edge pre-pass (ML)' }}
+        </button>
+        <div
+          v-if="edgeBusy"
+          class="progress"
+          role="progressbar"
+          :aria-label="store.mlState.edge.phase"
+        >
+          <div
+            class="progress-fill"
+            :class="{ indeterminate: store.mlState.edge.progress === null }"
+            :style="
+              store.mlState.edge.progress !== null
+                ? { width: `${store.mlState.edge.progress * 100}%` }
+                : {}
+            "
+          />
+        </div>
+        <p v-if="edgeBusy" class="phase">{{ store.mlState.edge.phase }}</p>
+        <p v-else-if="store.edgePrepass" class="phase instructions">
+          Applies to B&amp;W &amp; centerline modes · needs the edge-prepass model.
         </p>
       </div>
 

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -6,6 +6,7 @@ import {
   TARGET_PROFILES,
 } from '@vectorizer/core'
 import type {
+  GrayImage,
   ProfileId,
   RasterImage,
   StageId,
@@ -56,6 +57,7 @@ interface PersistedState {
   activeProfileId?: ProfileId | null
   profileModified?: boolean
   theme?: Theme
+  edgePrepass?: boolean
 }
 
 function loadPersisted(): PersistedState {
@@ -137,9 +139,12 @@ export const useAppStore = defineStore('app', () => {
     availability: null as MlAvailability | null,
     removeBg: { busy: false, progress: null, phase: '' } as MlToolState,
     magic: { busy: false, progress: null, phase: '' } as MlToolState,
+    edge: { busy: false, progress: null, phase: '' } as MlToolState,
   })
   const magicActive = ref(false)
   const magicPoints = ref<MagicPoint[]>([])
+  /** Optional ML edge pre-pass, consumed by bw/centerline tracing. */
+  const edgePrepass = ref(persisted.edgePrepass === true)
 
   // Non-reactive machinery
   let client: VectorizerClient | null = null
@@ -150,6 +155,10 @@ export const useAppStore = defineStore('app', () => {
   let remover: import('@vectorizer/ml').BackgroundRemover | null = null
   let segmenter: import('@vectorizer/ml').MagicSegmenter | null = null
   let segmenterImage: RasterImage | null = null
+  let edgeModel: import('@vectorizer/ml').EdgeEnhancer | null = null
+  // Edge hint cached per working image (independent of trace settings).
+  let edgeHintImage: RasterImage | null = null
+  let edgeHint: GrayImage | null = null
   const suggestionCache = new WeakMap<RasterImage, PaletteSuggestion[]>()
 
   // ------------------------------ Derived --------------------------------
@@ -340,11 +349,19 @@ export const useAppStore = defineStore('app', () => {
     busy.value = true
     error.value = null
     try {
+      // Optional ML edge hint (cached per image; null when off or unsupported).
+      const hint = (await ensureEdgeHint(image)) ?? undefined
+      if (runId !== runCounter) return // superseded while preparing the hint
       // The client copies the pixel buffer before transferring it, so the
       // working image stays intact for the preview and later runs.
-      const res = await getClient().vectorize(image, settings.value, (stage, overall) => {
-        if (runId === runCounter) progress.value = { stage, overall }
-      })
+      const res = await getClient().vectorize(
+        image,
+        settings.value,
+        (stage, overall) => {
+          if (runId === runCounter) progress.value = { stage, overall }
+        },
+        hint,
+      )
       if (runId !== runCounter) return
       result.value = res
       busy.value = false
@@ -377,7 +394,7 @@ export const useAppStore = defineStore('app', () => {
     }, RUN_DEBOUNCE_MS)
   }
 
-  watch([workingImage, settings], () => {
+  watch([workingImage, settings, edgePrepass], () => {
     if (workingImage.value) run()
   })
 
@@ -397,6 +414,46 @@ export const useAppStore = defineStore('app', () => {
     } finally {
       mlState.probing = false
     }
+  }
+
+  /**
+   * Produce the edge hint for the current image when the pre-pass is on and the
+   * mode consumes it (bw/centerline). Cached per image; fail-soft — on any model
+   * error it toasts, turns the toggle off, and returns null so tracing proceeds
+   * classically. The model is served same-origin from the app's static assets.
+   */
+  async function ensureEdgeHint(image: RasterImage): Promise<GrayImage | null> {
+    if (!edgePrepass.value) return null
+    if (settings.value.mode !== 'bw' && settings.value.mode !== 'centerline') return null
+    if (edgeHintImage === image && edgeHint) return edgeHint
+    mlState.edge = { busy: true, progress: null, phase: 'Preparing' }
+    const onProgress = (p: MlProgress): void => {
+      const info = mlPhaseInfo(p)
+      mlState.edge = { busy: true, progress: info.progress, phase: info.phase }
+    }
+    try {
+      const ml = await import('@vectorizer/ml')
+      // Resolve the project model against the deploy base (served same-origin).
+      ml.overrideModelUrl(
+        'edge-prepass',
+        new URL(`${import.meta.env.BASE_URL}models/edge-prepass.onnx`, location.origin).href,
+      )
+      edgeModel ??= await ml.EdgeEnhancer.create({ onProgress })
+      const { edges } = await edgeModel.run(image, { onProgress })
+      edgeHintImage = image
+      edgeHint = edges
+      return edges
+    } catch (e) {
+      notify(`Edge pre-pass unavailable: ${errorMessage(e)}`, 'error')
+      edgePrepass.value = false // don't retry every run until the model exists
+      return null
+    } finally {
+      mlState.edge = { busy: false, progress: null, phase: '' }
+    }
+  }
+
+  function setEdgePrepass(on: boolean): void {
+    edgePrepass.value = on
   }
 
   async function removeBackground(): Promise<void> {
@@ -506,7 +563,7 @@ export const useAppStore = defineStore('app', () => {
 
   // ---------------------------- Persistence ------------------------------
   watch(
-    [settings, activeProfileId, profileModified, theme],
+    [settings, activeProfileId, profileModified, theme, edgePrepass],
     () => {
       try {
         const state: PersistedState = {
@@ -514,6 +571,7 @@ export const useAppStore = defineStore('app', () => {
           activeProfileId: activeProfileId.value,
           profileModified: profileModified.value,
           theme: theme.value,
+          edgePrepass: edgePrepass.value,
         }
         localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
       } catch {
@@ -544,6 +602,7 @@ export const useAppStore = defineStore('app', () => {
     mlState,
     magicActive,
     magicPoints,
+    edgePrepass,
     // derived
     hasImage,
     activeProfile,
@@ -567,6 +626,7 @@ export const useAppStore = defineStore('app', () => {
     removePaletteEntry,
     run,
     ensureMlAvailability,
+    setEdgePrepass,
     removeBackground,
     restoreOriginal,
     toggleMagicSelect,

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -140,6 +140,7 @@ export const useAppStore = defineStore('app', () => {
     removeBg: { busy: false, progress: null, phase: '' } as MlToolState,
     magic: { busy: false, progress: null, phase: '' } as MlToolState,
     edge: { busy: false, progress: null, phase: '' } as MlToolState,
+    cleanup: { busy: false, progress: null, phase: '' } as MlToolState,
   })
   const magicActive = ref(false)
   const magicPoints = ref<MagicPoint[]>([])
@@ -156,6 +157,7 @@ export const useAppStore = defineStore('app', () => {
   let segmenter: import('@vectorizer/ml').MagicSegmenter | null = null
   let segmenterImage: RasterImage | null = null
   let edgeModel: import('@vectorizer/ml').EdgeEnhancer | null = null
+  let cleanupModel: import('@vectorizer/ml').CleanupEnhancer | null = null
   // Edge hint cached per working image (independent of trace settings).
   let edgeHintImage: RasterImage | null = null
   let edgeHint: GrayImage | null = null
@@ -480,6 +482,41 @@ export const useAppStore = defineStore('app', () => {
     }
   }
 
+  /**
+   * One-shot ML cleanup pre-pass: replaces the working image with a denoised/
+   * deblocked version so the classical tracer runs on cleaner pixels in any mode
+   * (docs/CLEANUP_PREPASS.md). The project's own model, served same-origin from
+   * the app's static assets. Fail-soft: with no weights it toasts and leaves the
+   * image untouched. Undo via "Restore original".
+   */
+  async function cleanUp(): Promise<void> {
+    const image = workingImage.value
+    if (!image || mlState.cleanup.busy) return
+    mlState.cleanup = { busy: true, progress: null, phase: 'Preparing' }
+    const onProgress = (p: MlProgress): void => {
+      const info = mlPhaseInfo(p)
+      mlState.cleanup = { busy: true, progress: info.progress, phase: info.phase }
+    }
+    try {
+      const ml = await import('@vectorizer/ml')
+      ml.overrideModelUrl(
+        'cleanup',
+        new URL(`${import.meta.env.BASE_URL}models/cleanup.onnx`, location.origin).href,
+      )
+      cleanupModel ??= await ml.CleanupEnhancer.create({ onProgress })
+      const out = await cleanupModel.run(image, { onProgress })
+      // Only apply if the user hasn't swapped images mid-run.
+      if (workingImage.value === image) {
+        workingImage.value = out.image
+        notify('Cleaned up — tracing the denoised image', 'success')
+      }
+    } catch (e) {
+      notify(`Cleanup unavailable: ${errorMessage(e)}`, 'error')
+    } finally {
+      mlState.cleanup = { busy: false, progress: null, phase: '' }
+    }
+  }
+
   function restoreOriginal(): void {
     if (!sourceImage.value) return
     cancelMagicSelect()
@@ -628,6 +665,7 @@ export const useAppStore = defineStore('app', () => {
     ensureMlAvailability,
     setEdgePrepass,
     removeBackground,
+    cleanUp,
     restoreOriginal,
     toggleMagicSelect,
     cancelMagicSelect,

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -417,14 +417,14 @@ export const useAppStore = defineStore('app', () => {
   }
 
   /**
-   * Produce the edge hint for the current image when the pre-pass is on and the
-   * mode consumes it (bw/centerline). Cached per image; fail-soft — on any model
-   * error it toasts, turns the toggle off, and returns null so tracing proceeds
+   * Produce the edge hint for the current image when the pre-pass is on. Every
+   * mode consumes it — bw/centerline guard the despeckle, color/grayscale guard
+   * the small-region merge. Cached per image; fail-soft — on any model error it
+   * toasts, turns the toggle off, and returns null so tracing proceeds
    * classically. The model is served same-origin from the app's static assets.
    */
   async function ensureEdgeHint(image: RasterImage): Promise<GrayImage | null> {
     if (!edgePrepass.value) return null
-    if (settings.value.mode !== 'bw' && settings.value.mode !== 'centerline') return null
     if (edgeHintImage === image && edgeHint) return edgeHint
     mlState.edge = { busy: true, progress: null, phase: 'Preparing' }
     const onProgress = (p: MlProgress): void => {

--- a/docs/CLEANUP_PREPASS.md
+++ b/docs/CLEANUP_PREPASS.md
@@ -1,0 +1,145 @@
+# Model spec: learned cleanup pre-pass
+
+A sibling of the [edge pre-pass](EDGE_PREPASS.md) and the second on-device conditioning model from
+[`ML_STRATEGY.md`](ML_STRATEGY.md): a small image→image network that predicts the **clean RGB image** from a degraded
+raster (JPEG blocks, resampling ringing, sensor noise, anti-aliasing), so the classical tracer runs on cleaner pixels in
+**every mode**. Its training data is produced by [`../scripts/dataset`](../scripts/dataset/README.md) (the `clean/`
+target — the same dataset that trains the edge head).
+
+Unlike the edge pre-pass, which emits a boundary _hint_ the tracer consumes, the cleanup model **rewrites the pixels the
+tracer sees**. That makes its integration a straight preprocessing swap with the lowest possible risk: nothing in the
+tracer changes, and discretization keeps happening downstream at quantize/threshold exactly as today.
+
+## Where it sits
+
+A **Tier-2 conditioning stage** under the two-tier determinism contract in [`ML_STRATEGY.md`](ML_STRATEGY.md): optional,
+fail-soft, and never writing final geometry. It improves the _input_ to the deterministic classical core. It lives in
+`@vectorizer/ml` beside `BackgroundRemover`, `MagicSegmenter`, and `EdgeEnhancer`.
+
+```
+decode → resize → denoise → flatten            [raster]  preprocess
+        └─► CleanupEnhancer.run() → clean RGB   [ml]      (optional, one-shot: replaces the working image)
+                     │
+     any mode: (quantize | binarize) → … → trace   ← runs on the cleaned pixels, unchanged
+```
+
+The 8-bit RGB output **is** the discretization boundary: once the cleaned `RasterImage` exists, everything downstream is
+the ordinary classical path and is byte-identical for those bytes. Cross-GPU float noise can only move a channel by ±1 at
+knife-edge values; **reproducible mode** (`create({ preferBackend: 'wasm' })`) pins the WASM backend for a hard
+cross-device guarantee, exactly as for the edge pre-pass.
+
+## Task
+
+|               |                                                                                          |
+| ------------- | ---------------------------------------------------------------------------------------- |
+| **Input**     | RGB(A) image tile, `H×W×3`, values `[0,1]`, ImageNet-normalized (as `packNchw` produces) |
+| **Output**    | Clean RGB image `H×W×3`, values `[0,1]` (the export applies a sigmoid)                   |
+| **Objective** | Reconstruct the _clean_ render of the underlying vector scene from a _degraded_ raster   |
+
+The source **alpha is preserved** (copied through), so a cleanup after a background removal / magic cutout keeps the
+cutout.
+
+## Data
+
+Produced by the dataset generator; no manual labeling.
+
+- **Pairs:** `input/` (degraded raster) → `clean/` (the pre-degradation render). Pixel-aligned by construction — the
+  target is the render the degradation pipeline started from.
+- **Augmentation is the degradation pipeline** (blur, resample, noise, JPEG, background compositing, geometric) — the
+  exact train/test domain gap the model must close.
+- **Size** (per [`ML_STRATEGY.md`](ML_STRATEGY.md)): **~20k pairs** to prototype, **50k–200k** for production. The same
+  generated set trains either task, since it carries both the `clean/` and `edge/` targets.
+- **Split by source family** (the generator does this) so no font/icon-pack straddles train/val/test.
+
+## Model
+
+Reuses the edge pre-pass network, widened to an RGB head — see [`../scripts/train/model.py`](../scripts/train/model.py).
+
+- **Architecture:** the shared `TinyUNet`, `out_channels=3`. A wider `--base-channels` (32–48) is worth it here; image
+  restoration benefits from capacity more than the sparse boundary task does.
+- **Budget:** target **< 5 MB** quantized ONNX, in line with u2netp.
+- **Resolution:** train at **256×256** tiles; at inference, large images are swept on a fixed overlapping grid (256 with
+  32 px overlap) and stitched **per channel** — a fixed grid keeps the pass deterministic for a given backend.
+- **Normalization:** ImageNet mean/std on the input (matches `packNchw`); the output is plain `[0,1]` RGB.
+
+## Training
+
+Offline, in PyTorch (not part of the repo's Node/TS build). One flag switches the scaffold to this task:
+
+```
+python scripts/train/pipeline.py --task cleanup --count 20000 --quantize
+```
+
+- **Loss:** L1 on the sigmoid'd RGB vs. the clean target ([`losses.py`](../scripts/train/losses.py) `cleanup_loss`). L1
+  over L2 keeps edges crisp rather than blurring them — important for a tracer input. A perceptual/SSIM term can be added
+  later if needed.
+- **Optimizer:** AdamW, cosine decay.
+- **Metrics:** PSNR on the held-out split, **plus the downstream metric that matters** — feed cleaned images through the
+  tracer and compare the app's **Oklab ΔE fidelity** and node counts against tracing the degraded input directly.
+- **Selection:** maximize downstream ΔE improvement on degraded val inputs **without regressing clean inputs**.
+
+## Export & verification
+
+Identical to the edge pre-pass, task-aware ([`export_onnx.py`](../scripts/train/export_onnx.py)):
+
+- Export PyTorch → **ONNX**, verify torch/onnxruntime parity within tolerance, then quantize (int8/fp16).
+- Output shape is asserted `[1, 3, size, size]`.
+- **Host it as a project asset, not on a third party.** Drop the ONNX at `apps/web/public/models/cleanup.onnx`; Vite
+  serves it **same-origin** (no CORS, no external host — unlike the third-party `u2netp`/SlimSAM, which keep fetching from
+  their upstream mirrors). The registry points at `models/cleanup.onnx`; the app resolves it against its deploy base at
+  runtime with `overrideModelUrl` and `import.meta.env.BASE_URL`.
+
+## Integration (`@vectorizer/ml`)
+
+Mirrors `BackgroundRemover` (a one-shot that returns a new image), plus the reproducible-mode backend option:
+
+```ts
+// cleanup is added to the ModelSpec id union and MODEL_REGISTRY.
+export class CleanupEnhancer {
+  // preferBackend: 'wasm' pins the deterministic backend (reproducible mode).
+  static create(opts?: {
+    preferBackend?: MlBackend
+    onProgress?: MlProgressFn
+  }): Promise<CleanupEnhancer>
+  // Cleaned RGB image at the input resolution (source alpha preserved); large images are tiled.
+  run(image: RasterImage, opts?: { onProgress?: MlProgressFn }): Promise<{ image: RasterImage }>
+  dispose(): void
+}
+```
+
+- **Backend & cache:** reuses `detectBackend()` (WebGPU → WASM), `ModelStore` (Cache Storage), and `MlProgress`
+  reporting, with the same lazy `import('onnxruntime-web')` inside the factory.
+- **App wiring (implemented):** the studio's ML tools panel has a **Clean up (ML)** one-shot button (beside Remove
+  background). It runs `CleanupEnhancer` on the working image and **replaces the working image** with the result, so the
+  next trace — in any mode — runs on the cleaned pixels. Undo via **Restore original**. Fail-soft: with no weights at
+  `apps/web/public/models/cleanup.onnx` it toasts and leaves the image untouched.
+- **Consumer:** none in the tracer — the cleaned image is just the raster the pipeline already expected, so no engine
+  changes and no new determinism handling beyond the 8-bit output boundary above.
+
+## Cleanup vs. edge pre-pass
+
+Both train from one generated dataset; pick per need (or ship both — they compose: clean up first, then trace with the
+edge hint on).
+
+|                  | Cleanup pre-pass                      | Edge pre-pass                             |
+| ---------------- | ------------------------------------- | ----------------------------------------- |
+| Output           | Clean RGB image                       | Boundary probability map                  |
+| Integration      | Replaces the working image (one-shot) | Hint consumed inside the tracer (per-run) |
+| Tracer changes   | None                                  | Guided despeckle / guarded region merge   |
+| Modes            | All (it is just cleaner pixels)       | All                                       |
+| Integration risk | Lowest                                | Low                                       |
+| Best at          | Denoise / deblock / de-ring           | Thin-feature recall on noisy input        |
+
+## Success criteria
+
+1. **Wins where it should:** measurable Oklab ΔE improvement (and/or lower node count at equal ΔE) when tracing
+   **degraded** inputs cleaned first vs. traced directly, on the held-out split.
+2. **First, do no harm:** no ΔE regression on **clean** inputs beyond a small tolerance.
+3. **Budget:** weights < 5 MB; added latency within an interactive budget on a 4096×4096 image (tiled), WebGPU path.
+4. **Determinism intact:** classical-only output byte-identical across devices; ML-assisted output byte-identical on WASM.
+
+## References
+
+Degradation models (Real-ESRGAN, BSRGAN) and restoration backbones are cited in
+[`ML_STRATEGY.md`](ML_STRATEGY.md#references). On-device model conventions (ORT setup, model mirroring, Cache Storage) are
+in [`REFERENCES.md`](REFERENCES.md) and `packages/ml/`.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -198,6 +198,7 @@ export function optimizePathData(commands: readonly PathCommand[], precision: nu
 export function cleanCommands(commands: readonly PathCommand[], precision: number): PathCommand[]
 export type Primitive =
   | { kind: 'rect'; x: number; y: number; width: number; height: number }
+  | { kind: 'rrect'; x: number; y: number; width: number; height: number; r: number } // circular corners → <rect rx>
   | { kind: 'circle'; cx: number; cy: number; r: number }
   | { kind: 'ellipse'; cx: number; cy: number; rx: number; ry: number }
 // The primitive a single closed subpath represents, or null. `allowRound` gates

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -122,10 +122,12 @@ export function adaptiveBinarize(
 // absorbed into the most frequent 4-neighbor label (repeat until stable, max 8
 // rounds). -1 stays -1. Mutates and returns `labels`.
 export interface MergeOptions {
-  oklab: Float32Array // palette colors in Oklab, length count*3, indexed by label
-  keepContrast: number // keep a small region when its Oklab ΔE to the target ≥ this
+  oklab?: Float32Array // palette colors in Oklab, length count*3, indexed by label
+  keepContrast?: number // keep a small region when its Oklab ΔE to the target ≥ this (needs oklab)
+  protect?: BinaryMask // 1 = keep this pixel's small region even below minArea (edge hint)
 }
-// With opts, small high-contrast regions are kept instead of absorbed.
+// With opts, small regions are kept instead of absorbed when high-contrast
+// (keepContrast+oklab) or on a protected edge pixel (protect).
 export function mergeSmallRegions(labels: LabelMap, minArea: number, opts?: MergeOptions): LabelMap
 export function extractLabelMask(labels: LabelMap, label: number): BinaryMask
 export function maskArea(mask: BinaryMask): number

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -256,8 +256,8 @@ export interface MlAvailability {
 export function detectBackend(): Promise<MlAvailability>
 
 export interface ModelSpec {
-  id: 'u2netp' | 'slimsam-encoder' | 'slimsam-decoder' | 'edge-prepass'
-  url: string // absolute https for third-party models; project-relative for edge-prepass (same-origin)
+  id: 'u2netp' | 'slimsam-encoder' | 'slimsam-decoder' | 'edge-prepass' | 'cleanup'
+  url: string // absolute https for third-party models; project-relative for edge-prepass/cleanup (same-origin)
   approxBytes: number
   license: string
 }
@@ -305,6 +305,18 @@ export class EdgeEnhancer {
   }): Promise<EdgeEnhancer>
   // Boundary probability map ([0,1]) at the input resolution; large images are tiled.
   run(image: RasterImage, opts?: { onProgress?: MlProgressFn }): Promise<{ edges: GrayImage }>
+  dispose(): void
+}
+
+export class CleanupEnhancer {
+  // Optional Tier-2 image→image cleanup pre-pass (docs/CLEANUP_PREPASS.md).
+  // preferBackend 'wasm' pins the deterministic backend (reproducible mode).
+  static create(opts?: {
+    preferBackend?: MlBackend
+    onProgress?: MlProgressFn
+  }): Promise<CleanupEnhancer>
+  // Cleaned RGB at the input resolution (source alpha preserved); large images are tiled.
+  run(image: RasterImage, opts?: { onProgress?: MlProgressFn }): Promise<{ image: RasterImage }>
   dispose(): void
 }
 ```

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -244,8 +244,8 @@ export interface MlAvailability {
 export function detectBackend(): Promise<MlAvailability>
 
 export interface ModelSpec {
-  id: 'u2netp' | 'slimsam-encoder' | 'slimsam-decoder'
-  url: string
+  id: 'u2netp' | 'slimsam-encoder' | 'slimsam-decoder' | 'edge-prepass'
+  url: string // absolute https for third-party models; project-relative for edge-prepass (same-origin)
   approxBytes: number
   license: string
 }
@@ -281,6 +281,18 @@ export class MagicSegmenter {
     mask: BinaryMask
     score: number
   }>
+  dispose(): void
+}
+
+export class EdgeEnhancer {
+  // Optional Tier-2 edge/boundary pre-pass (docs/EDGE_PREPASS.md).
+  // preferBackend 'wasm' pins the deterministic backend (reproducible mode).
+  static create(opts?: {
+    preferBackend?: MlBackend
+    onProgress?: MlProgressFn
+  }): Promise<EdgeEnhancer>
+  // Boundary probability map ([0,1]) at the input resolution; large images are tiled.
+  run(image: RasterImage, opts?: { onProgress?: MlProgressFn }): Promise<{ edges: GrayImage }>
   dispose(): void
 }
 ```

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -30,6 +30,8 @@ Rules that apply to every package:
 // resize.ts — area-averaged box downscale. Returns input object unchanged when
 // maxDimension is 0 or the image already fits. Never upscales.
 export function resizeToFit(image: RasterImage, maxDimension: number): RasterImage
+// Bilinear single-channel resize (e.g. an edge hint → the working resolution).
+export function resizeGray(image: GrayImage, width: number, height: number): GrayImage
 
 // filters.ts — all return new images, alpha handled sensibly (blur blurs it,
 // median/bilateral preserve it).
@@ -134,6 +136,13 @@ export function erode(mask: BinaryMask, radius: number): BinaryMask
 // Remove 8-connected foreground specks < minArea AND fill 4-connected background
 // holes < minArea (holes = background components not touching the border).
 export function despeckleMask(mask: BinaryMask, minArea: number): BinaryMask
+// As despeckleMask, but a component overlapping `protect` (1 = protected) is kept
+// even below minArea; `protect` null reproduces despeckleMask byte-for-byte.
+export function despeckleMaskGuided(
+  mask: BinaryMask,
+  minArea: number,
+  protect: BinaryMask | null,
+): BinaryMask
 
 // thin.ts
 export function zhangSuenThin(mask: BinaryMask): BinaryMask // classic two-pass thinning
@@ -344,6 +353,7 @@ export type WorkerInMessage =
       height: number
       buffer: ArrayBuffer
       settings: VectorizeSettings
+      edgeHint?: ArrayBuffer // optional Float32 plane, width×height, transferred
     }
   | { type: 'cancel'; id: number }
 export type WorkerOutMessage =
@@ -363,6 +373,7 @@ export class VectorizerClient {
     image: RasterImage,
     settings: VectorizeSettings,
     onProgress?: (stage: StageId, overall: number) => void,
+    edgeHint?: GrayImage, // optional boundary hint, same dimensions as `image`
   ): Promise<VectorizeResult>
   dispose(): void
 }
@@ -370,6 +381,8 @@ export function createNativeEngine(): VectorizerEngine
 export function vectorize(
   image: RasterImage,
   settings: VectorizeSettings,
+  // ctx.edgeHint (GrayImage, optional) is an on-device boundary hint honored in
+  // bw mode; absent, tracing is byte-identical to the classical path.
   ctx?: EngineContext,
 ): Promise<VectorizeResult>
 ```

--- a/docs/EDGE_PREPASS.md
+++ b/docs/EDGE_PREPASS.md
@@ -109,10 +109,15 @@ export class EdgeEnhancer {
 - **Backend & cache:** reuse `detectBackend()` (WebGPU → WASM), `ModelStore` (Cache Storage), and the `MlProgress`
   reporting already in the package. Same lazy `import('onnxruntime-web')` inside the factory so the main bundle stays lean.
 - **Consumers of the boundary map** (`@vectorizer/engine`):
-  - **bw / centerline:** after `binarize`/`adaptiveBinarize`, use the boundary map to guide `despeckleMask` and snap the
-    mask edge to predicted boundaries (a guided/joint step) → cleaner cracks into `traceMask`.
-  - **color / stacked:** pass the boundary map as an extra cost into `mergeSmallRegions` so region boundaries prefer
-    predicted edges.
+  - **bw / centerline (implemented):** the hint crosses the worker boundary as an optional Float32 plane
+    (`WorkerInMessage.edgeHint` → `EngineContext.edgeHint`), is resized to the working resolution and thresholded (the
+    discretization boundary), and drives `despeckleMaskGuided` so thin real features survive the size filter. In bw mode
+    the tracer then keeps them — `minArea` drops to 1 when a hint is present, mirroring `preserveDetails` in color.
+  - **color / stacked (future):** pass the boundary map as an extra cost into `mergeSmallRegions` so region boundaries
+    prefer predicted edges.
+- **App wiring (remaining):** the studio should run `EdgeEnhancer` on the source and pass its `edges` as the fourth
+  argument to `VectorizerClient.vectorize`, behind a UI toggle. It stays dormant (fail-soft, no hint sent) until the
+  weights at `apps/web/public/models/edge-prepass.onnx` exist.
 - **Determinism:** the boundary map is **discretized** (threshold / snap) before it reaches `crack.ts`, so the trace stays
   byte-identical across devices except at knife-edge pixels; a **reproducible mode** pins `EdgeEnhancer` to the WASM
   backend via `create({ preferBackend: 'wasm' })` for a hard cross-device guarantee. The pure classical path (no `EdgeEnhancer` engaged) is unchanged and remains

--- a/docs/EDGE_PREPASS.md
+++ b/docs/EDGE_PREPASS.md
@@ -1,0 +1,144 @@
+# Model spec: learned edge pre-pass
+
+The first on-device conditioning model proposed in [`ML_STRATEGY.md`](ML_STRATEGY.md) — a small network that predicts
+clean region **boundaries** from a degraded raster, so the tracer decomposes cleaner cracks on noisy, anti-aliased or
+JPEG-crushed input. This is a spec, not shipped code. Its training data is produced by
+[`../scripts/dataset`](../scripts/dataset/README.md) (the `edge/` target).
+
+A lower-integration-risk sibling — a **cleanup pre-pass** (image→image restoration) — trains from the same dataset (the
+`clean/` target) and is described at the end.
+
+## Where it sits
+
+A **Tier-2 conditioning stage** under the two-tier determinism contract in [`ML_STRATEGY.md`](ML_STRATEGY.md): optional,
+fail-soft, and never writing final geometry. It improves the _input_ to the deterministic classical core; its continuous
+output is **discretized before the tracer**, so cross-GPU float noise is absorbed and byte-identical output is preserved
+on the WASM backend. It lives in `@vectorizer/ml` beside `BackgroundRemover` and `MagicSegmenter`.
+
+```
+decode → resize → denoise → flatten          [raster]  preprocess
+        └─► EdgeEnhancer.run() → boundary map [ml]      (optional, new)
+                     │
+  bw/centerline: threshold → despeckle ──guided by boundary map──► mask → crack decomposition → trace
+  color/stacked: quantize → region cleanup ──boundary map as a merge prior──► per-layer masks → trace
+```
+
+## Task
+
+|               |                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------ |
+| **Input**     | RGB(A) image tile, `H×W×3`, values `[0,1]` (letterboxed like U²-Net / SlimSAM inputs)                  |
+| **Output**    | Single-channel boundary probability `H×W×1`, `[0,1]` — high on region/color boundaries and silhouettes |
+| **Objective** | Reproduce the _clean_ boundaries of the underlying vector scene from a _degraded_ raster               |
+
+The output is a boundary map (edges between regions), **not** a segmentation mask. Downstream code turns it into cleaner
+region boundaries (below).
+
+## Data
+
+Produced by the dataset generator; no manual labeling.
+
+- **Pairs:** `input/` (degraded raster) → `edge/` (soft Sobel boundary map of the clean, pre-degradation scene). The
+  generator guarantees pixel alignment because the target is derived before degradation.
+- **Augmentation is the degradation pipeline** (blur, resample, noise, JPEG, background compositing, geometric) — that is
+  precisely the train/test domain gap the model must close, so it doubles as augmentation.
+- **Size** (per [`ML_STRATEGY.md`](ML_STRATEGY.md)): **~20k pairs** to prototype, **50k–200k** for production. Start
+  procedural for volume and exact labels; mix in a real SVG corpus (fonts, icon sets) via `--source dir` for realism.
+- **Split by source family** (the generator does this) so no font/icon-pack straddles train/val/test.
+- **Class imbalance is real:** boundary pixels are sparse — the generator's own samples run ≈5–8% pixels above a mid
+  threshold — so the loss must weight them (below).
+
+## Model
+
+Small enough to ship in-browser and run over large images, in the size class of the existing models (u2netp ≈4.6 MB,
+SlimSAM ≈10 MB).
+
+- **Architecture:** a compact edge network — PiDiNet-tiny class (~0.1–0.7 M params) or a lightweight encoder–decoder
+  U-Net (~1–2 M params) with a single sigmoid boundary head. Deep supervision (side outputs fused, HED-style) helps and
+  is cheap.
+- **Budget:** target **< 5 MB** quantized ONNX (int8 or fp16), so the extra download stays in line with u2netp.
+- **Resolution:** train at **256×256** tiles. At inference, **tile** large images (up to the app's 4096×4096) on a fixed
+  overlapping grid (e.g. 512 with 32 px overlap) and stitch — a fixed grid keeps the pass deterministic for a given
+  backend.
+- **Normalization:** document the exact input scaling and letterbox with the weights (as the repo already does for its
+  ONNX models); the runtime must reproduce it byte-for-byte.
+
+## Training
+
+Offline, in PyTorch (not part of the repo's Node/TS build):
+
+- **Loss:** class-balanced binary cross-entropy (HED's β-weighting by the positive-pixel fraction) **+ a Dice/F-measure
+  term** to counter boundary sparsity. Soft targets (the 0–1 Sobel map) train directly with BCE on probabilities.
+- **Optimizer:** AdamW, cosine decay; standard for this scale.
+- **Metrics:** edge F-score (ODS/OIS) on the held-out split, **plus the downstream metric that actually matters** — feed
+  predictions through the tracer and compare the app's existing **Oklab ΔE fidelity** and node counts against tracing the
+  degraded input with no pre-pass.
+- **Selection:** pick the checkpoint that maximizes downstream ΔE improvement on degraded val inputs **without regressing
+  clean inputs** (a pre-pass that hurts clean images is a net loss — see success criteria).
+
+## Export & verification
+
+- Export PyTorch → **ONNX** (a widely supported opset), then quantize (int8/fp16) with `onnxruntime`'s tooling.
+- **Parity check:** assert the ONNX (WASM EP) output matches PyTorch within tolerance on a fixed sample set before
+  shipping weights.
+- Mirror the weights on a **CORS-enabled host** (Hugging Face `resolve/` URLs) — GitHub release assets lack the headers,
+  per the repo's ML troubleshooting note.
+
+## Integration (`@vectorizer/ml`)
+
+Mirror the existing `BackgroundRemover` surface exactly:
+
+```ts
+// Add to the model registry union and MODEL_REGISTRY.
+export interface ModelSpec {
+  id: 'u2netp' | 'slimsam-encoder' | 'slimsam-decoder' | 'edge-prepass'
+  url: string
+  approxBytes: number
+  license: string
+}
+
+export class EdgeEnhancer {
+  static create(onProgress?: MlProgressFn): Promise<EdgeEnhancer>
+  // Returns a boundary probability map aligned to `image`.
+  run(
+    image: RasterImage,
+    opts?: { backend?: MlBackend; tile?: number; onProgress?: MlProgressFn },
+  ): Promise<{ edges: GrayImage }>
+  dispose(): void
+}
+```
+
+- **Backend & cache:** reuse `detectBackend()` (WebGPU → WASM), `ModelStore` (Cache Storage), and the `MlProgress`
+  reporting already in the package. Same lazy `import('onnxruntime-web')` inside the factory so the main bundle stays lean.
+- **Consumers of the boundary map** (`@vectorizer/engine`):
+  - **bw / centerline:** after `binarize`/`adaptiveBinarize`, use the boundary map to guide `despeckleMask` and snap the
+    mask edge to predicted boundaries (a guided/joint step) → cleaner cracks into `traceMask`.
+  - **color / stacked:** pass the boundary map as an extra cost into `mergeSmallRegions` so region boundaries prefer
+    predicted edges.
+- **Determinism:** the boundary map is **discretized** (threshold / snap) before it reaches `crack.ts`, so the trace stays
+  byte-identical across devices except at knife-edge pixels; a **reproducible mode** pins `EdgeEnhancer` to the WASM
+  backend for a hard cross-device guarantee. The pure classical path (no `EdgeEnhancer` engaged) is unchanged and remains
+  the tested, byte-identical baseline.
+- **Fail-soft:** if the model is unavailable or `detectBackend()` reports none, skip the stage and trace as today.
+
+## Success criteria
+
+1. **Wins where it should:** measurable Oklab ΔE improvement (and/or lower node count at equal ΔE) when tracing **degraded**
+   inputs with the pre-pass vs. without, on the held-out split.
+2. **First, do no harm:** no ΔE regression on **clean** inputs beyond a small tolerance.
+3. **Budget:** weights < 5 MB; added latency within an interactive budget on a 4096×4096 image (tiled), WebGPU path.
+4. **Determinism intact:** classical-only output byte-identical across devices; ML-assisted output byte-identical on WASM.
+
+## Sibling: cleanup pre-pass (same data, lower integration risk)
+
+A small U-Net that predicts the **clean image** (`clean/` target) instead of edges. It integrates as a straight
+replacement of the preprocessed RGBA before `quantize`/`binarize` — **no changes to the tracer**, and discretization still
+happens downstream at quantize/threshold exactly as today, so determinism handling is trivial. Same `EdgeEnhancer`-shaped
+class (`run` returns `{ image: RasterImage }`), same dataset, same training loop with an L1/L2 + perceptual loss instead of
+BCE. Choose this first if integration risk matters more than the extra boundary robustness the edge head brings.
+
+## References
+
+Model families (PiDiNet, DexiNed, HED) and the degradation models (Real-ESRGAN, BSRGAN) are cited in
+[`ML_STRATEGY.md`](ML_STRATEGY.md#references). Existing on-device model conventions (ORT setup, model mirroring, Cache
+Storage) are in [`REFERENCES.md`](REFERENCES.md) and `packages/ml/`.

--- a/docs/EDGE_PREPASS.md
+++ b/docs/EDGE_PREPASS.md
@@ -81,29 +81,27 @@ Offline, in PyTorch (not part of the repo's Node/TS build):
 - Export PyTorch → **ONNX** (a widely supported opset), then quantize (int8/fp16) with `onnxruntime`'s tooling.
 - **Parity check:** assert the ONNX (WASM EP) output matches PyTorch within tolerance on a fixed sample set before
   shipping weights.
-- Mirror the weights on a **CORS-enabled host** (Hugging Face `resolve/` URLs) — GitHub release assets lack the headers,
-  per the repo's ML troubleshooting note.
+- **Host it as a project asset, not on a third party.** Drop the ONNX at `apps/web/public/models/edge-prepass.onnx`;
+  Vite serves it **same-origin** from the deployed site, so there is no CORS and no external host (unlike the third-party
+  `u2netp`/SlimSAM, which are fetched from their upstream mirrors). The binary is a few MB and force-tracked by git (the
+  root `.gitignore` keeps scratch weights out but allows that path); reach for **Git LFS** if several models accumulate.
+  The registry already points at `models/edge-prepass.onnx`; the app resolves it against its deploy base at startup with
+  `overrideModelUrl` and `import.meta.env.BASE_URL`.
 
 ## Integration (`@vectorizer/ml`)
 
-Mirror the existing `BackgroundRemover` surface exactly:
+Mirror the existing `BackgroundRemover` surface, plus a reproducible-mode backend option (this is the shipped API):
 
 ```ts
-// Add to the model registry union and MODEL_REGISTRY.
-export interface ModelSpec {
-  id: 'u2netp' | 'slimsam-encoder' | 'slimsam-decoder' | 'edge-prepass'
-  url: string
-  approxBytes: number
-  license: string
-}
-
+// edge-prepass is added to the ModelSpec id union and MODEL_REGISTRY.
 export class EdgeEnhancer {
-  static create(onProgress?: MlProgressFn): Promise<EdgeEnhancer>
-  // Returns a boundary probability map aligned to `image`.
-  run(
-    image: RasterImage,
-    opts?: { backend?: MlBackend; tile?: number; onProgress?: MlProgressFn },
-  ): Promise<{ edges: GrayImage }>
+  // preferBackend: 'wasm' pins the deterministic backend (reproducible mode).
+  static create(opts?: {
+    preferBackend?: MlBackend
+    onProgress?: MlProgressFn
+  }): Promise<EdgeEnhancer>
+  // Boundary probability map ([0,1] GrayImage) at the input resolution; large images are tiled.
+  run(image: RasterImage, opts?: { onProgress?: MlProgressFn }): Promise<{ edges: GrayImage }>
   dispose(): void
 }
 ```
@@ -117,7 +115,7 @@ export class EdgeEnhancer {
     predicted edges.
 - **Determinism:** the boundary map is **discretized** (threshold / snap) before it reaches `crack.ts`, so the trace stays
   byte-identical across devices except at knife-edge pixels; a **reproducible mode** pins `EdgeEnhancer` to the WASM
-  backend for a hard cross-device guarantee. The pure classical path (no `EdgeEnhancer` engaged) is unchanged and remains
+  backend via `create({ preferBackend: 'wasm' })` for a hard cross-device guarantee. The pure classical path (no `EdgeEnhancer` engaged) is unchanged and remains
   the tested, byte-identical baseline.
 - **Fail-soft:** if the model is unavailable or `detectBackend()` reports none, skip the stage and trace as today.
 

--- a/docs/EDGE_PREPASS.md
+++ b/docs/EDGE_PREPASS.md
@@ -108,16 +108,18 @@ export class EdgeEnhancer {
 
 - **Backend & cache:** reuse `detectBackend()` (WebGPU → WASM), `ModelStore` (Cache Storage), and the `MlProgress`
   reporting already in the package. Same lazy `import('onnxruntime-web')` inside the factory so the main bundle stays lean.
-- **Consumers of the boundary map** (`@vectorizer/engine`):
-  - **bw / centerline (implemented):** the hint crosses the worker boundary as an optional Float32 plane
-    (`WorkerInMessage.edgeHint` → `EngineContext.edgeHint`), is resized to the working resolution and thresholded (the
-    discretization boundary), and drives `despeckleMaskGuided` so thin real features survive the size filter. In bw mode
-    the tracer then keeps them — `minArea` drops to 1 when a hint is present, mirroring `preserveDetails` in color.
-  - **color / stacked (future):** pass the boundary map as an extra cost into `mergeSmallRegions` so region boundaries
-    prefer predicted edges.
-- **App wiring (implemented):** the studio's ML tools panel has an **Edge pre-pass (ML)** toggle. When on (in bw /
-  centerline modes), the store runs `EdgeEnhancer` on the working image, caches the result per image, and passes it as the
-  fourth argument to `VectorizerClient.vectorize`. It is fail-soft: with no weights at
+- **Consumers of the boundary map** (`@vectorizer/engine`): the hint crosses the worker boundary as an optional Float32
+  plane (`WorkerInMessage.edgeHint` → `EngineContext.edgeHint`), is resized to the working resolution and thresholded once
+  (the shared `edgeProtectMask` — the discretization boundary), then feeds every mode:
+  - **bw / centerline (implemented):** drives `despeckleMaskGuided` so thin real features survive the size filter. In bw
+    mode the tracer then keeps them — `minArea` drops to 1 when a hint is present, mirroring `preserveDetails` in color.
+  - **color / stacked (implemented):** the same protect mask is passed to `mergeSmallRegions` (`MergeOptions.protect`), so a
+    small region with any pixel on a predicted boundary is kept rather than absorbed by the size-based merge; `traceMinArea`
+    then drops to 1 so the tracer keeps it too. It composes with `preserveDetails` (contrast keep) — either reason keeps a
+    region. With no hint the merge is byte-identical to today's.
+- **App wiring (implemented):** the studio's ML tools panel has an **Edge pre-pass (ML)** toggle. When on (in every mode),
+  the store runs `EdgeEnhancer` on the working image, caches the result per image, and passes it as the fourth argument to
+  `VectorizerClient.vectorize`. It is fail-soft: with no weights at
   `apps/web/public/models/edge-prepass.onnx` it toasts and switches itself back off, and tracing proceeds classically.
 - **Determinism:** the boundary map is **discretized** (threshold / snap) before it reaches `crack.ts`, so the trace stays
   byte-identical across devices except at knife-edge pixels; a **reproducible mode** pins `EdgeEnhancer` to the WASM

--- a/docs/EDGE_PREPASS.md
+++ b/docs/EDGE_PREPASS.md
@@ -115,9 +115,10 @@ export class EdgeEnhancer {
     the tracer then keeps them — `minArea` drops to 1 when a hint is present, mirroring `preserveDetails` in color.
   - **color / stacked (future):** pass the boundary map as an extra cost into `mergeSmallRegions` so region boundaries
     prefer predicted edges.
-- **App wiring (remaining):** the studio should run `EdgeEnhancer` on the source and pass its `edges` as the fourth
-  argument to `VectorizerClient.vectorize`, behind a UI toggle. It stays dormant (fail-soft, no hint sent) until the
-  weights at `apps/web/public/models/edge-prepass.onnx` exist.
+- **App wiring (implemented):** the studio's ML tools panel has an **Edge pre-pass (ML)** toggle. When on (in bw /
+  centerline modes), the store runs `EdgeEnhancer` on the working image, caches the result per image, and passes it as the
+  fourth argument to `VectorizerClient.vectorize`. It is fail-soft: with no weights at
+  `apps/web/public/models/edge-prepass.onnx` it toasts and switches itself back off, and tracing proceeds classically.
 - **Determinism:** the boundary map is **discretized** (threshold / snap) before it reaches `crack.ts`, so the trace stays
   byte-identical across devices except at knife-edge pixels; a **reproducible mode** pins `EdgeEnhancer` to the WASM
   backend via `create({ preferBackend: 'wasm' })` for a hard cross-device guarantee. The pure classical path (no `EdgeEnhancer` engaged) is unchanged and remains

--- a/docs/EDGE_PREPASS.md
+++ b/docs/EDGE_PREPASS.md
@@ -6,7 +6,7 @@ JPEG-crushed input. This is a spec, not shipped code. Its training data is produ
 [`../scripts/dataset`](../scripts/dataset/README.md) (the `edge/` target).
 
 A lower-integration-risk sibling — a **cleanup pre-pass** (image→image restoration) — trains from the same dataset (the
-`clean/` target) and is described at the end.
+`clean/` target) and is specified in [`CLEANUP_PREPASS.md`](CLEANUP_PREPASS.md).
 
 ## Where it sits
 
@@ -137,11 +137,11 @@ export class EdgeEnhancer {
 
 ## Sibling: cleanup pre-pass (same data, lower integration risk)
 
-A small U-Net that predicts the **clean image** (`clean/` target) instead of edges. It integrates as a straight
-replacement of the preprocessed RGBA before `quantize`/`binarize` — **no changes to the tracer**, and discretization still
-happens downstream at quantize/threshold exactly as today, so determinism handling is trivial. Same `EdgeEnhancer`-shaped
-class (`run` returns `{ image: RasterImage }`), same dataset, same training loop with an L1/L2 + perceptual loss instead of
-BCE. Choose this first if integration risk matters more than the extra boundary robustness the edge head brings.
+A small U-Net that predicts the **clean image** (`clean/` target) instead of edges, integrating as a straight replacement
+of the preprocessed RGBA before `quantize`/`binarize` — **no changes to the tracer**. It is implemented (`CleanupEnhancer`
+
+- a one-shot studio button + `scripts/train --task cleanup`) and specified in [`CLEANUP_PREPASS.md`](CLEANUP_PREPASS.md).
+  The two compose: clean up first, then trace with the edge hint on.
 
 ## References
 

--- a/docs/ML_STRATEGY.md
+++ b/docs/ML_STRATEGY.md
@@ -1,0 +1,250 @@
+# ML & dataset strategy
+
+How (and how much) to use machine learning to push output quality toward the best commercial vectorizers, and — the
+question that motivated this doc — **what a training dataset should look like, how big it should be, and how to produce
+it**. This is a strategy/roadmap document, not a contract; nothing here is shipped yet. Shipped algorithms and models are
+tracked in [`REFERENCES.md`](REFERENCES.md); the pipeline it plugs into is in [`../ARCHITECTURE.md`](../ARCHITECTURE.md).
+
+## TL;DR
+
+- **Don't replace the tracer with a neural net.** The clean-room Potrace-class chain in `@vectorizer/trace` _is_ the
+  hard, valuable part — the same classical core the leading commercial tools spent years on. Keep it.
+- **Don't emulate DeepSVG.** It is a generative model over _simple icons_ (its training set had to be filtered to icons
+  with ≤ 8 paths); training your own gets you an icon generator, not a faithful raster→vector engine.
+- **Use ML surgically**, as optional _input-conditioning_ stages ahead of the deterministic core — exactly where
+  `@vectorizer/ml` already sits (background removal, magic-select) — and let the trace stay byte-identical.
+- **You almost certainly don't need millions of examples.** For the small on-device models that fit this project,
+  **50k–200k synthetic pairs** is plenty; a working prototype needs **5k–20k**.
+- **Produce data by rasterizing SVGs** (your instinct is right) — but the make-or-break step is **degrading the raster
+  inputs** so the model survives real photos, scans and JPEGs. Clean renders alone will not generalize.
+- **Determinism is nuanced, not absolute** — see [the two-tier contract](#determinism-and-webgpu-a-two-tier-contract).
+  WebGPU is allowed; byte-identical output is preserved where it actually matters.
+
+## What "as powerful as the commercial tools" actually means
+
+The leading hosted vectorizers are **hybrids**: deep-learning networks _and_ classical algorithms, plus a proprietary
+computational-geometry framework and heavy **shape fitting** (parameterized circles, ellipses, rounded rectangles, stars,
+arcs). The deep learning is applied to specific perceptual sub-problems; it is not one end-to-end "image in, SVG out"
+network. Their moat is 15 years of the _classical_ framework as much as the ML.
+
+Read against our codebase, that is encouraging: we already own a strong classical core. The visible gap is not "we lack a
+neural net" — it is a handful of concrete capabilities (clean shape/primitive fitting, gradient handling, robust behavior
+on noisy/compressed inputs, semantic layer separation), several of which are already on the README roadmap. ML helps with
+_some_ of them; classical work covers the rest.
+
+## Three ML families, and which one fits this project
+
+| Family | Representative | Data needed | Runs on-device (WASM/WebGPU)? | Verdict here |
+| --- | --- | --- | --- | --- |
+| End-to-end **SVG-code generation** | StarVector (1.4 B params, trained on ~2 M SVGs) | Huge | No — far too large | ✗ Also hallucinates geometry; wrong tool for faithful tracing |
+| **Optimization** with a differentiable rasterizer | LIVE / DiffVG | **None** | No — minutes to hours per image | ✗ For live use. ✓ **Offline** as a data/oracle tool (below) |
+| **Surgical** small models on sub-problems | U²-Netp, SlimSAM (already shipped) | Small–moderate | **Yes** — this is the proven path here | ✓ **Our lane** |
+
+Sources for all three are in [References](#references).
+
+### Why not DeepSVG / end-to-end
+
+DeepSVG is a hierarchical VAE over vector _commands_, trained on the SVG-Icons8 set (100k icons). For any vectorization-
+flavored use it has to be filtered hard — the common filter keeps only icons with **≤ 8 paths** and **≤ 32 commands per
+path**, leaving ~26k. That tells you its regime: small, clean, few-path icons. It cannot represent a photo, a detailed
+logo, or a multi-hundred-path illustration, and it emits _plausible_ shapes rather than _faithful_ ones. An end-to-end
+generator (DeepSVG, StarVector, an LLM emitting `<path>` code) optimizes for "looks like an SVG of roughly this," which is
+the opposite of what a tracer is for. Our tracer already beats them on fidelity for anything past icon complexity.
+
+## Where ML earns its place
+
+Keep ML as optional, fail-soft, _input-conditioning_ stages that hand the deterministic core a cleaner or richer input.
+Highest value first, each mapped to the pipeline stage it augments and the roadmap item it advances:
+
+1. **Learned edge / boundary map** — a small edge CNN (PiDiNet / DexiNed / HED class) produces clean boundaries on noisy,
+   anti-aliased or JPEG-crushed input, feeding `preprocess`→crack decomposition better cracks than a raw threshold. This
+   is the single biggest robustness win on _bad_ inputs.
+2. **Cleanup / super-resolution pre-pass** — a small U-Net that de-JPEGs, de-noises and up-samples low-res input before
+   quantization. Much of the commercial tools' apparent "magic" on poor uploads is exactly this.
+3. **Primitive / shape detection** — classify a region as circle / ellipse / rounded-rect / star and recover its
+   parameters, so the serializer can emit a true `<circle>`/`<ellipse>`/arc instead of a many-node path. Directly
+   advances the roadmap's "SVG elliptical-arc (`A`) fitting" and matches the commercial shape-fitting advantage.
+4. **Layer / occlusion ordering** — infer which region sits on top, for clean editable `stacked` output. Advances
+   "Semantic layering with SAM masks (object-per-layer SVG)".
+5. **Better segmentation / quantization priors** — extend the existing SlimSAM magic-select toward automatic
+   object-per-layer proposals.
+
+Stages 1–3 are the recommended starting points: they are image→image or image→small-vector, cheap to supervise with
+synthetic data, and slot in cleanly ahead of the deterministic core.
+
+## Determinism and WebGPU: a two-tier contract
+
+The README and `AGENTS.md` state determinism as an absolute: _same image + same settings ⇒ byte-identical SVG_. That is
+the right promise for the classical core, but taken literally it forbids the roadmap's own "Differentiable refinement pass
+(WebGPU)" and any WebGPU ML — because **WebGPU floating-point math is not bit-identical across GPUs, drivers and
+backends** (reduction order, fast-math, precision differ). Resolve the tension by scoping the guarantee instead of
+dropping it.
+
+First, be clear about **what determinism is _for_ here**, because it decides the scope:
+
+- **Reproducible tests** — Vitest runs in Node over pure functions; the suite exercises the classical core and never
+  touches the GPU or ML. It is unaffected by anything below.
+- **Reproducible exports, caching, user trust** — "I re-run and get the same file."
+- **Regression debugging** — a diff in output must mean a diff in code, not in hardware.
+
+### The contract
+
+**Tier 1 — the classical core** (`raster` preprocessing math → `trace` → `svg`): **byte-identical on every device,
+always.** No GPU floats, no ML, no wall-clock, fixed-seed PRNG. This is what the test suite and the byte-identical promise
+rest on. **Unchanged.**
+
+**Tier 2 — ML conditioning stages** (background removal, segmentation, and future edge / cleanup / refinement models):
+**may use WebGPU.** Their job is to produce an intermediate that Tier 1 then consumes.
+
+The lever that makes this safe is the **discretization boundary**. Tier 1's inputs are already _discrete_ —
+`BinaryMask`, `LabelMap`, thresholded `GrayImage`. If a Tier-2 model emits a continuous probability/feature map and Tier 1
+**discretizes it (threshold / argmax / quantize) before tracing**, then cross-GPU float noise is absorbed: `0.732` vs
+`0.731` collapse to the same mask bit. The result is byte-identical across machines _except_ at the rare pixel whose value
+sits exactly on the discretization knife-edge. WebGPU thus never perturbs geometry directly; at worst it flips an
+occasional boundary pixel.
+
+For the cases that need a **hard** cross-machine guarantee (CI golden files, a "reproducible export" toggle):
+
+- **Pin ML to the WASM backend.** ONNX Runtime Web's WASM execution is bit-reproducible and portable; WebGPU stays the
+  default fast path for interactive use. This is a per-run backend choice, not a code change.
+- **Cache the discretized intermediate** (the mask / labels) with the result, so re-runs and shared links reuse the exact
+  input to Tier 1 rather than re-inferring.
+
+### Restated determinism guarantee
+
+- **Pure classical pipeline (no ML stage engaged):** byte-identical on all devices. Non-negotiable; what the tests
+  guarantee.
+- **With an ML conditioning stage engaged:** deterministic run-to-run on the same device + backend (the interactive
+  guarantee), and byte-identical across devices when that stage runs on the **WASM backend** (reproducible mode).
+
+### Note for the roadmap's WebGPU refinement pass
+
+This pass is essentially a **bounded DiffVG / LIVE-style differentiable refinement** — LIVE's own machinery (a
+differentiable rasterizer driving gradient descent on path parameters), but scoped to _polish_ the classical tracer's
+existing paths against the source rather than vectorize from scratch. That scoping is what makes it shippable: from-
+scratch LIVE is minutes-to-hours and stays offline (see the data-factory note above), whereas a few refinement iterations
+on already-good paths is bounded. A pass that nudges Bézier control points by GPU-computed gradients is **Tier-1-touching**
+— it writes geometry — so it would break byte-identical output unless constrained. Two ways to keep the promise:
+
+- **Snap refined coordinates to the serializer's output-precision grid.** The `svg` serializer already quantizes
+  coordinates to a configurable precision; if the refinement delta is smaller than that step, it vanishes identically on
+  every device. This reuses an existing feature and is the cleanest option.
+- **Run the refinement in WASM** for reproducible mode, WebGPU otherwise — same split as above.
+
+## Dataset strategy
+
+### How big?
+
+There is no single number — it depends entirely on which model above you build. Grounded ranges:
+
+| What you're training | Realistic size | Notes |
+| --- | --- | --- |
+| Prototype, to prove a sub-model _learns_ | **5k–20k pairs** | Enough to see signal and de-risk the approach |
+| Production small ONNX conditioning model (edge / cleanup / primitive) | **50k–200k pairs** | Heavy augmentation multiplies effective size |
+| From-scratch icon generator (DeepSVG-style) | **~100k SVGs** collected, filtered | Only yields a simple-icon generator; not recommended |
+| Foundation model (StarVector-style) | **500k–2M+** | Not on-device viable; out of scope |
+
+The honest headline: for the surgical path **you do not need millions**. Diversity and _input realism_ dominate raw count
+— 50k well-degraded, diverse pairs beat 1M pristine ones that look nothing like real uploads.
+
+### How to produce it
+
+Your instinct — SVG + a rasterizer — is exactly the standard technique: rendering an SVG yields a _perfectly aligned_
+`(raster input, vector ground-truth)` pair, essentially for free and in unlimited quantity. The pipeline:
+
+1. **Collect an SVG corpus** — see [sources](#where-to-get-svgs).
+2. **Canonicalize** — flatten transforms, resolve `<use>`, expand shorthand, normalize the `viewBox`, drop unsupported
+   features. Raw SVGs are wildly inconsistent (this is why DeepSVG filtered so aggressively). Reuse our own
+   `@vectorizer/svg` path model as the canonical target representation so training targets match what the engine emits.
+3. **Rasterize deterministically** — [resvg](https://github.com/linebender/resvg) (Rust, fast, accurate) is the standard
+   choice; render at 2×–4× and area-downsample for clean anti-aliasing, at several output resolutions.
+4. **⚠ Degrade the _inputs_ — the make-or-break step** (details below). Ground truth stays the clean vector; only the
+   raster input is corrupted.
+5. **Emit the pairing** the task needs — full SVG, an edge map, a `LabelMap`, or a primitive list — as the target
+   alongside the degraded raster.
+6. **Split by _source family_, not by file** — never let the same font, icon set or clip-art pack straddle train/test, or
+   the metrics will lie.
+
+Keep the whole generator **seeded and versioned** (rasterizer version pinned, degradation RNG seeded), in the same spirit
+as the engine's determinism, so the dataset is regenerable rather than a frozen blob.
+
+### The degradation pipeline (why clean renders fail)
+
+Train only on pristine renders and the model collapses on real uploads. Apply a high-order degradation model
+(Real-ESRGAN / BSRGAN style) to the **input** side, in randomized order and strength:
+
+- **Blur** — isotropic/anisotropic Gaussian; sinc filters for ringing.
+- **Resampling** — down- then up-sample with a random filter (area / bilinear / bicubic).
+- **Noise** — Gaussian and Poisson, color and luminance.
+- **JPEG** — random quality (q ≈ 30–95), optionally applied twice.
+
+Then add corruptions specific to _real vectorizer inputs_, which generic super-resolution sets omit:
+
+- **Background compositing** — place the shape on photographic, textured or gradient backgrounds (real inputs are rarely
+  on clean white). Critical.
+- **Alpha / matting errors** — edge halos, fringing, imperfect cutouts.
+- **Palette reduction & dithering** — GIF-style quantization, ordered/Floyd–Steinberg dither.
+- **Geometric** — small rotations, affine/perspective warp, mild lens distortion (scans, photos of screens).
+- **Tone** — gamma / color-profile shifts, contrast changes.
+- **Line-art specific** — paper grain, pencil texture, scanner speckle for ink/centerline modes.
+
+### Where to get SVGs
+
+- **Fonts — the single best free source.** Every glyph is a clean, license-friendly vector shape; a handful of families
+  yields millions of diverse contours (including holes and thin strokes — great for centerline).
+- **Icon sets** — Material Symbols, Bootstrap Icons, Feather, Tabler, Iconoir, game-icons.net; Twemoji / Noto Emoji /
+  OpenMoji for multicolor. Mind each license.
+- **Large corpora** — SVG-Icons8 (~100k) if obtainable; SVG-Stack / TheStack (~2M, permissive) for scale; Wikimedia
+  Commons SVGs for genuinely hard, complex cases; FIGR-8 for icons.
+- **Procedural generation** — synthesize random compositions of primitives (circles, rects, stars, Béziers) with random
+  fills, gradients and strokes. Best for the **shape-detector** and **layer-ordering** tasks, because _you_ own the exact
+  ground-truth parameters and z-order. Also lets you dial difficulty directly.
+
+> **Licensing matters more than usual here:** trained weights would ship in-browser, i.e. publicly. Prefer fonts and
+> permissively-licensed sets for anything whose weights you distribute; treat restrictively-licensed art as eval-only.
+
+### Two data sources unique to this project
+
+- **Your own tracer is a supervision signal.** Trace clean renders with the existing pipeline; those outputs are
+  near-perfect targets for teaching a model to _reproduce tracer quality from a degraded input_ — the cheapest, most
+  aligned supervision available, and it needs no external ground truth.
+- **DiffVG / LIVE as an offline data factory and oracle.** They need no dataset and are far too slow to ship (minutes to
+  hours per image), but offline they can generate high-quality vector targets for arbitrary rasters, or score/refine
+  candidate targets. Use them to _manufacture_ training data, never at request time.
+
+## A concrete first milestone
+
+Pick **one** sub-problem, prove the whole loop small, then scale the data:
+
+1. Choose **Learned edge pre-pass** (stage 1) or **Cleanup pre-pass** (stage 2) — both are image→image, the easiest to
+   supervise and the clearest win on bad inputs. (Primitive detection, stage 3, is the highest _visible_ quality gain but
+   a bigger build; do it second.)
+2. Build **~20k synthetic pairs**: corpus → canonicalize → resvg render → degradation pipeline → aligned pairs.
+3. Train a small model, export to **ONNX**, and wire it as an optional Tier-2 conditioning stage in `@vectorizer/ml`,
+   discretizing its output before the tracer (per the [two-tier contract](#determinism-and-webgpu-a-two-tier-contract)).
+4. Measure against the existing **Oklab ΔE fidelity score** the app already computes — held out by source family — and
+   only then scale to 50k–200k.
+
+Keep every stage optional and fail-soft: the app must remain fully functional, and the classical path byte-identical, with
+no model loaded.
+
+## References
+
+Not-yet-shipped work that informs this strategy. When any of it becomes shipped code, move its citation into
+[`REFERENCES.md`](REFERENCES.md).
+
+- **Carlier et al., "DeepSVG: A Hierarchical Generative Network for Vector Graphics Animation", NeurIPS 2020.**
+  <https://arxiv.org/abs/2007.11301> — generative model over SVG commands; SVG-Icons8 (100k icons). Illustrates the
+  few-path-icon regime and the aggressive filtering such models require.
+- **Rodriguez et al., "StarVector: Generating Scalable Vector Graphics Code from Images and Text", CVPR 2025.**
+  <https://arxiv.org/abs/2312.11556> — 1.4 B-param multimodal model; SVG-Stack (~2M SVGs). The end-to-end code-generation
+  approach and why its scale/behavior is out of scope on-device.
+- **Ma et al., "Towards Layer-wise Image Vectorization (LIVE)", CVPR 2022.** <https://ma-xu.github.io/LIVE/> — training-
+  free, topology-preserving optimization; the offline data/oracle option.
+- **Li et al., "Differentiable Vector Graphics Rasterization for Editing and Learning (DiffVG)", SIGGRAPH Asia 2020.**
+  <https://github.com/BachiLi/diffvg> — the differentiable rasterizer LIVE and any refinement pass build on.
+- **Wang et al., "Real-ESRGAN", ICCVW 2021**, and **Zhang et al., "BSRGAN", ICCV 2021.** The high-order degradation
+  models behind the input-degradation pipeline.
+- **Su et al., "PiDiNet", ICCV 2021** / **Poma et al., "DexiNed", WACV 2020** / **Xie & Tu, "HED", ICCV 2015.** Compact
+  edge-detection networks suitable for the learned edge pre-pass.
+- **"Image Vectorization: a Review", 2023.** <https://arxiv.org/abs/2306.06441> — survey situating the above.

--- a/docs/ML_STRATEGY.md
+++ b/docs/ML_STRATEGY.md
@@ -218,9 +218,9 @@ Pick **one** sub-problem, prove the whole loop small, then scale the data. **A r
 seeded dataset generator in [`../scripts/dataset`](../scripts/dataset/README.md) and the model spec in
 [`EDGE_PREPASS.md`](EDGE_PREPASS.md):
 
-1. Choose **Learned edge pre-pass** (stage 1) or **Cleanup pre-pass** (stage 2) — both are image→image, the easiest to
-   supervise and the clearest win on bad inputs. (Primitive detection, stage 3, is the highest _visible_ quality gain but
-   a bigger build; do it second.)
+1. Choose **Learned edge pre-pass** (stage 1, [`EDGE_PREPASS.md`](EDGE_PREPASS.md)) or **Cleanup pre-pass** (stage 2,
+   [`CLEANUP_PREPASS.md`](CLEANUP_PREPASS.md)) — both are image→image, the easiest to supervise and the clearest win on
+   bad inputs. (Primitive detection, stage 3, is the highest _visible_ quality gain but a bigger build; do it second.)
 2. Build **~20k synthetic pairs** with the generator (`npm run dataset`): SVG source → resvg render → degradation
    pipeline → aligned `(input, edge/clean)` pairs, split by source family. It ships with a procedural source (no corpus
    needed) and a `--source dir` mode for real SVGs.

--- a/docs/ML_STRATEGY.md
+++ b/docs/ML_STRATEGY.md
@@ -34,11 +34,11 @@ _some_ of them; classical work covers the rest.
 
 ## Three ML families, and which one fits this project
 
-| Family | Representative | Data needed | Runs on-device (WASM/WebGPU)? | Verdict here |
-| --- | --- | --- | --- | --- |
-| End-to-end **SVG-code generation** | StarVector (1.4 B params, trained on ~2 M SVGs) | Huge | No — far too large | ✗ Also hallucinates geometry; wrong tool for faithful tracing |
-| **Optimization** with a differentiable rasterizer | LIVE / DiffVG | **None** | No — minutes to hours per image | ✗ For live use. ✓ **Offline** as a data/oracle tool (below) |
-| **Surgical** small models on sub-problems | U²-Netp, SlimSAM (already shipped) | Small–moderate | **Yes** — this is the proven path here | ✓ **Our lane** |
+| Family                                            | Representative                                  | Data needed    | Runs on-device (WASM/WebGPU)?          | Verdict here                                                  |
+| ------------------------------------------------- | ----------------------------------------------- | -------------- | -------------------------------------- | ------------------------------------------------------------- |
+| End-to-end **SVG-code generation**                | StarVector (1.4 B params, trained on ~2 M SVGs) | Huge           | No — far too large                     | ✗ Also hallucinates geometry; wrong tool for faithful tracing |
+| **Optimization** with a differentiable rasterizer | LIVE / DiffVG                                   | **None**       | No — minutes to hours per image        | ✗ For live use. ✓ **Offline** as a data/oracle tool (below)   |
+| **Surgical** small models on sub-problems         | U²-Netp, SlimSAM (already shipped)              | Small–moderate | **Yes** — this is the proven path here | ✓ **Our lane**                                                |
 
 Sources for all three are in [References](#references).
 
@@ -137,12 +137,12 @@ on already-good paths is bounded. A pass that nudges Bézier control points by G
 
 There is no single number — it depends entirely on which model above you build. Grounded ranges:
 
-| What you're training | Realistic size | Notes |
-| --- | --- | --- |
-| Prototype, to prove a sub-model _learns_ | **5k–20k pairs** | Enough to see signal and de-risk the approach |
-| Production small ONNX conditioning model (edge / cleanup / primitive) | **50k–200k pairs** | Heavy augmentation multiplies effective size |
-| From-scratch icon generator (DeepSVG-style) | **~100k SVGs** collected, filtered | Only yields a simple-icon generator; not recommended |
-| Foundation model (StarVector-style) | **500k–2M+** | Not on-device viable; out of scope |
+| What you're training                                                  | Realistic size                     | Notes                                                |
+| --------------------------------------------------------------------- | ---------------------------------- | ---------------------------------------------------- |
+| Prototype, to prove a sub-model _learns_                              | **5k–20k pairs**                   | Enough to see signal and de-risk the approach        |
+| Production small ONNX conditioning model (edge / cleanup / primitive) | **50k–200k pairs**                 | Heavy augmentation multiplies effective size         |
+| From-scratch icon generator (DeepSVG-style)                           | **~100k SVGs** collected, filtered | Only yields a simple-icon generator; not recommended |
+| Foundation model (StarVector-style)                                   | **500k–2M+**                       | Not on-device viable; out of scope                   |
 
 The honest headline: for the surgical path **you do not need millions**. Diversity and _input realism_ dominate raw count
 — 50k well-degraded, diverse pairs beat 1M pristine ones that look nothing like real uploads.
@@ -214,14 +214,19 @@ Then add corruptions specific to _real vectorizer inputs_, which generic super-r
 
 ## A concrete first milestone
 
-Pick **one** sub-problem, prove the whole loop small, then scale the data:
+Pick **one** sub-problem, prove the whole loop small, then scale the data. **A runnable scaffold already exists** — the
+seeded dataset generator in [`../scripts/dataset`](../scripts/dataset/README.md) and the model spec in
+[`EDGE_PREPASS.md`](EDGE_PREPASS.md):
 
 1. Choose **Learned edge pre-pass** (stage 1) or **Cleanup pre-pass** (stage 2) — both are image→image, the easiest to
    supervise and the clearest win on bad inputs. (Primitive detection, stage 3, is the highest _visible_ quality gain but
    a bigger build; do it second.)
-2. Build **~20k synthetic pairs**: corpus → canonicalize → resvg render → degradation pipeline → aligned pairs.
-3. Train a small model, export to **ONNX**, and wire it as an optional Tier-2 conditioning stage in `@vectorizer/ml`,
-   discretizing its output before the tracer (per the [two-tier contract](#determinism-and-webgpu-a-two-tier-contract)).
+2. Build **~20k synthetic pairs** with the generator (`npm run dataset`): SVG source → resvg render → degradation
+   pipeline → aligned `(input, edge/clean)` pairs, split by source family. It ships with a procedural source (no corpus
+   needed) and a `--source dir` mode for real SVGs.
+3. Train the small model per [`EDGE_PREPASS.md`](EDGE_PREPASS.md), export to **ONNX**, and wire it as an optional Tier-2
+   conditioning stage in `@vectorizer/ml` (an `EdgeEnhancer` mirroring `BackgroundRemover`), discretizing its output
+   before the tracer (per the [two-tier contract](#determinism-and-webgpu-a-two-tier-contract)).
 4. Measure against the existing **Oklab ΔE fidelity score** the app already computes — held out by source family — and
    only then scale to 50k–200k.
 

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -95,3 +95,7 @@ where it is used. Keep this file up to date when adding or changing algorithms.
   Curvilinear Feature Alignment”, _SIGGRAPH Asia_ 2009**, and
   **J. Kopf & D. Lischinski, “Depixelizing Pixel Art”, _SIGGRAPH_ 2011** —
   background for the pixel-art and gradient-handling roadmap items.
+- **ML & dataset roadmap.** Prospective ML models (DeepSVG, StarVector,
+  LIVE/DiffVG, edge and degradation networks) and how a training set would be
+  produced are discussed in [`ML_STRATEGY.md`](ML_STRATEGY.md). Citations move
+  into this file once the corresponding code ships.

--- a/docs/how-it-works.svg
+++ b/docs/how-it-works.svg
@@ -1,0 +1,195 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 700" width="1080" height="700"
+     role="img" aria-label="How Vectorizer works: a raster image becomes clean SVG through a deterministic classical core running in a Web Worker; an optional on-device ML edge pre-pass (EdgeEnhancer, WebGPU or WASM) produces a boundary map that is discretized at a fixed threshold before the tracer, so output stays byte-identical without it. The model is trained offline (SVG corpus, rasterized and degraded into pairs, U-Net, exported to ONNX) and ships same-origin with the app.">
+  <style>
+    :root{
+      --card:#ffffff; --ink:#1f2933; --muted:#616e7c; --edge:#b7c0cb;
+      --core:#eaf1fb; --core-stroke:#3f82db;
+      --ml:#e2f3ee; --ml-stroke:#0f9d8c;
+      --warm:#fbeede; --warm-stroke:#d9822b;
+      --flow:#3f82db; --divider:#d7dde4;
+    }
+    @media (prefers-color-scheme: dark){
+      :root{
+        --card:#0f141a; --ink:#e4e7eb; --muted:#9aa5b1; --edge:#39424c;
+        --core:#132132; --core-stroke:#5aa0f0;
+        --ml:#0f2320; --ml-stroke:#2bbfa6;
+        --warm:#2a2013; --warm-stroke:#e8a05a;
+        --flow:#5aa0f0; --divider:#2a323b;
+      }
+    }
+    text{font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;fill:var(--ink);}
+    .t-title{font-size:23px;font-weight:700;}
+    .t-sub{font-size:12.5px;fill:var(--muted);}
+    .t-band{font-size:14px;font-weight:700;}
+    .t-node{font-size:13px;font-weight:600;}
+    .t-small{font-size:10.5px;fill:var(--muted);}
+    .t-chip{font-size:11.5px;font-weight:600;}
+    .t-chipsub{font-size:9px;fill:var(--muted);}
+    .t-pill{font-size:9.5px;font-weight:700;fill:#ffffff;}
+    .bg{fill:var(--card);}
+    .node{fill:var(--card);stroke:var(--edge);stroke-width:1.5;}
+    .core{fill:var(--core);stroke:var(--core-stroke);stroke-width:2;}
+    .ml{fill:var(--ml);stroke:var(--ml-stroke);stroke-width:2;}
+    .warm{fill:var(--warm);stroke:var(--warm-stroke);stroke-width:1.5;}
+    .chip{fill:var(--card);stroke:var(--edge);stroke-width:1.2;}
+    .chip-hi{fill:var(--card);stroke:var(--ml-stroke);stroke-width:2;}
+    .gate{fill:var(--card);stroke:var(--ml-stroke);stroke-width:1.4;stroke-dasharray:4 3;}
+    .line{stroke:var(--flow);stroke-width:2;fill:none;}
+    .dash{stroke:var(--ml-stroke);stroke-width:2;fill:none;stroke-dasharray:6 6;}
+    .warm-dash{stroke:var(--warm-stroke);stroke-width:2;fill:none;stroke-dasharray:6 6;}
+    .divider{stroke:var(--divider);stroke-width:1.5;stroke-dasharray:2 6;}
+    .flow{fill:var(--flow);}
+    .flow-w{fill:var(--warm-stroke);}
+    .glow{fill:var(--ml-stroke);opacity:.16;}
+    .mk-flow{fill:var(--flow);} .mk-ml{fill:var(--ml-stroke);} .mk-warm{fill:var(--warm-stroke);}
+    @keyframes march{to{stroke-dashoffset:-24;}}
+    .dash,.warm-dash{animation:march 1.1s linear infinite;}
+    @keyframes pulse{0%,100%{opacity:.10;}50%{opacity:.34;}}
+    .glow{animation:pulse 2.8s ease-in-out infinite;}
+    @keyframes flowMain{0%{transform:translateX(0);opacity:0;}6%{opacity:1;}94%{opacity:1;}100%{transform:translateX(842px);opacity:0;}}
+    .flow-main{animation:flowMain 4.6s linear infinite;}
+    @keyframes flowOff{0%{transform:translateX(0);opacity:0;}6%{opacity:1;}94%{opacity:1;}100%{transform:translateX(852px);opacity:0;}}
+    .flow-off{animation:flowOff 5.6s linear infinite;}
+    @media (prefers-reduced-motion: reduce){
+      .dash,.warm-dash,.glow,.flow-main,.flow-off{animation:none;}
+      .flow-main,.flow-off{opacity:1;}
+    }
+  </style>
+  <defs>
+    <marker id="ahF" markerUnits="userSpaceOnUse" markerWidth="11" markerHeight="11" refX="8" refY="5" orient="auto"><path class="mk-flow" d="M0,1 L9,5 L0,9 Z"/></marker>
+    <marker id="ahM" markerUnits="userSpaceOnUse" markerWidth="11" markerHeight="11" refX="8" refY="5" orient="auto"><path class="mk-ml" d="M0,1 L9,5 L0,9 Z"/></marker>
+    <marker id="ahW" markerUnits="userSpaceOnUse" markerWidth="11" markerHeight="11" refX="8" refY="5" orient="auto"><path class="mk-warm" d="M0,1 L9,5 L0,9 Z"/></marker>
+  </defs>
+
+  <rect class="bg" x="0" y="0" width="1080" height="700" rx="16"/>
+
+  <!-- Header -->
+  <text class="t-title" x="40" y="44">How Vectorizer works</text>
+  <text class="t-sub" x="40" y="66">Raster → clean SVG, entirely client-side — with an optional, on-device ML edge pre-pass.</text>
+
+  <!-- ================= BAND A: runtime ================= -->
+  <text class="t-band" x="40" y="104" fill="var(--core-stroke)">① Runtime — in your browser, per image</text>
+
+  <!-- offline → runtime return connector (drawn first; boxes paint over it) -->
+  <path class="warm-dash" marker-end="url(#ahW)"
+        d="M954,516 H1046 Q1058,516 1058,504 V163 Q1058,151 1046,151 H608"/>
+  <text class="t-small" x="862" y="140" text-anchor="middle">trained ONNX ships to apps/web/public/models/ — loaded same-origin</text>
+
+  <!-- input -->
+  <rect class="node" x="40" y="281" width="118" height="70" rx="10"/>
+  <text class="t-node" x="99" y="312" text-anchor="middle">Raster in</text>
+  <text class="t-small" x="99" y="331" text-anchor="middle">noisy PNG / JPG</text>
+
+  <!-- classical path input -> core -->
+  <line class="line" x1="158" y1="316" x2="356" y2="316" marker-end="url(#ahF)"/>
+  <text class="t-small" x="255" y="308" text-anchor="middle">classical path</text>
+
+  <!-- flowing dots along the runtime pipeline -->
+  <circle class="flow flow-main" cx="160" cy="316" r="3.4"/>
+  <circle class="flow flow-main" cx="160" cy="316" r="3.4" style="animation-delay:1.5s"/>
+  <circle class="flow flow-main" cx="160" cy="316" r="3.4" style="animation-delay:3s"/>
+
+  <!-- EdgeEnhancer (optional ML) -->
+  <ellipse class="glow" cx="481" cy="151" rx="150" ry="46"/>
+  <rect class="ml" x="356" y="116" width="250" height="70" rx="12"/>
+  <text class="t-node" x="374" y="143" fill="var(--ml-stroke)">EdgeEnhancer</text>
+  <text class="t-small" x="374" y="161" fill="var(--ml-stroke)" opacity="0.85">optional · on-device ONNX</text>
+  <text class="t-small" x="374" y="177">WebGPU → WASM</text>
+  <rect x="536" y="124" width="60" height="18" rx="9" fill="var(--ml-stroke)"/>
+  <text class="t-pill" x="566" y="137" text-anchor="middle">Tier 2</text>
+
+  <!-- input -> EdgeEnhancer (optional) -->
+  <path class="dash" marker-end="url(#ahM)" d="M140,283 C 210,235 262,188 356,151"/>
+
+  <!-- EdgeEnhancer -> discretize gate -> segment -->
+  <path class="dash" marker-end="url(#ahM)" d="M500,186 C 556,202 560,198 578,201"/>
+  <rect class="gate" x="576" y="198" width="118" height="28" rx="7"/>
+  <text class="t-chipsub" x="635" y="216" text-anchor="middle" fill="var(--ink)">discretize · threshold 0.5</text>
+  <text class="t-small" x="704" y="216">← determinism boundary</text>
+  <path class="dash" marker-end="url(#ahM)" d="M635,226 V290"/>
+
+  <!-- deterministic core -->
+  <rect class="core" x="356" y="240" width="560" height="150" rx="14"/>
+  <text class="t-node" x="374" y="266">Deterministic core · Web Worker</text>
+  <rect x="744" y="251" width="156" height="20" rx="10" fill="var(--core-stroke)"/>
+  <text class="t-pill" x="822" y="265" text-anchor="middle">Tier 1 · byte-identical</text>
+
+  <!-- stage chips -->
+  <g>
+    <rect class="chip" x="372" y="290" width="94" height="88" rx="8"/>
+    <text class="t-chip" x="419" y="324" text-anchor="middle">preprocess</text>
+    <text class="t-chipsub" x="419" y="342" text-anchor="middle">resize · denoise</text>
+
+    <rect class="chip" x="480" y="290" width="94" height="88" rx="8"/>
+    <text class="t-chip" x="527" y="324" text-anchor="middle">quantize</text>
+    <text class="t-chipsub" x="527" y="342" text-anchor="middle">or threshold</text>
+
+    <rect class="chip-hi" x="588" y="290" width="94" height="88" rx="8"/>
+    <text class="t-chip" x="635" y="318" text-anchor="middle">segment</text>
+    <text class="t-chipsub" x="635" y="334" text-anchor="middle">edge-guided</text>
+    <text class="t-chipsub" x="635" y="346" text-anchor="middle">despeckle</text>
+
+    <rect class="chip" x="696" y="290" width="94" height="88" rx="8"/>
+    <text class="t-chip" x="743" y="318" text-anchor="middle">trace</text>
+    <text class="t-chipsub" x="743" y="334" text-anchor="middle">Potrace · boundary</text>
+    <text class="t-chipsub" x="743" y="346" text-anchor="middle">· centerline</text>
+
+    <rect class="chip" x="804" y="290" width="94" height="88" rx="8"/>
+    <text class="t-chip" x="851" y="324" text-anchor="middle">serialize</text>
+    <text class="t-chipsub" x="851" y="342" text-anchor="middle">compact SVG</text>
+
+    <line class="line" x1="466" y1="334" x2="480" y2="334" marker-end="url(#ahF)"/>
+    <line class="line" x1="574" y1="334" x2="588" y2="334" marker-end="url(#ahF)"/>
+    <line class="line" x1="682" y1="334" x2="696" y2="334" marker-end="url(#ahF)"/>
+    <line class="line" x1="790" y1="334" x2="804" y2="334" marker-end="url(#ahF)"/>
+  </g>
+
+  <!-- core -> output -->
+  <line class="line" x1="916" y1="316" x2="946" y2="316" marker-end="url(#ahF)"/>
+  <rect class="node" x="946" y="281" width="94" height="70" rx="10" stroke="var(--core-stroke)"/>
+  <text class="t-node" x="993" y="312" text-anchor="middle">Clean SVG</text>
+  <text class="t-small" x="993" y="331" text-anchor="middle">editable</text>
+
+  <!-- divider -->
+  <line class="divider" x1="40" y1="420" x2="1040" y2="420"/>
+
+  <!-- ================= BAND B: offline training ================= -->
+  <text class="t-band" x="40" y="450" fill="var(--warm-stroke)">② Offline — train the model on your GPU (ships with the app)</text>
+
+  <circle class="flow-w flow-off" cx="48" cy="516" r="3.2"/>
+  <circle class="flow-w flow-off" cx="48" cy="516" r="3.2" style="animation-delay:2.4s"/>
+
+  <rect class="warm" x="40" y="480" width="160" height="72" rx="10"/>
+  <text class="t-chip" x="120" y="512" text-anchor="middle">SVG corpus</text>
+  <text class="t-chipsub" x="120" y="528" text-anchor="middle">fonts · icons · art</text>
+
+  <rect class="warm" x="224" y="480" width="188" height="72" rx="10"/>
+  <text class="t-chip" x="318" y="512" text-anchor="middle">render + degrade</text>
+  <text class="t-chipsub" x="318" y="528" text-anchor="middle">resvg · blur / JPEG / noise</text>
+
+  <rect class="warm" x="436" y="480" width="150" height="72" rx="10"/>
+  <text class="t-chip" x="511" y="512" text-anchor="middle">(input → edge)</text>
+  <text class="t-chipsub" x="511" y="528" text-anchor="middle">aligned pairs</text>
+
+  <rect class="warm" x="610" y="480" width="150" height="72" rx="10"/>
+  <text class="t-chip" x="685" y="512" text-anchor="middle">train U-Net</text>
+  <text class="t-chipsub" x="685" y="528" text-anchor="middle">PyTorch · your GPU</text>
+
+  <rect class="warm" x="784" y="480" width="170" height="72" rx="10"/>
+  <text class="t-chip" x="869" y="512" text-anchor="middle">export ONNX</text>
+  <text class="t-chipsub" x="869" y="528" text-anchor="middle">&lt; 5 MB · int8</text>
+
+  <line class="warm-dash" x1="200" y1="516" x2="224" y2="516" marker-end="url(#ahW)"/>
+  <line class="warm-dash" x1="412" y1="516" x2="436" y2="516" marker-end="url(#ahW)"/>
+  <line class="warm-dash" x1="586" y1="516" x2="610" y2="516" marker-end="url(#ahW)"/>
+  <line class="warm-dash" x1="760" y1="516" x2="784" y2="516" marker-end="url(#ahW)"/>
+
+  <!-- ================= legend ================= -->
+  <g>
+    <line class="line" x1="40" y1="662" x2="70" y2="662"/>
+    <text class="t-small" x="78" y="666">data flow</text>
+    <line class="dash" x1="168" y1="662" x2="198" y2="662"/>
+    <text class="t-small" x="206" y="666">optional ML path</text>
+    <text class="t-small" x="340" y="666">Tier 1 = deterministic (byte-identical, tested) · Tier 2 = optional, on-device, discretized before the tracer</text>
+  </g>
+</svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,12 @@
         "apps/*"
       ],
       "devDependencies": {
+        "@resvg/resvg-js": "^2.6.2",
+        "jpeg-js": "^0.4.4",
         "oxfmt": "^0.64.0",
         "oxlint": "^1.79.0",
         "playwright-core": "^1.62.1",
+        "pngjs": "^7.0.0",
         "typescript": "^5.7.0",
         "vitest": "^4.1.11"
       }
@@ -802,6 +805,234 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@rolldown/binding-android-arm-eabi": {
       "version": "1.2.5",
@@ -1604,6 +1835,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/lightningcss": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
@@ -2128,6 +2366,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -22,12 +22,16 @@
     "fmt:check": "oxfmt . --check",
     "e2e": "node scripts/e2e.mjs",
     "test:render": "node scripts/svg-render-check.mjs",
+    "dataset": "node scripts/dataset/generate.mjs",
     "check": "npm run lint && npm run fmt:check && npm run typecheck && npm run test"
   },
   "devDependencies": {
+    "@resvg/resvg-js": "^2.6.2",
+    "jpeg-js": "^0.4.4",
     "oxfmt": "^0.64.0",
     "oxlint": "^1.79.0",
     "playwright-core": "^1.62.1",
+    "pngjs": "^7.0.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.11"
   }

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1,4 +1,4 @@
-import type { RasterImage } from './raster'
+import type { GrayImage, RasterImage } from './raster'
 import type { VectorizeMode, VectorizeSettings } from './settings'
 
 /** Pipeline stages, in execution order, used for progress reporting. */
@@ -49,6 +49,13 @@ export interface EngineContext {
   onProgress?: (stage: StageId, overall: number) => void
   /** Polled between work chunks; return true to abort with CancelledError. */
   shouldCancel?: () => boolean
+  /**
+   * Optional boundary probability map (e.g. from @vectorizer/ml's EdgeEnhancer)
+   * at the source-image resolution. When present, the pipeline discretizes it and
+   * uses it as a Tier-2 hint to protect thin features; absent, tracing is
+   * byte-identical to the classical path.
+   */
+  edgeHint?: GrayImage
 }
 
 /** Thrown (and rejected with) when `shouldCancel` interrupts a run. */

--- a/packages/engine/src/client.ts
+++ b/packages/engine/src/client.ts
@@ -1,5 +1,11 @@
 import { CancelledError } from '@vectorizer/core'
-import type { RasterImage, StageId, VectorizeResult, VectorizeSettings } from '@vectorizer/core'
+import type {
+  GrayImage,
+  RasterImage,
+  StageId,
+  VectorizeResult,
+  VectorizeSettings,
+} from '@vectorizer/core'
 import type { WorkerInMessage, WorkerOutMessage } from './protocol'
 
 interface PendingJob {
@@ -25,6 +31,8 @@ export class VectorizerClient {
     image: RasterImage,
     settings: VectorizeSettings,
     onProgress?: (stage: StageId, overall: number) => void,
+    // Optional boundary hint (from EdgeEnhancer), same dimensions as `image`.
+    edgeHint?: GrayImage,
   ): Promise<VectorizeResult> {
     this.cancelPending()
     const worker = this.ensureWorker()
@@ -32,8 +40,14 @@ export class VectorizerClient {
 
     return new Promise<VectorizeResult>((resolve, reject) => {
       this.jobs.set(id, { resolve, reject, onProgress, settled: false })
-      // Copy: transferring the original buffer would detach the caller's image.
+      // Copy: transferring the original buffers would detach the caller's data.
       const buffer = image.data.slice().buffer
+      const transfer: Transferable[] = [buffer]
+      let hint: ArrayBuffer | undefined
+      if (edgeHint) {
+        hint = edgeHint.data.slice().buffer
+        transfer.push(hint)
+      }
       const msg: WorkerInMessage = {
         type: 'vectorize',
         id,
@@ -41,8 +55,9 @@ export class VectorizerClient {
         height: image.height,
         buffer,
         settings,
+        edgeHint: hint,
       }
-      worker.postMessage(msg, [buffer])
+      worker.postMessage(msg, transfer)
     })
   }
 

--- a/packages/engine/src/native.ts
+++ b/packages/engine/src/native.ts
@@ -10,6 +10,7 @@ import {
 import type {
   BinaryMask,
   EngineContext,
+  GrayImage,
   RasterImage,
   StageId,
   StageTiming,
@@ -24,7 +25,7 @@ import {
   bilateralFilter,
   binarize,
   borderDominantColor,
-  despeckleMask,
+  despeckleMaskGuided,
   estimateStrokeWidth,
   flattenImage,
   gaussianBlur,
@@ -32,6 +33,7 @@ import {
   mergeSmallRegions,
   otsuThreshold,
   quantize,
+  resizeGray,
   resizeToFit,
   toGrayscale,
   zhangSuenThin,
@@ -45,6 +47,27 @@ const QUANTIZE_SEED = 0x02f6e2b1
 
 /** Oklab ΔE above which a small region counts as a keep-worthy detail. */
 const DETAIL_CONTRAST = 0.1
+
+/** Boundary-map probability above which a pixel counts as a protected edge. */
+const EDGE_PROTECT_THRESHOLD = 0.5
+
+/**
+ * Discretize an edge hint into a protect mask at the working resolution: resize
+ * to (width, height) when needed, then threshold. The threshold is the
+ * determinism boundary — a fixed cutoff, so upstream (possibly WebGPU) float
+ * noise in the hint cannot change the discrete mask the tracer consumes.
+ */
+function edgeProtectMask(
+  hint: GrayImage | undefined,
+  width: number,
+  height: number,
+): BinaryMask | null {
+  if (!hint) return null
+  const g = hint.width === width && hint.height === height ? hint : resizeGray(hint, width, height)
+  const data = new Uint8Array(width * height)
+  for (let i = 0; i < data.length; i++) data[i] = g.data[i] > EDGE_PROTECT_THRESHOLD ? 1 : 0
+  return { width, height, data }
+}
 
 /** Cumulative progress budget per stage (sums to 1). */
 const STAGE_BUDGET: Record<StageId, number> = {
@@ -142,7 +165,16 @@ export async function vectorize(
   if (settings.mode === 'color' || settings.mode === 'grayscale') {
     await colorPipeline(run, image, opaque, settings, shapes, warnings, (p) => (palette = p))
   } else {
-    await inkPipeline(run, image, opaque, settings, shapes, warnings, (p) => (palette = p))
+    await inkPipeline(
+      run,
+      image,
+      opaque,
+      settings,
+      shapes,
+      warnings,
+      (p) => (palette = p),
+      ctx?.edgeHint,
+    )
   }
 
   // ---- svg ----
@@ -348,6 +380,7 @@ async function inkPipeline(
   shapes: SvgShape[],
   warnings: VectorizeWarning[],
   setPalette: (p: string[]) => void,
+  edgeHint: GrayImage | undefined,
 ): Promise<void> {
   run.stage('palette')
   const gray = toGrayscale(image)
@@ -368,7 +401,10 @@ async function inkPipeline(
   await run.tick()
 
   run.stage('segment')
-  mask = despeckleMask(mask, settings.minRegionArea)
+  // Edge hint (if any) protects thin real features from the size-based despeckle;
+  // with no hint this is byte-identical to despeckleMask.
+  const protect = edgeProtectMask(edgeHint, image.width, image.height)
+  mask = despeckleMaskGuided(mask, settings.minRegionArea, protect)
   await run.tick()
 
   run.stage('trace')
@@ -381,7 +417,10 @@ async function inkPipeline(
       curveOptimize: settings.curveOptimize,
       optTolerance: settings.optTolerance,
       turnPolicy: settings.turnPolicy,
-      minArea: Math.max(1, settings.minRegionArea),
+      // With a hint, the guided despeckle is the speck filter (it already dropped
+      // everything small that the hint did not protect), so the tracer must not
+      // re-drop the small features it kept — mirrors preserveDetails in color.
+      minArea: protect ? 1 : Math.max(1, settings.minRegionArea),
     })
     for (const shape of traced) {
       shapes.push({ commands: shape.commands, fill: settings.fillColor, fillRule: 'evenodd' })

--- a/packages/engine/src/native.ts
+++ b/packages/engine/src/native.ts
@@ -163,7 +163,16 @@ export async function vectorize(
   let palette: string[] = []
 
   if (settings.mode === 'color' || settings.mode === 'grayscale') {
-    await colorPipeline(run, image, opaque, settings, shapes, warnings, (p) => (palette = p))
+    await colorPipeline(
+      run,
+      image,
+      opaque,
+      settings,
+      shapes,
+      warnings,
+      (p) => (palette = p),
+      ctx?.edgeHint,
+    )
   } else {
     await inkPipeline(
       run,
@@ -243,6 +252,7 @@ async function colorPipeline(
   shapes: SvgShape[],
   warnings: VectorizeWarning[],
   setPalette: (p: string[]) => void,
+  edgeHint: GrayImage | undefined,
 ): Promise<void> {
   run.stage('palette')
   const q = quantize(image, {
@@ -264,6 +274,9 @@ async function colorPipeline(
   await run.tick()
 
   run.stage('segment')
+  // Edge hint (if any) protects small regions on a predicted boundary from the
+  // size-based merge; with no hint this is byte-identical to the plain merge.
+  const protect = edgeProtectMask(edgeHint, image.width, image.height)
   if (settings.preserveDetails) {
     const oklab = new Float32Array(q.paletteHex.length * 3)
     for (let i = 0; i < q.paletteHex.length; i++) {
@@ -276,7 +289,13 @@ async function colorPipeline(
       oklab[i * 3 + 1] = a
       oklab[i * 3 + 2] = b
     }
-    mergeSmallRegions(q.labels, settings.minRegionArea, { oklab, keepContrast: DETAIL_CONTRAST })
+    mergeSmallRegions(q.labels, settings.minRegionArea, {
+      oklab,
+      keepContrast: DETAIL_CONTRAST,
+      protect: protect ?? undefined,
+    })
+  } else if (protect) {
+    mergeSmallRegions(q.labels, settings.minRegionArea, { protect })
   } else {
     mergeSmallRegions(q.labels, settings.minRegionArea)
   }
@@ -303,9 +322,9 @@ async function colorPipeline(
     curveOptimize: settings.curveOptimize,
     optTolerance: settings.optTolerance,
   }
-  // With detail preservation, the contrast-aware merge above is the sole speck
+  // With detail preservation or an edge hint, the merge above is the sole speck
   // filter — the tracer must not drop the small regions it deliberately kept.
-  const traceMinArea = settings.preserveDetails ? 1 : Math.max(1, settings.minRegionArea)
+  const traceMinArea = settings.preserveDetails || protect ? 1 : Math.max(1, settings.minRegionArea)
   const usedPalette: string[] = []
 
   if (settings.layering === 'cutout') {

--- a/packages/engine/src/protocol.ts
+++ b/packages/engine/src/protocol.ts
@@ -10,6 +10,8 @@ export type WorkerInMessage =
       /** RGBA bytes, transferred. */
       buffer: ArrayBuffer
       settings: VectorizeSettings
+      /** Optional edge-hint plane: Float32, `width`×`height`, transferred. */
+      edgeHint?: ArrayBuffer
     }
   | { type: 'cancel'; id: number }
 

--- a/packages/engine/src/worker.ts
+++ b/packages/engine/src/worker.ts
@@ -1,5 +1,5 @@
 import { CancelledError } from '@vectorizer/core'
-import type { RasterImage, VectorizeSettings } from '@vectorizer/core'
+import type { GrayImage, RasterImage, VectorizeSettings } from '@vectorizer/core'
 import { vectorize } from './native'
 import type { WorkerInMessage, WorkerOutMessage, WorkerScope } from './protocol'
 
@@ -24,14 +24,23 @@ export function installWorkerHandler(scope: WorkerScope): void {
     }
     if (msg.type !== 'vectorize') return
 
-    const { id, width, height, buffer, settings } = msg
+    const { id, width, height, buffer, settings, edgeHint } = msg
     const image: RasterImage = { width, height, data: new Uint8ClampedArray(buffer) }
-    void run(id, image, settings)
+    const hint: GrayImage | undefined = edgeHint
+      ? { width, height, data: new Float32Array(edgeHint) }
+      : undefined
+    void run(id, image, settings, hint)
   })
 
-  async function run(id: number, image: RasterImage, settings: VectorizeSettings) {
+  async function run(
+    id: number,
+    image: RasterImage,
+    settings: VectorizeSettings,
+    edgeHint?: GrayImage,
+  ) {
     try {
       const result = await vectorize(image, settings, {
+        edgeHint,
         shouldCancel: () => cancelled.has(id),
         onProgress: (stage, overall) => {
           const now = Date.now()

--- a/packages/engine/test/pipeline.test.ts
+++ b/packages/engine/test/pipeline.test.ts
@@ -225,6 +225,27 @@ describe('native engine pipeline', () => {
     await vectorize(redSquareOnWhite(), settings({ mode: 'color' }))
     expect(JSON.stringify(DEFAULT_SETTINGS)).toBe(before)
   })
+
+  it('an edge hint protects a small bw feature the size filter would drop', async () => {
+    const speckImage = (): RasterImage => {
+      const img = createRaster(60, 60)
+      fillRaster(img, 255, 255, 255)
+      for (let y = 15; y < 45; y++) {
+        for (let x = 15; x < 45; x++) setPixel(img, x, y, 0, 0, 0)
+      }
+      setPixel(img, 5, 5, 0, 0, 0) // 1px speck, below minRegionArea
+      return img
+    }
+    const s = settings({ mode: 'bw', minRegionArea: 2, thresholdMode: 'auto' })
+    const none = await vectorize(speckImage(), s)
+    const hint = { width: 60, height: 60, data: new Float32Array(60 * 60) }
+    hint.data[5 * 60 + 5] = 1 // mark the speck as a real boundary
+    const withHint = await vectorize(speckImage(), s, { edgeHint: hint })
+    expect(withHint.stats.pathCount).toBe(none.stats.pathCount + 1)
+    // Same hint ⇒ identical output.
+    const again = await vectorize(speckImage(), s, { edgeHint: hint })
+    expect(again.svg).toBe(withHint.svg)
+  })
 })
 
 describe('worker protocol', () => {
@@ -264,5 +285,37 @@ describe('worker protocol', () => {
     expect(result!.result.svg).toContain('<svg')
     const progress = outbox.filter((m) => (m as { type: string }).type === 'progress')
     expect(progress.length).toBeGreaterThan(0)
+  })
+
+  it('accepts an optional edge hint through the worker message', async () => {
+    const { installWorkerHandler } = await import('@vectorizer/engine')
+    type Listener = (ev: { data: unknown }) => void
+    let listener: Listener | null = null
+    const outbox: unknown[] = []
+    const scope = {
+      addEventListener: (_type: 'message', fn: Listener) => {
+        listener = fn
+      },
+      postMessage: (msg: unknown) => {
+        outbox.push(msg)
+      },
+    }
+    installWorkerHandler(scope)
+
+    const img = redSquareOnWhite()
+    listener!({
+      data: {
+        type: 'vectorize',
+        id: 7,
+        width: img.width,
+        height: img.height,
+        buffer: img.data.slice().buffer,
+        settings: settings({ mode: 'bw', thresholdMode: 'auto' }),
+        edgeHint: new Float32Array(img.width * img.height).buffer,
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    const result = outbox.find((m) => (m as { type: string }).type === 'result')
+    expect(result).toBeDefined()
   })
 })

--- a/packages/engine/test/pipeline.test.ts
+++ b/packages/engine/test/pipeline.test.ts
@@ -246,6 +246,36 @@ describe('native engine pipeline', () => {
     const again = await vectorize(speckImage(), s, { edgeHint: hint })
     expect(again.svg).toBe(withHint.svg)
   })
+
+  it('an edge hint protects a small color region the merge would drop', async () => {
+    const dotImage = (): RasterImage => {
+      const img = createRaster(40, 40)
+      fillRaster(img, 255, 255, 255)
+      for (let y = 5; y < 35; y++) {
+        for (let x = 5; x < 35; x++) setPixel(img, x, y, 180, 180, 180)
+      }
+      // A 2×2 black dot (4 px) — below minRegionArea, maximal contrast.
+      for (let y = 19; y < 21; y++) {
+        for (let x = 19; x < 21; x++) setPixel(img, x, y, 0, 0, 0)
+      }
+      return img
+    }
+    const s = settings({ mode: 'color', paletteSize: 4, minRegionArea: 6 })
+    const none = await vectorize(dotImage(), s)
+    const hint = { width: 40, height: 40, data: new Float32Array(40 * 40) }
+    for (let y = 19; y < 21; y++) {
+      for (let x = 19; x < 21; x++) hint.data[y * 40 + x] = 1 // mark the dot as a boundary
+    }
+    const withHint = await vectorize(dotImage(), s, { edgeHint: hint })
+    expect(withHint.stats.pathCount).toBeGreaterThan(none.stats.pathCount)
+    const veryDark = (p: string[]): boolean =>
+      p.some((h) => Number.parseInt(h.slice(1, 7), 16) < 0x20_20_20)
+    expect(veryDark(withHint.palette)).toBe(true)
+    expect(veryDark(none.palette)).toBe(false)
+    // Same hint ⇒ identical output.
+    const again = await vectorize(dotImage(), s, { edgeHint: hint })
+    expect(again.svg).toBe(withHint.svg)
+  })
 })
 
 describe('worker protocol', () => {

--- a/packages/ml/src/cleanup.ts
+++ b/packages/ml/src/cleanup.ts
@@ -1,0 +1,158 @@
+import type { RasterImage } from '@vectorizer/core'
+import type { InferenceSession } from 'onnxruntime-web'
+import { errorMessage } from './errors'
+import {
+  bilinearResizePlane,
+  bilinearResizeRgba,
+  clampPlane01,
+  cropRgba,
+  IMAGENET_MEAN,
+  IMAGENET_STD,
+  packNchw,
+  planTiles,
+  rgbPlanesToImage,
+  stitchPlane,
+} from './imageops'
+import type { OrtModule } from './ort'
+import { MODEL_REGISTRY } from './registry'
+import { releaseSession, tensorFloatData } from './session-util'
+import { ModelStore } from './store'
+import type { MlBackend, MlProgressFn } from './types'
+
+const INPUT_SIZE = 256
+const TILE_OVERLAP = 32
+
+/**
+ * Learned cleanup pre-pass (docs/CLEANUP_PREPASS.md): predicts a clean RGB image
+ * from a possibly-degraded raster (JPEG blocks, resampling ringing, sensor
+ * noise), for the classical tracer to run on in *any* mode. Unlike the edge
+ * pre-pass this rewrites the pixels the tracer sees, so it applies as a one-shot
+ * that replaces the working image rather than a per-run hint. A Tier-2 stage: its
+ * 8-bit output is the discretization boundary, and the classical path downstream
+ * stays byte-identical (reproducible mode pins the WASM backend). Fails soft:
+ * until weights are published (see registry.ts), `create()` rejects at fetch time
+ * and the app leaves the image untouched.
+ */
+export class CleanupEnhancer {
+  private readonly ort: OrtModule
+  private session: InferenceSession | null
+
+  private constructor(ort: OrtModule, session: InferenceSession) {
+    this.ort = ort
+    this.session = session
+  }
+
+  static async create(opts?: {
+    // 'wasm' pins the deterministic backend (reproducible mode); default prefers WebGPU.
+    preferBackend?: MlBackend
+    onProgress?: MlProgressFn
+  }): Promise<CleanupEnhancer> {
+    const buffer = await new ModelStore().fetch(MODEL_REGISTRY.cleanup, opts?.onProgress)
+    const { createModelSession } = await import('./ort')
+    const { ort, session } = await createModelSession(
+      buffer,
+      'cleanup model',
+      opts?.onProgress,
+      opts?.preferBackend,
+    )
+    return new CleanupEnhancer(ort, session)
+  }
+
+  /** Cleaned RGB image at the input's resolution; the source alpha is preserved. */
+  async run(
+    image: RasterImage,
+    opts?: { onProgress?: MlProgressFn },
+  ): Promise<{ image: RasterImage }> {
+    if (!this.session) throw new Error('CleanupEnhancer has been disposed')
+    opts?.onProgress?.({ phase: 'run' })
+
+    const { width, height } = image
+    // Images larger than the model input are swept in overlapping tiles and
+    // stitched per channel; smaller ones run in a single resized pass.
+    const tileW = Math.min(INPUT_SIZE, width)
+    const tileH = Math.min(INPUT_SIZE, height)
+    const placements = planTiles(width, height, tileW, tileH, TILE_OVERLAP)
+
+    let planes: [Float32Array, Float32Array, Float32Array]
+    if (placements.length === 1) {
+      planes = await this.inferTile(image, tileW, tileH)
+    } else {
+      const r: Float32Array[] = []
+      const g: Float32Array[] = []
+      const b: Float32Array[] = []
+      for (const { x, y } of placements) {
+        // A single ORT session is not safe to run concurrently — sweep in order.
+        // oxlint-disable-next-line no-await-in-loop
+        const [tr, tg, tb] = await this.inferTile(cropRgba(image, x, y, tileW, tileH), tileW, tileH)
+        r.push(tr)
+        g.push(tg)
+        b.push(tb)
+      }
+      planes = [
+        stitchPlane(width, height, tileW, tileH, placements, r),
+        stitchPlane(width, height, tileW, tileH, placements, g),
+        stitchPlane(width, height, tileW, tileH, placements, b),
+      ]
+    }
+    const cleaned = rgbPlanesToImage(planes[0], planes[1], planes[2], width, height, image.data)
+    return { image: cleaned }
+  }
+
+  /**
+   * One tile: resize to the model input, run, split the `[1,3,h,w]` output into
+   * three [0,1] channel planes resized back to the tile size. Preprocessing is
+   * ImageNet-normalized RGB and the export applies its own sigmoid (weights must
+   * match — see scripts/train).
+   */
+  private async inferTile(
+    tile: RasterImage,
+    tileW: number,
+    tileH: number,
+  ): Promise<[Float32Array, Float32Array, Float32Array]> {
+    const session = this.session
+    if (!session) throw new Error('CleanupEnhancer has been disposed')
+    const resized = bilinearResizeRgba(tile, INPUT_SIZE, INPUT_SIZE)
+    const input = packNchw(resized, IMAGENET_MEAN, IMAGENET_STD, { scale: 1 / 255 })
+    const feeds: InferenceSession.FeedsType = {
+      [session.inputNames[0]]: new this.ort.Tensor('float32', input, [
+        1,
+        3,
+        INPUT_SIZE,
+        INPUT_SIZE,
+      ]),
+    }
+    let outputs: InferenceSession.ReturnType
+    try {
+      outputs = await session.run(feeds)
+    } catch (err) {
+      throw new Error(`Cleanup failed (${errorMessage(err)})`, { cause: err })
+    }
+    const tensor = outputs[session.outputNames[0]]
+    if (!tensor) throw new Error('Cleanup failed (the model returned no output)')
+    let raw: Float32Array
+    try {
+      raw = await tensorFloatData(tensor)
+    } catch (err) {
+      throw new Error(`Cleanup failed (${errorMessage(err)})`, { cause: err })
+    }
+    const dims = tensor.dims
+    const mapHeight = dims.length >= 2 ? dims[dims.length - 2] : INPUT_SIZE
+    const mapWidth = dims.length >= 1 ? dims[dims.length - 1] : INPUT_SIZE
+    const plane = mapWidth * mapHeight
+    if (raw.length < 3 * plane) throw new Error('Cleanup failed (output smaller than 3 channels)')
+    const channel = (c: number): Float32Array =>
+      bilinearResizePlane(
+        clampPlane01(raw.subarray(c * plane, (c + 1) * plane)),
+        mapWidth,
+        mapHeight,
+        tileW,
+        tileH,
+      )
+    return [channel(0), channel(1), channel(2)]
+  }
+
+  dispose(): void {
+    releaseSession(this.session)
+    this.session = null
+  }
+}

--- a/packages/ml/src/edge.ts
+++ b/packages/ml/src/edge.ts
@@ -1,0 +1,129 @@
+import type { GrayImage, RasterImage } from '@vectorizer/core'
+import type { InferenceSession } from 'onnxruntime-web'
+import { errorMessage } from './errors'
+import {
+  bilinearResizePlane,
+  bilinearResizeRgba,
+  clampPlane01,
+  cropRgba,
+  IMAGENET_MEAN,
+  IMAGENET_STD,
+  packNchw,
+  planTiles,
+  stitchPlane,
+} from './imageops'
+import type { OrtModule } from './ort'
+import { MODEL_REGISTRY } from './registry'
+import { releaseSession, tensorFloatData } from './session-util'
+import { ModelStore } from './store'
+import type { MlBackend, MlProgressFn } from './types'
+
+const INPUT_SIZE = 256
+const TILE_OVERLAP = 32
+
+/**
+ * Learned edge / boundary pre-pass (docs/EDGE_PREPASS.md): predicts a clean
+ * boundary probability map from a possibly-degraded raster, for the trace stage
+ * to consume as a discretized hint. A Tier-2 conditioning stage — it never writes
+ * geometry itself. Fails soft: until weights are published (see registry.ts),
+ * `create()` rejects at fetch time and the app traces classically.
+ */
+export class EdgeEnhancer {
+  private readonly ort: OrtModule
+  private session: InferenceSession | null
+
+  private constructor(ort: OrtModule, session: InferenceSession) {
+    this.ort = ort
+    this.session = session
+  }
+
+  static async create(opts?: {
+    // 'wasm' pins the deterministic backend (reproducible mode); default prefers WebGPU.
+    preferBackend?: MlBackend
+    onProgress?: MlProgressFn
+  }): Promise<EdgeEnhancer> {
+    const buffer = await new ModelStore().fetch(MODEL_REGISTRY['edge-prepass'], opts?.onProgress)
+    const { createModelSession } = await import('./ort')
+    const { ort, session } = await createModelSession(
+      buffer,
+      'edge pre-pass model',
+      opts?.onProgress,
+      opts?.preferBackend,
+    )
+    return new EdgeEnhancer(ort, session)
+  }
+
+  /** Boundary probability map ([0,1] GrayImage) at the input image's resolution. */
+  async run(
+    image: RasterImage,
+    opts?: { onProgress?: MlProgressFn },
+  ): Promise<{ edges: GrayImage }> {
+    if (!this.session) throw new Error('EdgeEnhancer has been disposed')
+    opts?.onProgress?.({ phase: 'run' })
+
+    const { width, height } = image
+    // Images larger than the model input are swept in overlapping tiles and
+    // stitched; smaller ones run in a single pass (resized to the model input).
+    const tileW = Math.min(INPUT_SIZE, width)
+    const tileH = Math.min(INPUT_SIZE, height)
+    const placements = planTiles(width, height, tileW, tileH, TILE_OVERLAP)
+
+    let data: Float32Array
+    if (placements.length === 1) {
+      data = await this.inferTile(image, tileW, tileH)
+    } else {
+      const planes: Float32Array[] = []
+      for (const { x, y } of placements) {
+        // A single ORT session is not safe to run concurrently — sweep in order.
+        // oxlint-disable-next-line no-await-in-loop
+        planes.push(await this.inferTile(cropRgba(image, x, y, tileW, tileH), tileW, tileH))
+      }
+      data = stitchPlane(width, height, tileW, tileH, placements, planes)
+    }
+    return { edges: { width, height, data } }
+  }
+
+  /**
+   * One tile: resize to the model input, run, resize the boundary output back to
+   * the tile size, clamped to [0,1]. Assumes the exported model applies its own
+   * sigmoid; preprocessing is ImageNet-normalized RGB (weights must match).
+   */
+  private async inferTile(tile: RasterImage, tileW: number, tileH: number): Promise<Float32Array> {
+    const session = this.session
+    if (!session) throw new Error('EdgeEnhancer has been disposed')
+    const resized = bilinearResizeRgba(tile, INPUT_SIZE, INPUT_SIZE)
+    const input = packNchw(resized, IMAGENET_MEAN, IMAGENET_STD, { scale: 1 / 255 })
+    const feeds: InferenceSession.FeedsType = {
+      [session.inputNames[0]]: new this.ort.Tensor('float32', input, [
+        1,
+        3,
+        INPUT_SIZE,
+        INPUT_SIZE,
+      ]),
+    }
+    let outputs: InferenceSession.ReturnType
+    try {
+      outputs = await session.run(feeds)
+    } catch (err) {
+      throw new Error(`Edge pre-pass failed (${errorMessage(err)})`, { cause: err })
+    }
+    const tensor = outputs[session.outputNames[0]]
+    if (!tensor) throw new Error('Edge pre-pass failed (the model returned no output)')
+    let raw: Float32Array
+    try {
+      raw = await tensorFloatData(tensor)
+    } catch (err) {
+      throw new Error(`Edge pre-pass failed (${errorMessage(err)})`, { cause: err })
+    }
+    const dims = tensor.dims
+    const mapHeight = dims.length >= 2 ? dims[dims.length - 2] : INPUT_SIZE
+    const mapWidth = dims.length >= 1 ? dims[dims.length - 1] : INPUT_SIZE
+    const clamped = clampPlane01(raw.subarray(0, mapWidth * mapHeight))
+    return bilinearResizePlane(clamped, mapWidth, mapHeight, tileW, tileH)
+  }
+
+  dispose(): void {
+    releaseSession(this.session)
+    this.session = null
+  }
+}

--- a/packages/ml/src/imageops.ts
+++ b/packages/ml/src/imageops.ts
@@ -357,6 +357,34 @@ export function planTiles(
   return out
 }
 
+/**
+ * Assemble three [0,1] channel planes into an RGBA image: `byte = round(v*255)`
+ * (clamped). Alpha is copied from `alpha` (an interleaved RGBA source, alpha
+ * channel read) when given, else opaque. The Uint8ClampedArray store is the
+ * discretization boundary that keeps a cleaned image reproducible downstream.
+ */
+export function rgbPlanesToImage(
+  r: Float32Array,
+  g: Float32Array,
+  b: Float32Array,
+  width: number,
+  height: number,
+  alpha: Uint8ClampedArray | null,
+): RasterImage {
+  const n = width * height
+  if (r.length < n || g.length < n || b.length < n) {
+    throw new RangeError('plane shorter than its dimensions')
+  }
+  const data = new Uint8ClampedArray(n * 4)
+  for (let i = 0, o = 0; i < n; i++, o += 4) {
+    data[o] = r[i] * 255 // Uint8ClampedArray rounds + clamps on store
+    data[o + 1] = g[i] * 255
+    data[o + 2] = b[i] * 255
+    data[o + 3] = alpha ? alpha[o + 3] : 255
+  }
+  return { width, height, data }
+}
+
 /** Triangular window (peak at center, 1 at the edges) for seamless overlap blending. */
 function triWindow(n: number): Float32Array {
   const w = new Float32Array(n)

--- a/packages/ml/src/imageops.ts
+++ b/packages/ml/src/imageops.ts
@@ -291,3 +291,112 @@ export function planeToMask(
   for (let i = 0; i < data.length; i++) data[i] = plane[i] > threshold ? 1 : 0
   return { width, height, data }
 }
+
+/** Clamp a float plane into [0,1] in place-free fashion (fresh array). */
+export function clampPlane01(plane: Float32Array): Float32Array {
+  const out = new Float32Array(plane.length)
+  for (let i = 0; i < plane.length; i++) {
+    const v = plane[i]
+    out[i] = v < 0 ? 0 : v > 1 ? 1 : v
+  }
+  return out
+}
+
+/** Copy the `width`×`height` RGBA region at (x0, y0) out of an image (in-bounds). */
+export function cropRgba(
+  image: RasterImage,
+  x0: number,
+  y0: number,
+  width: number,
+  height: number,
+): RasterImage {
+  const src = image.data
+  const out = new Uint8ClampedArray(width * height * 4)
+  const srcRow = image.width * 4
+  const dstRow = width * 4
+  for (let y = 0; y < height; y++) {
+    const s = (y0 + y) * srcRow + x0 * 4
+    out.set(src.subarray(s, s + dstRow), y * dstRow)
+  }
+  return { width, height, data: out }
+}
+
+/** Top-left corner of one tile in a tiled sweep. */
+export interface TilePlacement {
+  x: number
+  y: number
+}
+
+/** Start offsets that cover [0, size) with `tile`-wide windows stepping by `tile − overlap`, last window flush to the end. */
+function axisStarts(size: number, tile: number, overlap: number): number[] {
+  if (tile >= size) return [0]
+  const step = Math.max(1, tile - overlap)
+  const starts: number[] = []
+  for (let s = 0; s < size - tile; s += step) starts.push(s)
+  const last = size - tile
+  if (starts[starts.length - 1] !== last) starts.push(last)
+  return starts
+}
+
+/**
+ * Cover a `width`×`height` image with overlapping `tileW`×`tileH` tiles (every
+ * tile fully in-bounds; the trailing tiles are flush to the right/bottom edge).
+ * A dimension smaller than its tile yields a single tile at 0.
+ */
+export function planTiles(
+  width: number,
+  height: number,
+  tileW: number,
+  tileH: number,
+  overlap: number,
+): TilePlacement[] {
+  const xs = axisStarts(width, tileW, overlap)
+  const ys = axisStarts(height, tileH, overlap)
+  const out: TilePlacement[] = []
+  for (const y of ys) for (const x of xs) out.push({ x, y })
+  return out
+}
+
+/** Triangular window (peak at center, 1 at the edges) for seamless overlap blending. */
+function triWindow(n: number): Float32Array {
+  const w = new Float32Array(n)
+  for (let i = 0; i < n; i++) w[i] = Math.min(i + 1, n - i)
+  return w
+}
+
+/**
+ * Blend per-tile planes back into one `width`×`height` plane by triangular-weighted
+ * averaging over overlaps. `placements` and `planes` are parallel; each plane is
+ * row-major `tileW`×`tileH`. Deterministic given the same inputs.
+ */
+export function stitchPlane(
+  width: number,
+  height: number,
+  tileW: number,
+  tileH: number,
+  placements: readonly TilePlacement[],
+  planes: readonly Float32Array[],
+): Float32Array {
+  const acc = new Float32Array(width * height)
+  const wsum = new Float32Array(width * height)
+  const wx = triWindow(tileW)
+  const wy = triWindow(tileH)
+  for (let t = 0; t < placements.length; t++) {
+    const { x: px, y: py } = placements[t]
+    const plane = planes[t]
+    for (let ty = 0; ty < tileH; ty++) {
+      const wyt = wy[ty]
+      const accRow = (py + ty) * width
+      const planeRow = ty * tileW
+      for (let tx = 0; tx < tileW; tx++) {
+        const w = wyt * wx[tx]
+        const gi = accRow + px + tx
+        acc[gi] += plane[planeRow + tx] * w
+        wsum[gi] += w
+      }
+    }
+  }
+  const out = new Float32Array(width * height)
+  for (let i = 0; i < out.length; i++) out[i] = wsum[i] > 0 ? acc[i] / wsum[i] : 0
+  return out
+}

--- a/packages/ml/src/index.ts
+++ b/packages/ml/src/index.ts
@@ -1,4 +1,5 @@
 export { BackgroundRemover } from './background'
+export { CleanupEnhancer } from './cleanup'
 export { detectBackend } from './detect'
 export { EdgeEnhancer } from './edge'
 export { MODEL_REGISTRY, overrideModelUrl } from './registry'

--- a/packages/ml/src/index.ts
+++ b/packages/ml/src/index.ts
@@ -1,5 +1,6 @@
 export { BackgroundRemover } from './background'
 export { detectBackend } from './detect'
+export { EdgeEnhancer } from './edge'
 export { MODEL_REGISTRY, overrideModelUrl } from './registry'
 export type { ModelSpec } from './registry'
 export { MagicSegmenter } from './segment'

--- a/packages/ml/src/ort.ts
+++ b/packages/ml/src/ort.ts
@@ -55,6 +55,9 @@ export async function createModelSession(
   buffer: ArrayBuffer,
   label: string,
   onProgress?: MlProgressFn,
+  // 'wasm' pins the deterministic WASM backend (reproducible mode); undefined
+  // keeps the default WebGPU-then-WASM preference.
+  preferBackend?: MlBackend,
 ): Promise<ModelSession> {
   let ort: OrtModule
   try {
@@ -64,7 +67,7 @@ export async function createModelSession(
   }
   onProgress?.({ phase: 'compile' })
   const bytes = new Uint8Array(buffer)
-  if (typeof navigator !== 'undefined' && 'gpu' in navigator) {
+  if (preferBackend !== 'wasm' && typeof navigator !== 'undefined' && 'gpu' in navigator) {
     try {
       const session = await ort.InferenceSession.create(bytes, { executionProviders: ['webgpu'] })
       recordBackend('webgpu')

--- a/packages/ml/src/registry.ts
+++ b/packages/ml/src/registry.ts
@@ -1,5 +1,5 @@
 export interface ModelSpec {
-  id: 'u2netp' | 'slimsam-encoder' | 'slimsam-decoder'
+  id: 'u2netp' | 'slimsam-encoder' | 'slimsam-decoder' | 'edge-prepass'
   url: string
   approxBytes: number
   license: string
@@ -27,6 +27,20 @@ export const MODEL_REGISTRY: Record<ModelSpec['id'], ModelSpec> = {
     url: 'https://huggingface.co/Xenova/slimsam-77-uniform/resolve/main/onnx/prompt_encoder_mask_decoder_quantized.onnx',
     approxBytes: 4_200_000,
     license: 'Apache-2.0',
+  },
+  'edge-prepass': {
+    id: 'edge-prepass',
+    // The project's own model, not a third-party one: it ships as a same-origin
+    // static asset of the app (apps/web/public/models/), so the browser fetches
+    // it from the very site it is served from — no CORS, no external host. This
+    // default is relative; the app resolves it against its deploy base at startup
+    // with overrideModelUrl(`${import.meta.env.BASE_URL}models/edge-prepass.onnx`).
+    // No weights exist yet: train per docs/EDGE_PREPASS.md on scripts/dataset
+    // output and drop the file in place. Until then create() fails soft (the
+    // fetch 404s) and the app traces exactly as it does today.
+    url: 'models/edge-prepass.onnx',
+    approxBytes: 3_000_000,
+    license: 'MIT',
   },
 }
 

--- a/packages/ml/src/registry.ts
+++ b/packages/ml/src/registry.ts
@@ -1,5 +1,5 @@
 export interface ModelSpec {
-  id: 'u2netp' | 'slimsam-encoder' | 'slimsam-decoder' | 'edge-prepass'
+  id: 'u2netp' | 'slimsam-encoder' | 'slimsam-decoder' | 'edge-prepass' | 'cleanup'
   url: string
   approxBytes: number
   license: string
@@ -39,6 +39,18 @@ export const MODEL_REGISTRY: Record<ModelSpec['id'], ModelSpec> = {
     // output and drop the file in place. Until then create() fails soft (the
     // fetch 404s) and the app traces exactly as it does today.
     url: 'models/edge-prepass.onnx',
+    approxBytes: 3_000_000,
+    license: 'MIT',
+  },
+  cleanup: {
+    id: 'cleanup',
+    // The project's own model (see edge-prepass above for the same-origin
+    // rationale): shipped as a static app asset, resolved against the deploy base
+    // at startup with overrideModelUrl(`${import.meta.env.BASE_URL}models/cleanup.onnx`).
+    // No weights exist yet: train per docs/CLEANUP_PREPASS.md (scripts/train
+    // --task cleanup) and drop the file in place. Until then create() fails soft
+    // (the fetch 404s) and the app leaves the image untouched.
+    url: 'models/cleanup.onnx',
     approxBytes: 3_000_000,
     license: 'MIT',
   },

--- a/packages/ml/test/imageops.test.ts
+++ b/packages/ml/test/imageops.test.ts
@@ -5,17 +5,21 @@ import {
   argmax,
   bilinearResizePlane,
   bilinearResizeRgba,
+  clampPlane01,
   computeLetterbox,
   cropPlane,
+  cropRgba,
   IMAGENET_MEAN,
   IMAGENET_STD,
   mapPointToLetterbox,
   minMaxNormalize,
   packNchw,
   planeToMask,
+  planTiles,
   SAM_MEAN,
   SAM_STD,
   smoothstep,
+  stitchPlane,
 } from '../src/imageops'
 
 const raster = (width: number, height: number, rgba: number[]): RasterImage => ({
@@ -233,5 +237,71 @@ describe('planeToMask', () => {
     expect(Array.from(mask.data)).toEqual([0, 0, 1, 1])
     expect(mask.width).toBe(2)
     expect(mask.height).toBe(2)
+  })
+})
+
+describe('clampPlane01', () => {
+  it('clamps values into [0,1]', () => {
+    const out = clampPlane01(Float32Array.from([-0.5, 0, 0.25, 1, 2]))
+    expect(out.length).toBe(5)
+    closeTo(out, [0, 0, 0.25, 1, 1])
+  })
+})
+
+describe('cropRgba', () => {
+  it('copies an in-bounds sub-rectangle', () => {
+    const img = raster(
+      3,
+      2,
+      [
+        // prettier-ignore
+        0, 0, 0, 255, 10, 0, 0, 255, 20, 0, 0, 255, 30, 0, 0, 255, 40, 0, 0, 255, 50, 0, 0, 255,
+      ],
+    )
+    const crop = cropRgba(img, 1, 0, 2, 2)
+    expect(crop.width).toBe(2)
+    expect(crop.height).toBe(2)
+    expect([...crop.data]).toEqual([10, 0, 0, 255, 20, 0, 0, 255, 40, 0, 0, 255, 50, 0, 0, 255])
+  })
+})
+
+describe('planTiles', () => {
+  it('returns a single tile when the image fits within one', () => {
+    expect(planTiles(100, 80, 100, 80, 16)).toEqual([{ x: 0, y: 0 }])
+  })
+
+  it('covers the image with in-bounds tiles flush to the far edge', () => {
+    const width = 300
+    const tile = 128
+    const overlap = 32
+    const tiles = planTiles(width, 100, tile, 100, overlap)
+    for (const t of tiles) {
+      expect(t.x).toBeGreaterThanOrEqual(0)
+      expect(t.x + tile).toBeLessThanOrEqual(width)
+    }
+    const xs = [...new Set(tiles.map((t) => t.x))].toSorted((a, b) => a - b)
+    expect(xs[0]).toBe(0)
+    expect(xs[xs.length - 1]).toBe(width - tile)
+    for (let i = 1; i < xs.length; i++) expect(xs[i] - xs[i - 1]).toBeLessThanOrEqual(tile)
+  })
+})
+
+describe('stitchPlane', () => {
+  it('reconstructs a plane from overlapping tiles', () => {
+    const width = 40
+    const height = 24
+    const tileW = 16
+    const tileH = 16
+    const ref = new Float32Array(width * height)
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) ref[y * width + x] = x * 0.01 + y * 0.02
+    }
+    const placements = planTiles(width, height, tileW, tileH, 6)
+    const planes = placements.map((p) => cropPlane(ref, width, p.x, p.y, tileW, tileH))
+    // Every output pixel is a weighted average of identical samples of the ramp,
+    // so stitching returns the original plane.
+    const stitched = stitchPlane(width, height, tileW, tileH, placements, planes)
+    expect(stitched.length).toBe(width * height)
+    closeTo(stitched, [...ref], 4)
   })
 })

--- a/packages/ml/test/imageops.test.ts
+++ b/packages/ml/test/imageops.test.ts
@@ -16,6 +16,7 @@ import {
   packNchw,
   planeToMask,
   planTiles,
+  rgbPlanesToImage,
   SAM_MEAN,
   SAM_STD,
   smoothstep,
@@ -283,6 +284,34 @@ describe('planTiles', () => {
     expect(xs[0]).toBe(0)
     expect(xs[xs.length - 1]).toBe(width - tile)
     for (let i = 1; i < xs.length; i++) expect(xs[i] - xs[i - 1]).toBeLessThanOrEqual(tile)
+  })
+})
+
+describe('rgbPlanesToImage', () => {
+  it('interleaves three planes and scales [0,1] to bytes', () => {
+    const r = Float32Array.from([0, 1])
+    const g = Float32Array.from([0.5, 0.25])
+    const b = Float32Array.from([1, 0])
+    const img = rgbPlanesToImage(r, g, b, 2, 1, null)
+    expect(img.width).toBe(2)
+    expect(img.height).toBe(1)
+    // Uint8ClampedArray rounds on store: 0.5*255=127.5→128, 0.25*255=63.75→64.
+    expect([...img.data]).toEqual([0, 128, 255, 255, 255, 64, 0, 255])
+  })
+
+  it('copies alpha from the source and clamps out-of-range values', () => {
+    const r = Float32Array.from([2]) // >1 clamps to 255
+    const g = Float32Array.from([-1]) // <0 clamps to 0
+    const b = Float32Array.from([0.5])
+    const src = Uint8ClampedArray.from([9, 9, 9, 42])
+    const img = rgbPlanesToImage(r, g, b, 1, 1, src)
+    expect([...img.data]).toEqual([255, 0, 128, 42])
+  })
+
+  it('rejects planes shorter than the dimensions', () => {
+    expect(() =>
+      rgbPlanesToImage(new Float32Array(1), new Float32Array(2), new Float32Array(2), 2, 1, null),
+    ).toThrow(RangeError)
   })
 })
 

--- a/packages/ml/test/registry.test.ts
+++ b/packages/ml/test/registry.test.ts
@@ -2,16 +2,25 @@ import { describe, expect, it } from 'vitest'
 import { MODEL_REGISTRY, overrideModelUrl } from '../src/registry'
 
 describe('MODEL_REGISTRY', () => {
-  it('declares all three models with consistent ids and https URLs', () => {
-    const ids = ['u2netp', 'slimsam-encoder', 'slimsam-decoder'] as const
+  it('declares every model with a consistent id, positive size, and license', () => {
+    const ids = ['u2netp', 'slimsam-encoder', 'slimsam-decoder', 'edge-prepass'] as const
     expect(Object.keys(MODEL_REGISTRY).toSorted()).toEqual([...ids].toSorted())
     for (const id of ids) {
       const spec = MODEL_REGISTRY[id]
       expect(spec.id).toBe(id)
-      expect(spec.url).toMatch(/^https:\/\//)
       expect(spec.approxBytes).toBeGreaterThan(0)
       expect(spec.license.length).toBeGreaterThan(0)
     }
+  })
+
+  it('fetches third-party models over https and the project model same-origin', () => {
+    for (const id of ['u2netp', 'slimsam-encoder', 'slimsam-decoder'] as const) {
+      expect(MODEL_REGISTRY[id].url).toMatch(/^https:\/\//)
+    }
+    // The project's own model is a relative path resolved against the app's base.
+    const edge = MODEL_REGISTRY['edge-prepass'].url
+    expect(edge).not.toMatch(/^https?:\/\//)
+    expect(edge).toMatch(/\.onnx$/)
   })
 })
 

--- a/packages/ml/test/registry.test.ts
+++ b/packages/ml/test/registry.test.ts
@@ -3,7 +3,7 @@ import { MODEL_REGISTRY, overrideModelUrl } from '../src/registry'
 
 describe('MODEL_REGISTRY', () => {
   it('declares every model with a consistent id, positive size, and license', () => {
-    const ids = ['u2netp', 'slimsam-encoder', 'slimsam-decoder', 'edge-prepass'] as const
+    const ids = ['u2netp', 'slimsam-encoder', 'slimsam-decoder', 'edge-prepass', 'cleanup'] as const
     expect(Object.keys(MODEL_REGISTRY).toSorted()).toEqual([...ids].toSorted())
     for (const id of ids) {
       const spec = MODEL_REGISTRY[id]
@@ -17,10 +17,12 @@ describe('MODEL_REGISTRY', () => {
     for (const id of ['u2netp', 'slimsam-encoder', 'slimsam-decoder'] as const) {
       expect(MODEL_REGISTRY[id].url).toMatch(/^https:\/\//)
     }
-    // The project's own model is a relative path resolved against the app's base.
-    const edge = MODEL_REGISTRY['edge-prepass'].url
-    expect(edge).not.toMatch(/^https?:\/\//)
-    expect(edge).toMatch(/\.onnx$/)
+    // The project's own models are relative paths resolved against the app's base.
+    for (const id of ['edge-prepass', 'cleanup'] as const) {
+      const url = MODEL_REGISTRY[id].url
+      expect(url).not.toMatch(/^https?:\/\//)
+      expect(url).toMatch(/\.onnx$/)
+    }
   })
 })
 

--- a/packages/raster/src/index.ts
+++ b/packages/raster/src/index.ts
@@ -4,7 +4,7 @@
  * color-space conversion, quantization, thresholding, region cleanup,
  * morphology and skeletonization.
  */
-export { resizeToFit } from './resize'
+export { resizeGray, resizeToFit } from './resize'
 export { bilateralFilter, gaussianBlur, medianFilter } from './filters'
 export { borderDominantColor, flattenImage } from './background'
 export type { FlattenResult } from './background'
@@ -14,5 +14,5 @@ export type { QuantizeOptions, QuantizeResult } from './quantize'
 export { adaptiveBinarize, binarize, otsuThreshold } from './threshold'
 export { extractLabelMask, maskArea, mergeSmallRegions } from './regions'
 export type { MergeOptions } from './regions'
-export { despeckleMask, dilate, erode } from './morphology'
+export { despeckleMask, despeckleMaskGuided, dilate, erode } from './morphology'
 export { chamferDistance, estimateStrokeWidth, zhangSuenThin } from './thin'

--- a/packages/raster/src/morphology.ts
+++ b/packages/raster/src/morphology.ts
@@ -75,11 +75,27 @@ export function erode(mask: BinaryMask, radius: number): BinaryMask {
  * the input mask; a new mask is returned.
  */
 export function despeckleMask(mask: BinaryMask, minArea: number): BinaryMask {
+  return despeckleMaskGuided(mask, minArea, null)
+}
+
+/**
+ * Like {@link despeckleMask}, but a component is left untouched when any of its
+ * pixels overlaps `protect` (1 = protected), even when it is below `minArea` —
+ * so a boundary map (e.g. EdgeEnhancer's, thresholded to a mask) keeps thin real
+ * features a size filter would otherwise erase. `protect` must match the mask
+ * dimensions; passing `null` reproduces {@link despeckleMask} byte-for-byte.
+ */
+export function despeckleMaskGuided(
+  mask: BinaryMask,
+  minArea: number,
+  protect: BinaryMask | null,
+): BinaryMask {
   const { width: w, height: h, data: src } = mask
   const n = w * h
   const out = createMask(w, h)
   out.data.set(src)
   if (minArea <= 1) return out
+  const prot = protect?.data ?? null
   const visited = new Uint8Array(n)
   const stack = new Int32Array(n)
   const bag = new Int32Array(n)
@@ -89,11 +105,13 @@ export function despeckleMask(mask: BinaryMask, minArea: number): BinaryMask {
     if (src[i] === 0 || visited[i] !== 0) continue
     let sp = 0
     let size = 0
+    let guarded = false
     stack[sp++] = i
     visited[i] = 1
     while (sp > 0) {
       const p = stack[--sp]
       bag[size++] = p
+      if (prot !== null && prot[p] !== 0) guarded = true
       const x = p - ((p / w) | 0) * w
       const y = (p / w) | 0
       for (let dy = -1; dy <= 1; dy++) {
@@ -111,7 +129,7 @@ export function despeckleMask(mask: BinaryMask, minArea: number): BinaryMask {
         }
       }
     }
-    if (size < minArea) {
+    if (size < minArea && !guarded) {
       for (let s = 0; s < size; s++) out.data[bag[s]] = 0
     }
   }
@@ -123,11 +141,13 @@ export function despeckleMask(mask: BinaryMask, minArea: number): BinaryMask {
     let sp = 0
     let size = 0
     let touchesBorder = false
+    let guarded = false
     stack[sp++] = i
     visited[i] = 1
     while (sp > 0) {
       const p = stack[--sp]
       bag[size++] = p
+      if (prot !== null && prot[p] !== 0) guarded = true
       const x = p - ((p / w) | 0) * w
       const y = (p / w) | 0
       if (x === 0 || y === 0 || x === w - 1 || y === h - 1) touchesBorder = true
@@ -148,7 +168,7 @@ export function despeckleMask(mask: BinaryMask, minArea: number): BinaryMask {
         stack[sp++] = p + w
       }
     }
-    if (!touchesBorder && size < minArea) {
+    if (!touchesBorder && size < minArea && !guarded) {
       for (let s = 0; s < size; s++) out.data[bag[s]] = 1
     }
   }

--- a/packages/raster/src/regions.ts
+++ b/packages/raster/src/regions.ts
@@ -6,14 +6,19 @@ import { createMask, deltaEOkSq } from '@vectorizer/core'
 import type { BinaryMask, LabelMap } from '@vectorizer/core'
 
 export interface MergeOptions {
-  /** Palette colors in Oklab, length `labels.count * 3`, indexed by label. */
-  oklab: Float32Array
+  /** Palette colors in Oklab, length `labels.count * 3`, indexed by label. Enables the contrast keep. */
+  oklab?: Float32Array
   /**
    * Keep a small region instead of absorbing it when its Oklab ΔE to the
    * would-be target label is at least this (a high-contrast detail, e.g. a
-   * logo dot). Low-contrast specks still merge away.
+   * logo dot). Low-contrast specks still merge away. Requires `oklab`.
    */
-  keepContrast: number
+  keepContrast?: number
+  /**
+   * 1 = keep this pixel's small region even below `minArea` — a discretized edge
+   * hint (from EdgeEnhancer), so features on a predicted boundary survive.
+   */
+  protect?: BinaryMask
 }
 
 /**
@@ -23,8 +28,9 @@ export interface MergeOptions {
  * rounds. -1 pixels stay -1. Mutates and returns `labels`.
  *
  * With `opts`, a small component is kept (not merged) when its color differs
- * from the target label's by at least `keepContrast` in Oklab, preserving small
- * high-contrast features while still clearing low-contrast noise.
+ * from the target label's by at least `keepContrast` in Oklab, or when any of
+ * its pixels lies on the `protect` mask (a discretized edge hint), preserving
+ * small high-contrast features while still clearing low-contrast noise.
  */
 export function mergeSmallRegions(
   labels: LabelMap,
@@ -32,7 +38,8 @@ export function mergeSmallRegions(
   opts?: MergeOptions,
 ): LabelMap {
   if (minArea <= 1) return labels
-  const keepSq = opts ? opts.keepContrast * opts.keepContrast : 0
+  const keepSq = opts?.keepContrast ? opts.keepContrast * opts.keepContrast : 0
+  const prot = opts?.protect?.data ?? null
   const { width: w, height: h, data } = labels
   const n = w * h
   const comp = new Int32Array(n)
@@ -85,8 +92,10 @@ export function mergeSmallRegions(
       const start = compStart[id]
       const lab = data[order[start]]
       neighborCount.clear()
+      let guarded = false
       for (let s = start; s < start + size; s++) {
         const p = order[s]
+        if (prot !== null && prot[p] !== 0) guarded = true
         const x = p - ((p / w) | 0) * w
         if (x > 0 && comp[p - 1] !== id && data[p - 1] !== -1 && data[p - 1] !== lab) {
           neighborCount.set(data[p - 1], (neighborCount.get(data[p - 1]) ?? 0) + 1)
@@ -101,6 +110,7 @@ export function mergeSmallRegions(
           neighborCount.set(data[p + w], (neighborCount.get(data[p + w]) ?? 0) + 1)
         }
       }
+      if (guarded) continue // a protected edge pixel — keep this small region
       let bestLab = -1
       let bestCnt = 0
       for (const [lb, c] of neighborCount) {
@@ -110,7 +120,7 @@ export function mergeSmallRegions(
         }
       }
       if (bestLab !== -1) {
-        if (opts && contrastExceeds(opts.oklab, lab, bestLab, keepSq)) continue // keep the detail
+        if (opts?.oklab && contrastExceeds(opts.oklab, lab, bestLab, keepSq)) continue // keep the detail
         for (let s = start; s < start + size; s++) data[order[s]] = bestLab
         merged = true
       }

--- a/packages/raster/src/resize.ts
+++ b/packages/raster/src/resize.ts
@@ -5,7 +5,7 @@
  * non-integer scale factors are handled exactly. The two separable passes
  * multiply out to the exact 2D box filter.
  */
-import type { RasterImage } from '@vectorizer/core'
+import type { GrayImage, RasterImage } from '@vectorizer/core'
 
 interface BoxTaps {
   start: Int32Array
@@ -126,4 +126,35 @@ export function resizeToFit(image: RasterImage, maxDimension: number): RasterIma
     }
   }
   return { width: dw, height: dh, data: out }
+}
+
+/**
+ * Bilinear resample of a single-channel float image to an exact size, center-
+ * aligned and edge-clamped. Used to bring an edge hint to the working image
+ * resolution before it is discretized. Returns a fresh image (a copy at identity).
+ */
+export function resizeGray(image: GrayImage, width: number, height: number): GrayImage {
+  const { width: w, height: h, data } = image
+  if (width <= 0 || height <= 0) throw new RangeError('resize target must be positive')
+  if (width === w && height === h) return { width, height, data: new Float32Array(data) }
+  const out = new Float32Array(width * height)
+  const sx = w / width
+  const sy = h / height
+  const last = (v: number, hi: number): number => (v < 0 ? 0 : v > hi ? hi : v)
+  for (let y = 0; y < height; y++) {
+    const fy = last((y + 0.5) * sy - 0.5, h - 1)
+    const y0 = Math.floor(fy)
+    const y1 = Math.min(h - 1, y0 + 1)
+    const wy = fy - y0
+    for (let x = 0; x < width; x++) {
+      const fx = last((x + 0.5) * sx - 0.5, w - 1)
+      const x0 = Math.floor(fx)
+      const x1 = Math.min(w - 1, x0 + 1)
+      const wx = fx - x0
+      const top = data[y0 * w + x0] + (data[y0 * w + x1] - data[y0 * w + x0]) * wx
+      const bot = data[y1 * w + x0] + (data[y1 * w + x1] - data[y1 * w + x0]) * wx
+      out[y * width + x] = top + (bot - top) * wy
+    }
+  }
+  return { width, height, data: out }
 }

--- a/packages/raster/test/morphology.test.ts
+++ b/packages/raster/test/morphology.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { despeckleMask, dilate, erode, maskArea } from '../src/index'
+import { despeckleMask, despeckleMaskGuided, dilate, erode, maskArea } from '../src/index'
 import { maskOf } from './helpers'
 
 describe('dilate', () => {
@@ -111,5 +111,39 @@ describe('despeckleMask', () => {
     const before = new Uint8Array(mask.data)
     despeckleMask(mask, 4)
     expect(mask.data).toEqual(before)
+  })
+})
+
+describe('despeckleMaskGuided', () => {
+  it('protects a small foreground speck that overlaps the protect mask', () => {
+    const mask = maskOf(12, 10, (x, y) => {
+      if (x >= 1 && x <= 5 && y >= 1 && y <= 5) return true // 5x5 blob
+      return x === 9 && y === 2 // single-pixel speck
+    })
+    const protect = maskOf(12, 10, (x, y) => x === 9 && y === 2)
+    const kept = despeckleMaskGuided(mask, 3, protect)
+    expect(kept.data[2 * 12 + 9]).toBe(1) // speck survives
+    expect(maskArea(kept)).toBe(26)
+    // Unprotected, the same speck is removed.
+    expect(despeckleMaskGuided(mask, 3, null).data[2 * 12 + 9]).toBe(0)
+  })
+
+  it('protects a small hole from being filled', () => {
+    const mask = maskOf(7, 7, (x, y) => {
+      if (x === 3 && y === 3) return false // 1px interior hole
+      return x >= 0 && x <= 6 && y >= 1 && y <= 5
+    })
+    const protect = maskOf(7, 7, (x, y) => x === 3 && y === 3)
+    expect(despeckleMaskGuided(mask, 2, protect).data[3 * 7 + 3]).toBe(0) // hole kept open
+    expect(despeckleMaskGuided(mask, 2, null).data[3 * 7 + 3]).toBe(1) // filled without protection
+  })
+
+  it('null protect reproduces despeckleMask byte-for-byte', () => {
+    const mask = maskOf(12, 10, (x, y) => {
+      if (x >= 1 && x <= 5 && y >= 1 && y <= 5) return true
+      if (x === 9 && y === 2) return true
+      return (x === 8 && y === 7) || (x === 9 && y === 8)
+    })
+    expect(despeckleMaskGuided(mask, 3, null).data).toEqual(despeckleMask(mask, 3).data)
   })
 })

--- a/packages/raster/test/regions.test.ts
+++ b/packages/raster/test/regions.test.ts
@@ -64,6 +64,33 @@ describe('mergeSmallRegions', () => {
     expect([...labels.data]).toEqual([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1])
   })
 
+  it('keeps a small region marked by the protect mask', () => {
+    const rows = [
+      [0, 0, 0, 1],
+      [0, 2, 2, 1],
+      [0, 0, 0, 1],
+    ]
+    const labels = labelMap(4, 3, rows, 3)
+    const protect = { width: 4, height: 3, data: new Uint8Array(12) }
+    protect.data[1 * 4 + 1] = 1 // one pixel of region 2 sits on a predicted edge
+    mergeSmallRegions(labels, 3, { protect })
+    expect(labels.data[1 * 4 + 1]).toBe(2)
+    expect(labels.data[1 * 4 + 2]).toBe(2)
+  })
+
+  it('still merges a small region the protect mask does not cover', () => {
+    const rows = [
+      [0, 0, 0, 1],
+      [0, 2, 2, 1],
+      [0, 0, 0, 1],
+    ]
+    const labels = labelMap(4, 3, rows, 3)
+    const protect = { width: 4, height: 3, data: new Uint8Array(12) }
+    protect.data[0] = 1 // marks a background pixel, not region 2
+    mergeSmallRegions(labels, 3, { protect })
+    expect([...labels.data]).toEqual([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1])
+  })
+
   it('keeps -1 pixels and regions surrounded only by -1', () => {
     const rows = [
       [-1, -1, -1, -1],

--- a/packages/raster/test/resize.test.ts
+++ b/packages/raster/test/resize.test.ts
@@ -1,7 +1,7 @@
 import { mulberry32 } from '@vectorizer/core'
 import { describe, expect, it } from 'vitest'
-import { resizeToFit } from '../src/index'
-import { channelMeans, rasterOf } from './helpers'
+import { resizeGray, resizeToFit } from '../src/index'
+import { channelMeans, grayOf, rasterOf } from './helpers'
 
 describe('resizeToFit', () => {
   it('returns the same object when maxDimension is 0', () => {
@@ -70,5 +70,26 @@ describe('resizeToFit', () => {
     for (let c = 0; c < 4; c++) {
       expect(Math.abs(inMeans[c] - outMeans[c])).toBeLessThanOrEqual(1)
     }
+  })
+})
+
+describe('resizeGray', () => {
+  it('returns a fresh copy at identity size', () => {
+    const g = grayOf(2, 2, (x, y) => x + 2 * y)
+    const out = resizeGray(g, 2, 2)
+    expect(out).not.toBe(g)
+    expect(Array.from(out.data)).toEqual([0, 1, 2, 3])
+  })
+
+  it('bilinearly resamples a 1-D ramp (center-aligned, edge-clamped)', () => {
+    const out = resizeGray(
+      grayOf(2, 1, (x) => x),
+      4,
+      1,
+    )
+    expect(out.width).toBe(4)
+    // sx = 0.5; sample centers clamp to 0, 0.25, 0.75, 1.
+    const expected = [0, 0.25, 0.75, 1]
+    for (let i = 0; i < expected.length; i++) expect(out.data[i]).toBeCloseTo(expected[i], 6)
   })
 })

--- a/packages/svg/src/primitive.ts
+++ b/packages/svg/src/primitive.ts
@@ -12,6 +12,7 @@ import { clampPrecision } from './pathdata'
 
 export type Primitive =
   | { kind: 'rect'; x: number; y: number; width: number; height: number }
+  | { kind: 'rrect'; x: number; y: number; width: number; height: number; r: number }
   | { kind: 'circle'; cx: number; cy: number; r: number }
   | { kind: 'ellipse'; cx: number; cy: number; rx: number; ry: number }
 
@@ -139,6 +140,80 @@ function detectRound(start: Pt, ops: PathCommand[], precision: number): Primitiv
   return null
 }
 
+/** Signed distance from a point to an axis-aligned rounded rectangle (circular corners). */
+function roundedRectSdf(
+  px: number,
+  py: number,
+  cx: number,
+  cy: number,
+  hx: number,
+  hy: number,
+  r: number,
+): number {
+  const qx = Math.abs(px - cx) - (hx - r)
+  const qy = Math.abs(py - cy) - (hy - r)
+  return Math.hypot(Math.max(qx, 0), Math.max(qy, 0)) + Math.min(Math.max(qx, qy), 0) - r
+}
+
+/**
+ * Recognize an axis-aligned rounded rectangle (straight edges + circular corner
+ * arcs) and emit `<rect rx>`. Structure-agnostic: it fits one corner radius by a
+ * scan and accepts only if every densely sampled boundary point lies on that
+ * rounded rect within tolerance, so a shape that is not really one is rejected.
+ */
+function detectRoundedRect(start: Pt, ops: PathCommand[], precision: number): Primitive | null {
+  if (ops.length < 4 || !ops.every((o) => o.type === 'L' || o.type === 'C')) return null
+  if (!ops.some((o) => o.type === 'C')) return null // corners must be arcs
+
+  // Dense samples: anchors plus each segment's midpoint (a non-axis-aligned edge
+  // or a wrong corner then fails the fit).
+  const samples: Pt[] = [start]
+  let prev = start
+  for (const op of ops) {
+    if (op.type === 'C') samples.push(cubicMid(prev, op))
+    else samples.push({ x: (prev.x + op.x) / 2, y: (prev.y + op.y) / 2 })
+    samples.push({ x: op.x, y: op.y })
+    prev = { x: op.x, y: op.y }
+  }
+
+  const xs = samples.map((p) => p.x)
+  const ys = samples.map((p) => p.y)
+  const minX = Math.min(...xs)
+  const maxX = Math.max(...xs)
+  const minY = Math.min(...ys)
+  const maxY = Math.max(...ys)
+  const cx = (minX + maxX) / 2
+  const cy = (minY + maxY) / 2
+  const hx = (maxX - minX) / 2
+  const hy = (maxY - minY) / 2
+  if (hx <= 0 || hy <= 0) return null
+
+  const maxR = Math.min(hx, hy)
+  const tol = Math.max(0.75, maxR * 0.03)
+  // Fit the corner radius by scanning for the smallest max-error.
+  let bestR = 0
+  let bestErr = Infinity
+  const steps = 64
+  for (let i = 1; i <= steps; i++) {
+    const r = (maxR * i) / steps
+    let err = 0
+    for (const p of samples) {
+      const d = Math.abs(roundedRectSdf(p.x, p.y, cx, cy, hx, hy, r))
+      if (d > err) err = d
+    }
+    if (err < bestErr) {
+      bestErr = err
+      bestR = r
+    }
+  }
+  if (bestErr > tol) return null
+  if (bestR < tol) return null // square corners — a plain rect (handled elsewhere)
+  return round(
+    { kind: 'rrect', x: cx - hx, y: cy - hy, width: 2 * hx, height: 2 * hy, r: bestR },
+    precision,
+  )
+}
+
 function round(prim: Primitive, precision: number): Primitive {
   const p = clampPrecision(precision)
   const q = (v: number): number => Number(v.toFixed(p))
@@ -149,6 +224,16 @@ function round(prim: Primitive, precision: number): Primitive {
       y: q(prim.y),
       width: q(prim.width),
       height: q(prim.height),
+    }
+  }
+  if (prim.kind === 'rrect') {
+    return {
+      kind: 'rrect',
+      x: q(prim.x),
+      y: q(prim.y),
+      width: q(prim.width),
+      height: q(prim.height),
+      r: q(prim.r),
     }
   }
   if (prim.kind === 'circle')
@@ -170,5 +255,10 @@ export function detectPrimitive(
   const scale = 10 ** clampPrecision(precision)
   const rect = detectRect(loop.start, loop.ops, scale)
   if (rect) return rect
-  return allowRound ? detectRound(loop.start, loop.ops, precision) : null
+  if (!allowRound) return null
+  // Circle/ellipse first so a true circle stays `<circle>`, not a pill `<rect rx>`.
+  return (
+    detectRound(loop.start, loop.ops, precision) ??
+    detectRoundedRect(loop.start, loop.ops, precision)
+  )
 }

--- a/packages/svg/src/serialize.ts
+++ b/packages/svg/src/serialize.ts
@@ -105,6 +105,8 @@ function primitiveElement(prim: Primitive, shape: SvgShape, precision: number): 
   switch (prim.kind) {
     case 'rect':
       return `<rect x="${n(prim.x)}" y="${n(prim.y)}" width="${n(prim.width)}" height="${n(prim.height)}"${paint}/>`
+    case 'rrect':
+      return `<rect x="${n(prim.x)}" y="${n(prim.y)}" width="${n(prim.width)}" height="${n(prim.height)}" rx="${n(prim.r)}"${paint}/>`
     case 'circle':
       return `<circle cx="${n(prim.cx)}" cy="${n(prim.cy)}" r="${n(prim.r)}"${paint}/>`
     case 'ellipse':

--- a/packages/svg/test/primitive.test.ts
+++ b/packages/svg/test/primitive.test.ts
@@ -25,6 +25,23 @@ function ellipsePath(cx: number, cy: number, rx: number, ry: number): PathComman
   ]
 }
 
+/** Axis-aligned rounded rectangle: straight edges + kappa cubic corner arcs. */
+function roundedRectPath(x0: number, y0: number, x1: number, y1: number, r: number): PathCommand[] {
+  const k = 0.5522847498 * r
+  return [
+    { type: 'M', x: x0 + r, y: y0 },
+    { type: 'L', x: x1 - r, y: y0 },
+    { type: 'C', x1: x1 - r + k, y1: y0, x2: x1, y2: y0 + r - k, x: x1, y: y0 + r },
+    { type: 'L', x: x1, y: y1 - r },
+    { type: 'C', x1: x1, y1: y1 - r + k, x2: x1 - r + k, y2: y1, x: x1 - r, y: y1 },
+    { type: 'L', x: x0 + r, y: y1 },
+    { type: 'C', x1: x0 + r - k, y1: y1, x2: x0, y2: y1 - r + k, x: x0, y: y1 - r },
+    { type: 'L', x: x0, y: y0 + r },
+    { type: 'C', x1: x0, y1: y0 + r - k, x2: x0 + r - k, y2: y0, x: x0 + r, y: y0 },
+    { type: 'Z' },
+  ]
+}
+
 describe('detectPrimitive — rectangles (exact)', () => {
   it('detects an axis-aligned rectangle in any mode', () => {
     expect(detectPrimitive(rectPath(4, 6, 20, 30), 2, false)).toEqual({
@@ -101,6 +118,39 @@ describe('detectPrimitive — circles and ellipses (gated)', () => {
   })
 })
 
+describe('detectPrimitive — rounded rectangles (gated)', () => {
+  it('detects a rounded rect only when round primitives are allowed', () => {
+    const cmds = roundedRectPath(10, 10, 90, 60, 12)
+    expect(detectPrimitive(cmds, 2, false)).toBeNull()
+    const p = detectPrimitive(cmds, 2, true) as Extract<Primitive, { kind: 'rrect' }>
+    expect(p.kind).toBe('rrect')
+    expect(p.x).toBeCloseTo(10, 0)
+    expect(p.y).toBeCloseTo(10, 0)
+    expect(p.width).toBeCloseTo(80, 0)
+    expect(p.height).toBeCloseTo(50, 0)
+    expect(p.r).toBeCloseTo(12, 0)
+  })
+
+  it('keeps a true circle as a circle, not a pill', () => {
+    expect(detectPrimitive(ellipsePath(50, 50, 30, 30), 2, true)?.kind).toBe('circle')
+  })
+
+  it('keeps a plain rectangle exact (not a rounded rect)', () => {
+    expect(detectPrimitive(rectPath(0, 0, 10, 10), 2, true)?.kind).toBe('rect')
+  })
+
+  it('rejects a rounded blob (not axis-aligned edges)', () => {
+    const blob: PathCommand[] = [
+      { type: 'M', x: 0, y: 0 },
+      { type: 'C', x1: 40, y1: -10, x2: 60, y2: 30, x: 30, y: 40 },
+      { type: 'L', x: 12, y: 44 },
+      { type: 'C', x1: 10, y1: 50, x2: -20, y2: 10, x: 0, y: 0 },
+      { type: 'Z' },
+    ]
+    expect(detectPrimitive(blob, 2, true)).toBeNull()
+  })
+})
+
 const primitiveDoc = (commands: PathCommand[]): SvgDocument => ({
   width: 100,
   height: 100,
@@ -129,5 +179,16 @@ describe('serializeSvg primitive emission', () => {
       roundPrimitives: true,
     })
     expect(round).toContain('<circle ')
+  })
+
+  it('emits <rect rx> for a rounded rectangle only when roundPrimitives is set', () => {
+    const commands = roundedRectPath(10, 10, 90, 60, 10)
+    expect(serializeSvg(doc(commands), { precision: 2, optimizePaths: true })).toContain('<path ')
+    const round = serializeSvg(doc(commands), {
+      precision: 2,
+      optimizePaths: true,
+      roundPrimitives: true,
+    })
+    expect(round).toMatch(/<rect [^>]*\brx="/)
   })
 })

--- a/scripts/dataset/README.md
+++ b/scripts/dataset/README.md
@@ -1,0 +1,80 @@
+# Dataset generator
+
+A seeded, reproducible pipeline that turns SVGs into aligned `(degraded raster → ground-truth)` training pairs for the
+on-device conditioning models in [`../../docs/ML_STRATEGY.md`](../../docs/ML_STRATEGY.md). The first model it feeds — a
+learned edge pre-pass — is specced in [`../../docs/EDGE_PREPASS.md`](../../docs/EDGE_PREPASS.md).
+
+The core idea (see the strategy doc): rendering an SVG gives a _perfectly aligned_ raster + vector pair for free; the
+make-or-break step is **degrading the raster input** so the model survives real photos, scans and JPEGs. Ground truth is
+derived from the clean render **before** degradation, so inputs and targets stay pixel-aligned.
+
+## Run
+
+```sh
+npm run dataset                       # 64 procedural samples → dataset-out/
+npm run dataset -- --count 500        # more
+npm run dataset -- --source dir --corpus /path/to/svgs --count 2000
+npm run dataset -- --help             # all options
+```
+
+No corpus is needed to start: the default `procedural` source synthesizes random primitive compositions (the strategy
+doc's procedural data source), which also gives exact ground truth. Point `--source dir --corpus <dir>` at real SVGs
+(fonts exported per-glyph, icon sets, clip art) to scale up.
+
+## Output
+
+```
+dataset-out/
+  manifest.json           config, seed, and per-sample split assignment
+  train/ val/ test/
+    input/  <id>.png       degraded raster (what the model sees)
+    clean/  <id>.png       clean scene      (cleanup / super-resolution target)
+    edge/   <id>.png       soft edge map    (edge pre-pass target)
+```
+
+For a real `--source dir` corpus, splits are assigned **per source family** (top-level subdirectory) so no source SVG
+leaks across train/val/test — otherwise metrics inflate. Procedural samples are mutually independent, so they split per
+sample and hit the ratios directly. Each sample also records its `family` label in the manifest. Pick the target heads
+with `--targets edge,clean`.
+
+## Pipeline (one sample)
+
+1. **Rasterize** the SVG with [resvg](https://github.com/linebender/resvg) at `resolution × supersample`, letterbox to a
+   square, apply optional geometric augmentation (rotate/scale/translate), and area-downsample for clean anti-aliasing
+   → the **shape** (keeps alpha). — `render.mjs`
+2. **Edge target** = max Sobel gradient across the shape's R/G/B/A channels (color boundaries + silhouette). — `targets.mjs`
+3. **Background** synth (solid/gradient/checker/noise) and **composite** the shape over it → the **clean scene** (also the
+   cleanup target). — `degrade.mjs`
+4. **Degrade** a copy of the clean scene: Gaussian blur → down/up resample → Gaussian noise → optional posterize → JPEG
+   round-trip (high-order degradation, Real-ESRGAN / BSRGAN style) → the **input**. — `degrade.mjs`
+
+## Determinism
+
+Every random draw comes from `mulberry32` (same PRNG as `@vectorizer/core`), seeded from `--seed` and the sample index,
+so a given config regenerates the same dataset. The manifest records the config and seed and contains **no wall-clock**.
+Note that PNG/JPEG encoders can vary across library or platform versions — pin `node_modules` (the repo lockfile) if you
+need byte-identical regeneration across machines.
+
+## Files
+
+| File           | Role                                                               |
+| -------------- | ------------------------------------------------------------------ |
+| `generate.mjs` | CLI, orchestration, split assignment, manifest                     |
+| `config.mjs`   | defaults + argument parsing + usage                                |
+| `sources.mjs`  | procedural SVG synthesis and real-corpus directory walk            |
+| `render.mjs`   | resvg rasterization, letterbox, geometric augmentation, downsample |
+| `degrade.mjs`  | background, composite, and the photometric degradation ops         |
+| `targets.mjs`  | edge-map ground truth (Sobel)                                      |
+| `imageops.mjs` | RGBA resize / area-downsample / affine / letterbox primitives      |
+| `random.mjs`   | seeded PRNG and distribution helpers                               |
+| `io.mjs`       | PNG writing and manifest                                           |
+
+## Extending
+
+- **Canonicalization** (`sources.mjs`) is a pass-through stub. A production corpus pipeline should flatten transforms,
+  resolve `<use>`, and expand shorthand into the `@vectorizer/svg` path model so targets match engine output.
+- **New target heads** (e.g. region label maps for layer ordering, or primitive parameter lists for shape fitting): add a
+  deriver beside `targets.mjs` and a `--targets` key.
+- **Real backgrounds / more degradations** (chromatic aberration, halftone, scanner warps) plug into `degrade.mjs`.
+- **`@vectorizer/trace` as a target source:** trace clean renders with the engine to produce near-perfect vector targets
+  (see the strategy doc's "your own tracer is a supervision signal").

--- a/scripts/dataset/README.md
+++ b/scripts/dataset/README.md
@@ -1,8 +1,9 @@
 # Dataset generator
 
 A seeded, reproducible pipeline that turns SVGs into aligned `(degraded raster → ground-truth)` training pairs for the
-on-device conditioning models in [`../../docs/ML_STRATEGY.md`](../../docs/ML_STRATEGY.md). The first model it feeds — a
-learned edge pre-pass — is specced in [`../../docs/EDGE_PREPASS.md`](../../docs/EDGE_PREPASS.md).
+on-device conditioning models in [`../../docs/ML_STRATEGY.md`](../../docs/ML_STRATEGY.md). It feeds two models from one
+run — the learned edge pre-pass ([`../../docs/EDGE_PREPASS.md`](../../docs/EDGE_PREPASS.md), the `edge/` target) and the
+cleanup pre-pass ([`../../docs/CLEANUP_PREPASS.md`](../../docs/CLEANUP_PREPASS.md), the `clean/` target).
 
 The core idea (see the strategy doc): rendering an SVG gives a _perfectly aligned_ raster + vector pair for free; the
 make-or-break step is **degrading the raster input** so the model survives real photos, scans and JPEGs. Ground truth is

--- a/scripts/dataset/README.md
+++ b/scripts/dataset/README.md
@@ -14,8 +14,13 @@ derived from the clean render **before** degradation, so inputs and targets stay
 npm run dataset                       # 64 procedural samples → dataset-out/
 npm run dataset -- --count 500        # more
 npm run dataset -- --source dir --corpus /path/to/svgs --count 2000
+npm run dataset -- --count 20000 --jobs 8   # spread across 8 worker threads
 npm run dataset -- --help             # all options
 ```
+
+Generation runs on worker threads (`--jobs`, default: CPU count; `--jobs 1` for single-thread). It is CPU-bound
+(rasterize + degrade + PNG encode), so this scales roughly linearly with cores — and the output is **byte-identical**
+regardless of `--jobs` (each sample is pure and the manifest is sorted by index).
 
 No corpus is needed to start: the default `procedural` source synthesizes random primitive compositions (the strategy
 doc's procedural data source), which also gives exact ground truth. Point `--source dir --corpus <dir>` at real SVGs
@@ -57,17 +62,19 @@ need byte-identical regeneration across machines.
 
 ## Files
 
-| File           | Role                                                               |
-| -------------- | ------------------------------------------------------------------ |
-| `generate.mjs` | CLI, orchestration, split assignment, manifest                     |
-| `config.mjs`   | defaults + argument parsing + usage                                |
-| `sources.mjs`  | procedural SVG synthesis and real-corpus directory walk            |
-| `render.mjs`   | resvg rasterization, letterbox, geometric augmentation, downsample |
-| `degrade.mjs`  | background, composite, and the photometric degradation ops         |
-| `targets.mjs`  | edge-map ground truth (Sobel)                                      |
-| `imageops.mjs` | RGBA resize / area-downsample / affine / letterbox primitives      |
-| `random.mjs`   | seeded PRNG and distribution helpers                               |
-| `io.mjs`       | PNG writing and manifest                                           |
+| File                | Role                                                               |
+| ------------------- | ------------------------------------------------------------------ |
+| `generate.mjs`      | CLI, worker-pool orchestration, split assignment, manifest         |
+| `sample.mjs`        | one sample end to end (render → degrade → targets → write)         |
+| `sample-worker.mjs` | worker-thread entry: runs `sample.mjs` off the main thread         |
+| `config.mjs`        | defaults + argument parsing + usage                                |
+| `sources.mjs`       | procedural SVG synthesis and real-corpus directory walk            |
+| `render.mjs`        | resvg rasterization, letterbox, geometric augmentation, downsample |
+| `degrade.mjs`       | background, composite, and the photometric degradation ops         |
+| `targets.mjs`       | edge-map ground truth (Sobel)                                      |
+| `imageops.mjs`      | RGBA resize / area-downsample / affine / letterbox primitives      |
+| `random.mjs`        | seeded PRNG and distribution helpers                               |
+| `io.mjs`            | PNG writing and manifest                                           |
 
 ## Extending
 

--- a/scripts/dataset/config.mjs
+++ b/scripts/dataset/config.mjs
@@ -1,0 +1,104 @@
+// Dataset generation config: defaults, CLI parsing, and usage text. All
+// randomness is seeded from `seed`, so a config fully determines the dataset.
+
+export const DEFAULTS = {
+  source: 'procedural', // 'procedural' | 'dir'
+  corpus: '', // directory of .svg files when source === 'dir'
+  out: 'dataset-out', // output root
+  count: 64, // samples to generate (procedural) or cap for 'dir' (0 = all)
+  resolution: 256, // square output tile size, px
+  supersample: 2, // render scale before area-downsample, for anti-aliasing
+  seed: 1,
+  targets: ['edge', 'clean'], // ground-truth heads to emit
+  split: { train: 0.8, val: 0.1, test: 0.1 }, // assigned per source family
+  geometric: { enabled: true, rotateDeg: 8, scale: 0.15, translateFrac: 0.05 },
+  degrade: {
+    background: true, // composite the shape over a procedural background
+    blurSigmaMax: 1.5,
+    resampleMinScale: 0.5, // down-then-up resampling floor (1 = disabled)
+    noiseStdMax: 12, // gaussian noise sigma on the 0..255 scale
+    jpeg: true,
+    jpegQuality: { min: 30, max: 95 },
+    posterizeLevels: 0, // >0 quantizes each channel to N levels
+  },
+}
+
+export function parseArgs(argv) {
+  const cfg = structuredClone(DEFAULTS)
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (!arg.startsWith('--')) continue
+    const key = arg.slice(2)
+    const next = argv[i + 1]
+    switch (key) {
+      case 'source':
+        cfg.source = next
+        i++
+        break
+      case 'corpus':
+        cfg.corpus = next
+        i++
+        break
+      case 'out':
+        cfg.out = next
+        i++
+        break
+      case 'count':
+        cfg.count = Number(next)
+        i++
+        break
+      case 'resolution':
+        cfg.resolution = Number(next)
+        i++
+        break
+      case 'supersample':
+        cfg.supersample = Number(next)
+        i++
+        break
+      case 'seed':
+        cfg.seed = Number(next)
+        i++
+        break
+      case 'targets':
+        cfg.targets = next.split(',').map((t) => t.trim())
+        i++
+        break
+      case 'no-geometric':
+        cfg.geometric.enabled = false
+        break
+      case 'no-jpeg':
+        cfg.degrade.jpeg = false
+        break
+      case 'no-background':
+        cfg.degrade.background = false
+        break
+      case 'help':
+        cfg.help = true
+        break
+      default:
+        throw new Error(`unknown flag --${key}`)
+    }
+  }
+  if (cfg.source !== 'procedural' && cfg.source !== 'dir') {
+    throw new Error(`--source must be 'procedural' or 'dir', got '${cfg.source}'`)
+  }
+  return cfg
+}
+
+export const USAGE = `dataset generator — SVG corpus → rasterize → degrade → aligned pairs
+
+Usage: npm run dataset -- [options]
+
+  --source <procedural|dir>  sample source (default procedural)
+  --corpus <dir>             directory of .svg files (required for source=dir)
+  --out <dir>                output root (default dataset-out)
+  --count <n>                samples to generate, or cap for dir (default 64)
+  --resolution <px>          square tile size (default 256)
+  --supersample <n>          anti-aliasing render scale (default 2)
+  --seed <n>                 base seed (default 1)
+  --targets <a,b>            ground-truth heads: edge,clean (default edge,clean)
+  --no-geometric             disable rotate/scale/translate augmentation
+  --no-jpeg                  disable JPEG degradation
+  --no-background            render on white instead of a procedural background
+  --help                     show this message
+`

--- a/scripts/dataset/config.mjs
+++ b/scripts/dataset/config.mjs
@@ -9,6 +9,8 @@ export const DEFAULTS = {
   resolution: 256, // square output tile size, px
   supersample: 2, // render scale before area-downsample, for anti-aliasing
   seed: 1,
+  jobs: 0, // parallel worker threads; 0 = auto (CPU count), 1 = single-thread
+
   targets: ['edge', 'clean'], // ground-truth heads to emit
   split: { train: 0.8, val: 0.1, test: 0.1 }, // assigned per source family
   geometric: { enabled: true, rotateDeg: 8, scale: 0.15, translateFrac: 0.05 },
@@ -59,6 +61,10 @@ export function parseArgs(argv) {
         cfg.seed = Number(next)
         i++
         break
+      case 'jobs':
+        cfg.jobs = Number(next)
+        i++
+        break
       case 'targets':
         cfg.targets = next.split(',').map((t) => t.trim())
         i++
@@ -96,6 +102,7 @@ Usage: npm run dataset -- [options]
   --resolution <px>          square tile size (default 256)
   --supersample <n>          anti-aliasing render scale (default 2)
   --seed <n>                 base seed (default 1)
+  --jobs <n>                 parallel worker threads (default: CPU count; 1 = single-thread)
   --targets <a,b>            ground-truth heads: edge,clean (default edge,clean)
   --no-geometric             disable rotate/scale/translate augmentation
   --no-jpeg                  disable JPEG degradation

--- a/scripts/dataset/degrade.mjs
+++ b/scripts/dataset/degrade.mjs
@@ -1,0 +1,179 @@
+// The degradation half of the pipeline: build a background, composite the shape
+// over it to form a clean scene, then corrupt a copy of that scene to form the
+// model input. Ground truth (the clean scene and the edge map) is derived before
+// this corruption, so input and targets stay pixel-aligned. The corruptions
+// follow the high-order degradation idea from Real-ESRGAN / BSRGAN.
+
+import jpeg from 'jpeg-js'
+import { createImage, resizeBilinear } from './imageops.mjs'
+import { chance, gaussian, int, pick, uniform } from './random.mjs'
+
+// Opaque procedural background so inputs are not on clean white (real uploads
+// rarely are). With backgrounds disabled the scene sits on white.
+export function makeBackground(width, height, rng, enabled) {
+  const bg = createImage(width, height)
+  const d = bg.data
+  if (!enabled) {
+    d.fill(255)
+    return bg
+  }
+  const kind = pick(rng, ['solid', 'gradient', 'checker', 'noise'])
+  const c1 = randColor(rng)
+  const c2 = randColor(rng)
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4
+      let c
+      if (kind === 'solid') c = c1
+      else if (kind === 'gradient') c = mix(c1, c2, x / width)
+      else if (kind === 'checker') c = ((x >> 4) + (y >> 4)) & 1 ? c1 : c2
+      else c = mix(c1, c2, (Math.sin(x * 0.08) + Math.cos(y * 0.08) + 2) / 4)
+      d[i] = c[0]
+      d[i + 1] = c[1]
+      d[i + 2] = c[2]
+      d[i + 3] = 255
+    }
+  }
+  return bg
+}
+
+// Source-over composite of an RGBA shape onto an opaque background → opaque scene.
+export function compositeOver(shape, bg) {
+  const out = createImage(bg.width, bg.height)
+  const s = shape.data
+  const b = bg.data
+  const o = out.data
+  for (let i = 0; i < o.length; i += 4) {
+    const a = s[i + 3] / 255
+    o[i] = s[i] * a + b[i] * (1 - a)
+    o[i + 1] = s[i + 1] * a + b[i + 1] * (1 - a)
+    o[i + 2] = s[i + 2] * a + b[i + 2] * (1 - a)
+    o[i + 3] = 255
+  }
+  return out
+}
+
+export function degrade(scene, cfg, rng) {
+  const p = cfg.degrade
+  let out = scene
+  if (p.blurSigmaMax > 0 && chance(rng, 0.8))
+    out = gaussianBlur(out, uniform(rng, 0.3, p.blurSigmaMax))
+  if (p.resampleMinScale < 1 && chance(rng, 0.7))
+    out = resampleRoundtrip(out, uniform(rng, p.resampleMinScale, 1))
+  if (p.noiseStdMax > 0) out = addNoise(out, uniform(rng, 0, p.noiseStdMax), rng)
+  if (p.posterizeLevels > 0) out = posterize(out, p.posterizeLevels)
+  if (p.jpeg) out = jpegRoundtrip(out, int(rng, p.jpegQuality.min, p.jpegQuality.max))
+  return out
+}
+
+// Separable Gaussian blur (RGB only; alpha is already opaque here).
+function gaussianBlur(img, sigma) {
+  const radius = Math.max(1, Math.ceil(sigma * 3))
+  const kernel = new Float32Array(radius * 2 + 1)
+  let sum = 0
+  for (let i = -radius; i <= radius; i++) {
+    const v = Math.exp(-(i * i) / (2 * sigma * sigma))
+    kernel[i + radius] = v
+    sum += v
+  }
+  for (let i = 0; i < kernel.length; i++) kernel[i] /= sum
+  return convolveSeparable(img, kernel, radius)
+}
+
+function convolveSeparable(img, kernel, radius) {
+  const { width: w, height: h, data } = img
+  const tmp = createImage(w, h).data
+  const out = createImage(w, h)
+  const o = out.data
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      let r = 0
+      let g = 0
+      let b = 0
+      for (let k = -radius; k <= radius; k++) {
+        const xx = clampInt(x + k, 0, w - 1)
+        const i = (y * w + xx) * 4
+        const wk = kernel[k + radius]
+        r += data[i] * wk
+        g += data[i + 1] * wk
+        b += data[i + 2] * wk
+      }
+      const ti = (y * w + x) * 4
+      tmp[ti] = r
+      tmp[ti + 1] = g
+      tmp[ti + 2] = b
+      tmp[ti + 3] = 255
+    }
+  }
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      let r = 0
+      let g = 0
+      let b = 0
+      for (let k = -radius; k <= radius; k++) {
+        const yy = clampInt(y + k, 0, h - 1)
+        const i = (yy * w + x) * 4
+        const wk = kernel[k + radius]
+        r += tmp[i] * wk
+        g += tmp[i + 1] * wk
+        b += tmp[i + 2] * wk
+      }
+      const oi = (y * w + x) * 4
+      o[oi] = r
+      o[oi + 1] = g
+      o[oi + 2] = b
+      o[oi + 3] = 255
+    }
+  }
+  return out
+}
+
+// Downscale then upscale to simulate a low-resolution source.
+function resampleRoundtrip(img, scale) {
+  const dw = Math.max(1, Math.round(img.width * scale))
+  const dh = Math.max(1, Math.round(img.height * scale))
+  return resizeBilinear(resizeBilinear(img, dw, dh), img.width, img.height)
+}
+
+function addNoise(img, std, rng) {
+  const out = { width: img.width, height: img.height, data: new Uint8ClampedArray(img.data) }
+  const d = out.data
+  for (let i = 0; i < d.length; i += 4) {
+    d[i] += gaussian(rng, 0, std)
+    d[i + 1] += gaussian(rng, 0, std)
+    d[i + 2] += gaussian(rng, 0, std)
+  }
+  return out
+}
+
+function posterize(img, levels) {
+  const out = { width: img.width, height: img.height, data: new Uint8ClampedArray(img.data) }
+  const d = out.data
+  const step = 255 / (levels - 1)
+  for (let i = 0; i < d.length; i += 4) {
+    d[i] = Math.round(d[i] / step) * step
+    d[i + 1] = Math.round(d[i + 1] / step) * step
+    d[i + 2] = Math.round(d[i + 2] / step) * step
+  }
+  return out
+}
+
+// Encode to JPEG at the given quality and decode back, baking in block artifacts.
+function jpegRoundtrip(img, quality) {
+  const raw = Buffer.from(img.data.buffer, img.data.byteOffset, img.data.byteLength)
+  const encoded = jpeg.encode({ data: raw, width: img.width, height: img.height }, quality)
+  const decoded = jpeg.decode(encoded.data, { useTArray: true })
+  return { width: decoded.width, height: decoded.height, data: new Uint8ClampedArray(decoded.data) }
+}
+
+function randColor(rng) {
+  return [int(rng, 0, 255), int(rng, 0, 255), int(rng, 0, 255)]
+}
+
+function mix(a, b, t) {
+  return [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t, a[2] + (b[2] - a[2]) * t]
+}
+
+function clampInt(v, lo, hi) {
+  return v < lo ? lo : v > hi ? hi : v
+}

--- a/scripts/dataset/generate.mjs
+++ b/scripts/dataset/generate.mjs
@@ -9,15 +9,19 @@
 //   edge/   the soft edge map  (edge pre-pass target)
 // plus a manifest.json with the config and per-sample split assignment.
 //
+// Work is spread across worker threads (--jobs, default: CPU count). Because
+// each sample is fully determined by its own seeds and the manifest is sorted by
+// index, the output is byte-identical regardless of --jobs.
+//
 // Usage: npm run dataset -- [options]   (see --help)
+import { availableParallelism, cpus } from 'node:os'
 import { join } from 'node:path'
+import { Worker } from 'node:worker_threads'
 import { parseArgs, USAGE } from './config.mjs'
-import { compositeOver, degrade, makeBackground } from './degrade.mjs'
-import { ensureDir, sanitize, writeGrayPng, writeManifest, writeRgbaPng } from './io.mjs'
+import { ensureDir, sanitize, writeManifest } from './io.mjs'
 import { hashString, mulberry32, seedFor } from './random.mjs'
-import { renderShape } from './render.mjs'
-import { dirSource, proceduralSource } from './sources.mjs'
-import { edgeMap } from './targets.mjs'
+import { processItem } from './sample.mjs'
+import { dirSource, proceduralItem } from './sources.mjs'
 
 const cfg = parseArgs(process.argv.slice(2))
 if (cfg.help) {
@@ -32,13 +36,10 @@ for (const s of SPLITS) {
   if (cfg.targets.includes('edge')) ensureDir(join(cfg.out, s, 'edge'))
 }
 
-// Assign a split from a stable hash of the split key. For a real corpus the key
-// is the source family (top-level subdir), so no source SVG leaks across splits;
-// procedural samples are mutually independent, so each splits on its own id and
-// the ratios are hit directly.
+// Assign a split from a stable hash of the split key (mulberry32 avalanches it).
+// For a real corpus the key is the source family (top-level subdir), so no source
+// SVG leaks across splits; procedural samples split on their own id.
 function assignSplit(key) {
-  // mulberry32 avalanches the hash — FNV-1a alone leaves high bits correlated
-  // for near-identical sequential ids, which would bias the split.
   const r = mulberry32(hashString(`${cfg.seed}:${key}`))()
   const { train, val } = cfg.split
   if (r < train) return 'train'
@@ -46,66 +47,111 @@ function assignSplit(key) {
   return 'test'
 }
 
-// Two independent PRNG streams per sample: one for shape synthesis, one for the
-// render/degrade pipeline, so changing one does not shift the other.
-const synthRng = (i) => mulberry32(seedFor(cfg.seed, i * 2))
-const pipeRng = (id, i) =>
-  cfg.source === 'dir'
-    ? mulberry32(seedFor(cfg.seed ^ hashString(id), 1))
-    : mulberry32(seedFor(cfg.seed, i * 2 + 1))
-
-function source() {
+/** Yield fully-resolved work items (svg + seeds + split + filename) in order. */
+function* buildItems() {
   if (cfg.source === 'dir') {
     if (!cfg.corpus) throw new Error('source=dir requires --corpus <dir>')
-    return dirSource(cfg.corpus, cfg.count)
+    let index = 0
+    for (const { id, family, svg } of dirSource(cfg.corpus, cfg.count)) {
+      yield {
+        index,
+        id,
+        family,
+        split: assignSplit(family),
+        base: sanitize(id),
+        svg,
+        pipeSeed: seedFor((cfg.seed ^ hashString(id)) >>> 0, 1),
+      }
+      index++
+    }
+  } else {
+    for (let index = 0; index < cfg.count; index++) {
+      const { id, family, svg } = proceduralItem(index, cfg.seed)
+      yield {
+        index,
+        id,
+        family,
+        split: assignSplit(id),
+        base: sanitize(id),
+        svg,
+        pipeSeed: seedFor(cfg.seed, index * 2 + 1),
+      }
+    }
   }
-  return proceduralSource(cfg.count, synthRng)
+}
+
+/** Run items through a pool of worker threads; `onRecord` fires as each finishes. */
+function runPool(iterator, jobs, onRecord) {
+  return new Promise((resolve, reject) => {
+    const url = new URL('./sample-worker.mjs', import.meta.url)
+    const workers = []
+    let active = 0
+    let settled = false
+    const fail = (err) => {
+      if (settled) return
+      settled = true
+      for (const w of workers) void w.terminate()
+      reject(err)
+    }
+    const feed = (w) => {
+      const n = iterator.next()
+      // worker_threads postMessage takes no targetOrigin (this is not window).
+      // oxlint-disable-next-line unicorn/require-post-message-target-origin
+      w.postMessage(n.done ? { type: 'stop' } : { type: 'item', item: n.value })
+    }
+    for (let i = 0; i < jobs; i++) {
+      const w = new Worker(url, { workerData: { config: cfg } })
+      workers.push(w)
+      active++
+      w.on('message', (msg) => {
+        if (msg.type === 'record') {
+          onRecord(msg.record)
+          feed(w)
+        }
+      })
+      w.on('error', fail)
+      w.on('exit', (code) => {
+        if (code !== 0) fail(new Error(`dataset worker exited with code ${code}`))
+        else if (--active === 0 && !settled) {
+          settled = true
+          resolve()
+        }
+      })
+      feed(w) // prime
+    }
+  })
 }
 
 const records = []
 const started = Date.now()
-let i = 0
-for (const item of source()) {
-  const rng = pipeRng(item.id, i)
-  const split = assignSplit(cfg.source === 'dir' ? item.family : item.id)
-  const base = sanitize(item.id)
-
-  const shape = renderShape(item.svg, cfg, rng)
-  const bg = makeBackground(cfg.resolution, cfg.resolution, rng, cfg.degrade.background)
-  const clean = compositeOver(shape, bg)
-  const input = degrade(clean, cfg, rng)
-
-  writeRgbaPng(join(cfg.out, split, 'input', `${base}.png`), input)
-  const rec = { id: item.id, family: item.family, split, input: `${split}/input/${base}.png` }
-  if (cfg.targets.includes('clean')) {
-    writeRgbaPng(join(cfg.out, split, 'clean', `${base}.png`), clean)
-    rec.clean = `${split}/clean/${base}.png`
-  }
-  if (cfg.targets.includes('edge')) {
-    writeGrayPng(
-      join(cfg.out, split, 'edge', `${base}.png`),
-      edgeMap(shape),
-      cfg.resolution,
-      cfg.resolution,
-    )
-    rec.edge = `${split}/edge/${base}.png`
-  }
+let n = 0
+const onRecord = (rec) => {
   records.push(rec)
-  i++
-  if (i % 16 === 0) console.log(`  ${i} samples…`)
+  if (++n % 64 === 0) console.log(`  ${n} samples…`)
 }
 
+const jobs = cfg.jobs > 0 ? cfg.jobs : (availableParallelism?.() ?? cpus().length)
+if (jobs <= 1) {
+  for (const item of buildItems()) onRecord(processItem(item, cfg))
+} else {
+  await runPool(buildItems(), jobs, onRecord)
+}
+
+// Stable order regardless of worker completion order.
+records.sort((a, b) => a.index - b.index)
 const counts = SPLITS.reduce(
   (acc, s) => ((acc[s] = records.filter((r) => r.split === s).length), acc),
   {},
 )
+
 writeManifest(join(cfg.out, 'manifest.json'), {
   generatedWith: {
     source: cfg.source,
     seed: cfg.seed,
     resolution: cfg.resolution,
     supersample: cfg.supersample,
-    count: i,
+    jobs,
+    count: records.length,
   },
   config: cfg,
   counts,
@@ -113,6 +159,6 @@ writeManifest(join(cfg.out, 'manifest.json'), {
 })
 
 console.log(
-  `\ndone — ${i} samples (train ${counts.train}, val ${counts.val}, test ${counts.test}) ` +
-    `in ${((Date.now() - started) / 1000).toFixed(1)}s → ${cfg.out}/`,
+  `\ndone — ${records.length} samples (train ${counts.train}, val ${counts.val}, test ${counts.test}) ` +
+    `on ${jobs} job${jobs === 1 ? '' : 's'} in ${((Date.now() - started) / 1000).toFixed(1)}s → ${cfg.out}/`,
 )

--- a/scripts/dataset/generate.mjs
+++ b/scripts/dataset/generate.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Dataset generator: SVG corpus → rasterize → degrade → aligned (input, target)
+// pairs, for training the on-device conditioning models described in
+// docs/ML_STRATEGY.md and docs/EDGE_PREPASS.md.
+//
+// Per sample it emits, all pixel-aligned at the target resolution:
+//   input/  the degraded raster the model sees
+//   clean/  the clean scene    (cleanup / super-resolution target)
+//   edge/   the soft edge map  (edge pre-pass target)
+// plus a manifest.json with the config and per-sample split assignment.
+//
+// Usage: npm run dataset -- [options]   (see --help)
+import { join } from 'node:path'
+import { parseArgs, USAGE } from './config.mjs'
+import { compositeOver, degrade, makeBackground } from './degrade.mjs'
+import { ensureDir, sanitize, writeGrayPng, writeManifest, writeRgbaPng } from './io.mjs'
+import { hashString, mulberry32, seedFor } from './random.mjs'
+import { renderShape } from './render.mjs'
+import { dirSource, proceduralSource } from './sources.mjs'
+import { edgeMap } from './targets.mjs'
+
+const cfg = parseArgs(process.argv.slice(2))
+if (cfg.help) {
+  console.log(USAGE)
+  process.exit(0)
+}
+
+const SPLITS = ['train', 'val', 'test']
+for (const s of SPLITS) {
+  ensureDir(join(cfg.out, s, 'input'))
+  if (cfg.targets.includes('clean')) ensureDir(join(cfg.out, s, 'clean'))
+  if (cfg.targets.includes('edge')) ensureDir(join(cfg.out, s, 'edge'))
+}
+
+// Assign a split from a stable hash of the split key. For a real corpus the key
+// is the source family (top-level subdir), so no source SVG leaks across splits;
+// procedural samples are mutually independent, so each splits on its own id and
+// the ratios are hit directly.
+function assignSplit(key) {
+  // mulberry32 avalanches the hash — FNV-1a alone leaves high bits correlated
+  // for near-identical sequential ids, which would bias the split.
+  const r = mulberry32(hashString(`${cfg.seed}:${key}`))()
+  const { train, val } = cfg.split
+  if (r < train) return 'train'
+  if (r < train + val) return 'val'
+  return 'test'
+}
+
+// Two independent PRNG streams per sample: one for shape synthesis, one for the
+// render/degrade pipeline, so changing one does not shift the other.
+const synthRng = (i) => mulberry32(seedFor(cfg.seed, i * 2))
+const pipeRng = (id, i) =>
+  cfg.source === 'dir'
+    ? mulberry32(seedFor(cfg.seed ^ hashString(id), 1))
+    : mulberry32(seedFor(cfg.seed, i * 2 + 1))
+
+function source() {
+  if (cfg.source === 'dir') {
+    if (!cfg.corpus) throw new Error('source=dir requires --corpus <dir>')
+    return dirSource(cfg.corpus, cfg.count)
+  }
+  return proceduralSource(cfg.count, synthRng)
+}
+
+const records = []
+const started = Date.now()
+let i = 0
+for (const item of source()) {
+  const rng = pipeRng(item.id, i)
+  const split = assignSplit(cfg.source === 'dir' ? item.family : item.id)
+  const base = sanitize(item.id)
+
+  const shape = renderShape(item.svg, cfg, rng)
+  const bg = makeBackground(cfg.resolution, cfg.resolution, rng, cfg.degrade.background)
+  const clean = compositeOver(shape, bg)
+  const input = degrade(clean, cfg, rng)
+
+  writeRgbaPng(join(cfg.out, split, 'input', `${base}.png`), input)
+  const rec = { id: item.id, family: item.family, split, input: `${split}/input/${base}.png` }
+  if (cfg.targets.includes('clean')) {
+    writeRgbaPng(join(cfg.out, split, 'clean', `${base}.png`), clean)
+    rec.clean = `${split}/clean/${base}.png`
+  }
+  if (cfg.targets.includes('edge')) {
+    writeGrayPng(
+      join(cfg.out, split, 'edge', `${base}.png`),
+      edgeMap(shape),
+      cfg.resolution,
+      cfg.resolution,
+    )
+    rec.edge = `${split}/edge/${base}.png`
+  }
+  records.push(rec)
+  i++
+  if (i % 16 === 0) console.log(`  ${i} samples…`)
+}
+
+const counts = SPLITS.reduce(
+  (acc, s) => ((acc[s] = records.filter((r) => r.split === s).length), acc),
+  {},
+)
+writeManifest(join(cfg.out, 'manifest.json'), {
+  generatedWith: {
+    source: cfg.source,
+    seed: cfg.seed,
+    resolution: cfg.resolution,
+    supersample: cfg.supersample,
+    count: i,
+  },
+  config: cfg,
+  counts,
+  samples: records,
+})
+
+console.log(
+  `\ndone — ${i} samples (train ${counts.train}, val ${counts.val}, test ${counts.test}) ` +
+    `in ${((Date.now() - started) / 1000).toFixed(1)}s → ${cfg.out}/`,
+)

--- a/scripts/dataset/imageops.mjs
+++ b/scripts/dataset/imageops.mjs
@@ -1,0 +1,151 @@
+// RGBA image helpers on flat Uint8ClampedArray buffers (length w*h*4, y-down),
+// mirroring the pixel conventions of @vectorizer/raster. Dependency-free and
+// allocation-conscious; an image is { width, height, data }.
+
+export function createImage(width, height) {
+  return { width, height, data: new Uint8ClampedArray(width * height * 4) }
+}
+
+// Bilinear resample to an arbitrary size.
+export function resizeBilinear(img, outW, outH) {
+  const { width: w, height: h, data } = img
+  const out = createImage(outW, outH)
+  const o = out.data
+  const sx = w / outW
+  const sy = h / outH
+  for (let y = 0; y < outH; y++) {
+    const fy = (y + 0.5) * sy - 0.5
+    const y0 = Math.floor(fy)
+    const wy = fy - y0
+    const y0c = clampInt(y0, 0, h - 1)
+    const y1c = clampInt(y0 + 1, 0, h - 1)
+    for (let x = 0; x < outW; x++) {
+      const fx = (x + 0.5) * sx - 0.5
+      const x0 = Math.floor(fx)
+      const wx = fx - x0
+      const x0c = clampInt(x0, 0, w - 1)
+      const x1c = clampInt(x0 + 1, 0, w - 1)
+      const i00 = (y0c * w + x0c) * 4
+      const i01 = (y0c * w + x1c) * 4
+      const i10 = (y1c * w + x0c) * 4
+      const i11 = (y1c * w + x1c) * 4
+      const oi = (y * outW + x) * 4
+      for (let c = 0; c < 4; c++) {
+        const top = data[i00 + c] * (1 - wx) + data[i01 + c] * wx
+        const bot = data[i10 + c] * (1 - wx) + data[i11 + c] * wx
+        o[oi + c] = top * (1 - wy) + bot * wy
+      }
+    }
+  }
+  return out
+}
+
+// Area-average downsample (box filter over the covered source rectangle) — the
+// anti-aliasing step for a supersampled render. Falls back to bilinear on upscale.
+export function resizeArea(img, outW, outH) {
+  const { width: w, height: h, data } = img
+  if (outW >= w && outH >= h) return resizeBilinear(img, outW, outH)
+  const out = createImage(outW, outH)
+  const o = out.data
+  const sx = w / outW
+  const sy = h / outH
+  for (let y = 0; y < outH; y++) {
+    const y0 = Math.floor(y * sy)
+    const y1 = Math.min(h, Math.ceil((y + 1) * sy))
+    for (let x = 0; x < outW; x++) {
+      const x0 = Math.floor(x * sx)
+      const x1 = Math.min(w, Math.ceil((x + 1) * sx))
+      let r = 0
+      let g = 0
+      let b = 0
+      let a = 0
+      let n = 0
+      for (let yy = y0; yy < y1; yy++) {
+        for (let xx = x0; xx < x1; xx++) {
+          const i = (yy * w + xx) * 4
+          r += data[i]
+          g += data[i + 1]
+          b += data[i + 2]
+          a += data[i + 3]
+          n++
+        }
+      }
+      const oi = (y * outW + x) * 4
+      o[oi] = r / n
+      o[oi + 1] = g / n
+      o[oi + 2] = b / n
+      o[oi + 3] = a / n
+    }
+  }
+  return out
+}
+
+// Inverse-mapped affine transform about the image center (rotate degrees, uniform
+// scale, fractional translate), bilinear sampled; samples outside the source stay
+// transparent.
+export function affineTransform(img, { rotateDeg = 0, scale = 1, tx = 0, ty = 0 }) {
+  const { width: w, height: h, data } = img
+  const out = createImage(w, h)
+  const o = out.data
+  const rad = (rotateDeg * Math.PI) / 180
+  const cos = Math.cos(rad) / scale
+  const sin = Math.sin(rad) / scale
+  const cx = w / 2
+  const cy = h / 2
+  const dx = tx * w
+  const dy = ty * h
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const rx = x - cx - dx
+      const ry = y - cy - dy
+      const sxp = cos * rx + sin * ry + cx
+      const syp = -sin * rx + cos * ry + cy
+      const oi = (y * w + x) * 4
+      if (sxp < 0 || syp < 0 || sxp > w - 1 || syp > h - 1) continue
+      const x0 = Math.floor(sxp)
+      const y0 = Math.floor(syp)
+      const x1 = Math.min(w - 1, x0 + 1)
+      const y1 = Math.min(h - 1, y0 + 1)
+      const wx = sxp - x0
+      const wy = syp - y0
+      const i00 = (y0 * w + x0) * 4
+      const i01 = (y0 * w + x1) * 4
+      const i10 = (y1 * w + x0) * 4
+      const i11 = (y1 * w + x1) * 4
+      for (let c = 0; c < 4; c++) {
+        const top = data[i00 + c] * (1 - wx) + data[i01 + c] * wx
+        const bot = data[i10 + c] * (1 - wx) + data[i11 + c] * wx
+        o[oi + c] = top * (1 - wy) + bot * wy
+      }
+    }
+  }
+  return out
+}
+
+// Fit an image into a square `side`×`side` canvas, longest edge scaled to `side`
+// and centered on transparent (letterbox) — the input convention U²-Net and
+// SlimSAM already use in @vectorizer/ml.
+export function fitSquare(img, side) {
+  const s = Math.min(side / img.width, side / img.height)
+  const rw = Math.max(1, Math.round(img.width * s))
+  const rh = Math.max(1, Math.round(img.height * s))
+  const resized = rw === img.width && rh === img.height ? img : resizeBilinear(img, rw, rh)
+  const out = createImage(side, side)
+  const ox = ((side - rw) / 2) | 0
+  const oy = ((side - rh) / 2) | 0
+  for (let y = 0; y < rh; y++) {
+    for (let x = 0; x < rw; x++) {
+      const si = (y * rw + x) * 4
+      const di = ((y + oy) * side + (x + ox)) * 4
+      out.data[di] = resized.data[si]
+      out.data[di + 1] = resized.data[si + 1]
+      out.data[di + 2] = resized.data[si + 2]
+      out.data[di + 3] = resized.data[si + 3]
+    }
+  }
+  return out
+}
+
+function clampInt(v, lo, hi) {
+  return v < lo ? lo : v > hi ? hi : v
+}

--- a/scripts/dataset/io.mjs
+++ b/scripts/dataset/io.mjs
@@ -1,0 +1,38 @@
+// Output helpers: 8-bit PNG writing (via pngjs) and the JSON manifest. The
+// manifest carries the full config and per-sample records but no wall-clock, so
+// dataset content stays reproducible for a given (config, platform).
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { PNG } from 'pngjs'
+
+export function ensureDir(dir) {
+  mkdirSync(dir, { recursive: true })
+}
+
+export function writeRgbaPng(path, img) {
+  const png = new PNG({ width: img.width, height: img.height })
+  png.data = Buffer.from(img.data.buffer, img.data.byteOffset, img.data.byteLength)
+  writeFileSync(path, PNG.sync.write(png))
+}
+
+// Single-channel data written as a gray RGBA PNG for portability.
+export function writeGrayPng(path, gray, width, height) {
+  const png = new PNG({ width, height })
+  for (let i = 0; i < width * height; i++) {
+    const v = gray[i]
+    png.data[i * 4] = v
+    png.data[i * 4 + 1] = v
+    png.data[i * 4 + 2] = v
+    png.data[i * 4 + 3] = 255
+  }
+  writeFileSync(path, PNG.sync.write(png))
+}
+
+export function writeManifest(path, manifest) {
+  writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`)
+}
+
+// Make an id safe as a flat filename.
+export function sanitize(id) {
+  return id.replaceAll(/[^a-zA-Z0-9._-]+/g, '_')
+}

--- a/scripts/dataset/random.mjs
+++ b/scripts/dataset/random.mjs
@@ -1,0 +1,56 @@
+// Seeded pseudo-randomness for reproducible dataset generation. Every draw comes
+// from mulberry32 (Tommy Ettinger, public domain), matching @vectorizer/core, so
+// a (seed, index) pair fully determines a sample and the same config regenerates
+// the same dataset.
+
+export function mulberry32(seed) {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+// FNV-1a → 32-bit unsigned; stable across runs, for deriving seeds and split
+// assignment from string ids.
+export function hashString(str) {
+  let h = 0x811c9dc5
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return h >>> 0
+}
+
+// Knuth multiplicative mix of a base seed and an index into a fresh 32-bit seed.
+export function seedFor(base, index) {
+  return (Math.imul((base ^ index) >>> 0, 2654435761) + 0x9e3779b9) >>> 0
+}
+
+export function uniform(rng, lo, hi) {
+  return lo + (hi - lo) * rng()
+}
+
+// Inclusive integer in [lo, hi].
+export function int(rng, lo, hi) {
+  return lo + Math.floor(rng() * (hi - lo + 1))
+}
+
+export function chance(rng, p) {
+  return rng() < p
+}
+
+export function pick(rng, arr) {
+  return arr[Math.floor(rng() * arr.length)]
+}
+
+// Standard normal via the Box–Muller transform.
+export function gaussian(rng, mean = 0, std = 1) {
+  let u = 0
+  let v = 0
+  while (u === 0) u = rng()
+  while (v === 0) v = rng()
+  return mean + std * Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v)
+}

--- a/scripts/dataset/render.mjs
+++ b/scripts/dataset/render.mjs
@@ -1,0 +1,34 @@
+// Rasterize an SVG to a clean, square RGBA "shape" image (with alpha). Renders at
+// supersample scale for anti-aliasing, applies optional geometric augmentation,
+// then area-downsamples to the target resolution. The shape keeps its alpha so
+// the caller can composite it over a background and derive edge targets from the
+// true outline rather than from background texture.
+
+import { Resvg } from '@resvg/resvg-js'
+import { affineTransform, fitSquare, resizeArea } from './imageops.mjs'
+import { uniform } from './random.mjs'
+
+export function renderShape(svg, cfg, rng) {
+  const side = cfg.resolution * cfg.supersample
+  const resvg = new Resvg(svg, {
+    fitTo: { mode: 'width', value: side },
+    font: { loadSystemFonts: false },
+  })
+  const rendered = resvg.render()
+  const raw = {
+    width: rendered.width,
+    height: rendered.height,
+    data: new Uint8ClampedArray(rendered.pixels),
+  }
+  let img = fitSquare(raw, side)
+  if (cfg.geometric.enabled) {
+    const g = cfg.geometric
+    img = affineTransform(img, {
+      rotateDeg: uniform(rng, -g.rotateDeg, g.rotateDeg),
+      scale: 1 + uniform(rng, -g.scale, g.scale),
+      tx: uniform(rng, -g.translateFrac, g.translateFrac),
+      ty: uniform(rng, -g.translateFrac, g.translateFrac),
+    })
+  }
+  return resizeArea(img, cfg.resolution, cfg.resolution)
+}

--- a/scripts/dataset/sample-worker.mjs
+++ b/scripts/dataset/sample-worker.mjs
@@ -1,0 +1,18 @@
+// Worker thread: receive one item at a time, process it, post the record back.
+// The config is passed once via workerData. An uncaught throw here surfaces as
+// the Worker 'error' event on the main thread, which fails the whole run.
+
+import { parentPort, workerData } from 'node:worker_threads'
+import { processItem } from './sample.mjs'
+
+const cfg = workerData.config
+
+parentPort.on('message', (msg) => {
+  if (msg.type === 'stop') {
+    parentPort.close()
+    return
+  }
+  // worker_threads postMessage takes no targetOrigin (this is not window).
+  // oxlint-disable-next-line unicorn/require-post-message-target-origin
+  parentPort.postMessage({ type: 'record', record: processItem(msg.item, cfg) })
+})

--- a/scripts/dataset/sample.mjs
+++ b/scripts/dataset/sample.mjs
@@ -1,0 +1,44 @@
+// One sample, end to end: render → background → composite → degrade → targets →
+// write. Pure per item — its output depends only on (svg, pipeSeed, cfg), never
+// on order or which thread runs it, so single-threaded and multi-threaded runs
+// produce byte-identical files. Shared by generate.mjs (inline) and the worker.
+
+import { join } from 'node:path'
+import { compositeOver, degrade, makeBackground } from './degrade.mjs'
+import { writeGrayPng, writeRgbaPng } from './io.mjs'
+import { mulberry32 } from './random.mjs'
+import { renderShape } from './render.mjs'
+import { edgeMap } from './targets.mjs'
+
+/**
+ * @param item {{ index, id, family, split, base, svg, pipeSeed }}
+ * @param cfg  resolved DatasetConfig
+ * @returns the manifest record (carries `index` for a stable manifest sort)
+ */
+export function processItem(item, cfg) {
+  const { index, id, family, split, base, svg, pipeSeed } = item
+  // One rng drives render → background → degrade, in that order (matches the
+  // single-threaded sequence exactly).
+  const rng = mulberry32(pipeSeed)
+  const shape = renderShape(svg, cfg, rng)
+  const bg = makeBackground(cfg.resolution, cfg.resolution, rng, cfg.degrade.background)
+  const clean = compositeOver(shape, bg)
+  const input = degrade(clean, cfg, rng)
+
+  writeRgbaPng(join(cfg.out, split, 'input', `${base}.png`), input)
+  const record = { id, family, split, index, input: `${split}/input/${base}.png` }
+  if (cfg.targets.includes('clean')) {
+    writeRgbaPng(join(cfg.out, split, 'clean', `${base}.png`), clean)
+    record.clean = `${split}/clean/${base}.png`
+  }
+  if (cfg.targets.includes('edge')) {
+    writeGrayPng(
+      join(cfg.out, split, 'edge', `${base}.png`),
+      edgeMap(shape),
+      cfg.resolution,
+      cfg.resolution,
+    )
+    record.edge = `${split}/edge/${base}.png`
+  }
+  return record
+}

--- a/scripts/dataset/sources.mjs
+++ b/scripts/dataset/sources.mjs
@@ -5,7 +5,7 @@
 
 import { readdirSync, readFileSync } from 'node:fs'
 import { join, relative, sep } from 'node:path'
-import { chance, gaussian, int, pick, uniform } from './random.mjs'
+import { chance, gaussian, int, mulberry32, pick, seedFor, uniform } from './random.mjs'
 
 const ARCHETYPES = ['geo', 'blobs', 'rings', 'stripes', 'scatter']
 
@@ -17,11 +17,11 @@ const PALETTES = [
   ['#ffffff', '#ffd166', '#06d6a0', '#118ab2', '#073b4c'],
 ]
 
-export function* proceduralSource(count, rngFor) {
-  for (let i = 0; i < count; i++) {
-    const family = ARCHETYPES[i % ARCHETYPES.length]
-    yield { id: `proc-${String(i).padStart(5, '0')}`, family, svg: synthSvg(family, rngFor(i)) }
-  }
+/** One procedural sample by index, fully determined by (index, seed). */
+export function proceduralItem(index, seed) {
+  const family = ARCHETYPES[index % ARCHETYPES.length]
+  const rng = mulberry32(seedFor(seed, index * 2))
+  return { id: `proc-${String(index).padStart(5, '0')}`, family, svg: synthSvg(family, rng) }
 }
 
 export function* dirSource(dir, cap) {

--- a/scripts/dataset/sources.mjs
+++ b/scripts/dataset/sources.mjs
@@ -1,0 +1,123 @@
+// SVG sources. Two are provided: a procedural synthesizer (unlimited, exact
+// control, no assets — the built-in source), and a directory walker for a real
+// corpus (fonts, icon sets, clip art). Each yields { id, family, svg }; `family`
+// drives the train/val/test split so no source family straddles splits.
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import { chance, gaussian, int, pick, uniform } from './random.mjs'
+
+const ARCHETYPES = ['geo', 'blobs', 'rings', 'stripes', 'scatter']
+
+const PALETTES = [
+  ['#1f2933', '#3e4c59', '#7b8794', '#cbd2d9', '#e4e7eb'],
+  ['#0b3954', '#087e8b', '#bfd7ea', '#ff5a5f', '#c81d25'],
+  ['#2b2d42', '#8d99ae', '#edf2f4', '#ef233c', '#d90429'],
+  ['#264653', '#2a9d8f', '#e9c46a', '#f4a261', '#e76f51'],
+  ['#ffffff', '#ffd166', '#06d6a0', '#118ab2', '#073b4c'],
+]
+
+export function* proceduralSource(count, rngFor) {
+  for (let i = 0; i < count; i++) {
+    const family = ARCHETYPES[i % ARCHETYPES.length]
+    yield { id: `proc-${String(i).padStart(5, '0')}`, family, svg: synthSvg(family, rngFor(i)) }
+  }
+}
+
+export function* dirSource(dir, cap) {
+  const files = walkSvg(dir)
+  const list = cap > 0 ? files.slice(0, cap) : files
+  for (const file of list) {
+    const rel = relative(dir, file)
+    yield {
+      id: rel.replaceAll(sep, '/'),
+      family: rel.split(sep)[0] || 'root', // top-level subdir is the source family
+      svg: canonicalize(readFileSync(file, 'utf8')),
+    }
+  }
+}
+
+// Scaffold pass-through. A production pipeline flattens transforms, resolves
+// <use>, and expands shorthand into the @vectorizer/svg path model so targets
+// match engine output; see docs/ML_STRATEGY.md.
+function canonicalize(svg) {
+  return svg
+}
+
+function walkSvg(dir) {
+  const out = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...walkSvg(full))
+    else if (entry.name.toLowerCase().endsWith('.svg')) out.push(full)
+  }
+  return out.toSorted() // stable order → stable ids and split assignment
+}
+
+function synthSvg(family, rng) {
+  const S = 100
+  const palette = pick(rng, PALETTES)
+  const parts = [`<rect width="${S}" height="${S}" fill="${pick(rng, palette)}"/>`]
+  const n = int(rng, 3, 9)
+  for (let k = 0; k < n; k++) parts.push(shape(family, rng, palette, S))
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${S} ${S}">${parts.join('')}</svg>`
+}
+
+function shape(family, rng, palette, S) {
+  const fill = pick(rng, palette)
+  const opacity = chance(rng, 0.25) ? uniform(rng, 0.4, 0.9).toFixed(2) : '1'
+  const cx = uniform(rng, 0, S)
+  const cy = uniform(rng, 0, S)
+  const r = Math.abs(gaussian(rng, S * 0.18, S * 0.1)) + 4
+  const attr = `fill="${fill}" fill-opacity="${opacity}"`
+  switch (family) {
+    case 'rings':
+      return `<circle cx="${f(cx)}" cy="${f(cy)}" r="${f(r)}" fill="none" stroke="${fill}" stroke-width="${f(uniform(rng, 1, 6))}"/>`
+    case 'stripes': {
+      const w = uniform(rng, 4, 16)
+      return `<rect x="${f(cx)}" y="0" width="${f(w)}" height="${S}" ${attr} transform="rotate(${f(uniform(rng, -30, 30))} ${f(cx)} ${f(S / 2)})"/>`
+    }
+    case 'scatter':
+      return `<circle cx="${f(cx)}" cy="${f(cy)}" r="${f(uniform(rng, 1, 5))}" ${attr}/>`
+    case 'blobs':
+      return blob(cx, cy, r, rng, attr)
+    default: {
+      const kind = int(rng, 0, 2)
+      if (kind === 0) return `<circle cx="${f(cx)}" cy="${f(cy)}" r="${f(r)}" ${attr}/>`
+      if (kind === 1) {
+        return `<rect x="${f(cx - r)}" y="${f(cy - r)}" width="${f(r * 2)}" height="${f(r * 1.4)}" rx="${f(uniform(rng, 0, r * 0.4))}" ${attr}/>`
+      }
+      return star(cx, cy, r, int(rng, 3, 7), rng, attr)
+    }
+  }
+}
+
+// Closed polygon around a jittered circle — an irregular organic outline.
+function blob(cx, cy, r, rng, attr) {
+  const n = int(rng, 6, 10)
+  const pts = []
+  for (let i = 0; i < n; i++) {
+    const a = (i / n) * Math.PI * 2
+    const rr = r * uniform(rng, 0.6, 1.3)
+    pts.push(`${f(cx + Math.cos(a) * rr)},${f(cy + Math.sin(a) * rr)}`)
+  }
+  return `<polygon points="${pts.join(' ')}" ${attr}/>`
+}
+
+// n-point star (alternating outer/inner radius).
+function star(cx, cy, r, points, rng, attr) {
+  const inner = r * uniform(rng, 0.35, 0.6)
+  const rot = uniform(rng, 0, Math.PI)
+  const pts = []
+  for (let i = 0; i < points * 2; i++) {
+    const rr = i % 2 === 0 ? r : inner
+    const a = rot + (i / (points * 2)) * Math.PI * 2
+    pts.push(`${f(cx + Math.cos(a) * rr)},${f(cy + Math.sin(a) * rr)}`)
+  }
+  return `<polygon points="${pts.join(' ')}" ${attr}/>`
+}
+
+// Round SVG numbers to keep markup compact.
+function f(x) {
+  return Math.round(x * 100) / 100
+}

--- a/scripts/dataset/targets.mjs
+++ b/scripts/dataset/targets.mjs
@@ -1,0 +1,52 @@
+// Ground-truth derivation. The edge target is a soft boundary map: the maximum
+// Sobel (1968) gradient magnitude across the shape's R, G, B and A channels, so
+// both color boundaries between regions and the silhouette (via the alpha
+// gradient) become edges — exactly the region boundaries crack decomposition
+// consumes. Derived from the clean, pre-degradation shape so labels are exact.
+
+export function edgeMap(shape) {
+  const { width: w, height: h, data } = shape
+  const out = new Uint8ClampedArray(w * h)
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      let maxMag = 0
+      for (let c = 0; c < 4; c++) {
+        const gx = sobelX(data, w, h, x, y, c)
+        const gy = sobelY(data, w, h, x, y, c)
+        const mag = Math.sqrt(gx * gx + gy * gy)
+        if (mag > maxMag) maxMag = mag
+      }
+      // Sobel magnitude peaks near 4*255; scale so a strong edge saturates.
+      out[y * w + x] = (maxMag * 255) / 1020
+    }
+  }
+  return out
+}
+
+function sobelX(d, w, h, x, y, c) {
+  return (
+    -sample(d, w, h, x - 1, y - 1, c) +
+    sample(d, w, h, x + 1, y - 1, c) -
+    2 * sample(d, w, h, x - 1, y, c) +
+    2 * sample(d, w, h, x + 1, y, c) -
+    sample(d, w, h, x - 1, y + 1, c) +
+    sample(d, w, h, x + 1, y + 1, c)
+  )
+}
+
+function sobelY(d, w, h, x, y, c) {
+  return (
+    -sample(d, w, h, x - 1, y - 1, c) -
+    2 * sample(d, w, h, x, y - 1, c) -
+    sample(d, w, h, x + 1, y - 1, c) +
+    sample(d, w, h, x - 1, y + 1, c) +
+    2 * sample(d, w, h, x, y + 1, c) +
+    sample(d, w, h, x + 1, y + 1, c)
+  )
+}
+
+function sample(d, w, h, x, y, c) {
+  const xx = x < 0 ? 0 : x >= w ? w - 1 : x
+  const yy = y < 0 ? 0 : y >= h ? h - 1 : y
+  return d[(yy * w + xx) * 4 + c]
+}

--- a/scripts/train/README.md
+++ b/scripts/train/README.md
@@ -1,0 +1,87 @@
+# Training the edge pre-pass model
+
+Offline PyTorch training for the on-device edge pre-pass ([`../../docs/EDGE_PREPASS.md`](../../docs/EDGE_PREPASS.md)).
+It reads the dataset from [`../dataset`](../dataset/README.md), trains a compact U-Net, and exports an ONNX model that
+drops straight into the app at `apps/web/public/models/edge-prepass.onnx` (served same-origin — see
+[`../../apps/web/public/models/README.md`](../../apps/web/public/models/README.md)).
+
+These scripts are **not part of the JS build or CI** — they run only when you train. The weights are not committed;
+you generate them here and drop the `.onnx` in place.
+
+## Setup (Windows / macOS / Linux)
+
+From the repo root. First make sure the JS deps are installed (`npm install`) — the data step uses `npm run dataset`.
+
+Create and activate a virtualenv:
+
+```powershell
+# Windows (PowerShell)
+py -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+```sh
+# macOS / Linux
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install PyTorch for your GPU, then the rest. Pick the CUDA build that matches your driver from
+<https://pytorch.org/get-started/locally/> — for example:
+
+```sh
+pip install torch --index-url https://download.pytorch.org/whl/cu124
+pip install -r scripts/train/requirements.txt
+```
+
+(No GPU? Just `pip install -r scripts/train/requirements.txt` — it works on CPU, only slower. The scripts auto-detect
+CUDA and use it when present.)
+
+## One command
+
+```sh
+python scripts/train/pipeline.py --count 20000 --epochs 40 --quantize
+```
+
+This generates the dataset, trains, and writes `apps/web/public/models/edge-prepass.onnx`. Add `--workers 8` to speed up
+data loading (leave it at the default `0` if you hit a multiprocessing error on Windows). Reuse an existing dataset with
+`--data dataset-out --skip-data`.
+
+## Or step by step
+
+```sh
+# 1. data  (→ dataset-out/, see ../dataset/README.md)
+npm run dataset -- --count 20000 --out dataset-out
+
+# 2. train (auto-uses your GPU; best checkpoint → scripts/train/checkpoints/edge-prepass.pt)
+python scripts/train/train.py --data dataset-out --epochs 40 --batch 32 --workers 8
+
+# 3. export (→ apps/web/public/models/edge-prepass.onnx, with a torch/onnx parity check)
+python scripts/train/export_onnx.py --quantize
+```
+
+## What each file does
+
+| File               | Role                                                                           |
+| ------------------ | ------------------------------------------------------------------------------ |
+| `pipeline.py`      | one-shot: data → train → export (cross-platform)                               |
+| `dataset.py`       | reads the generator manifest; input normalization matches EdgeEnhancer exactly |
+| `model.py`         | `TinyUNet` (compact U-Net) + the sigmoid export wrapper                        |
+| `losses.py`        | class-balanced BCE (HED-style) + soft Dice                                     |
+| `train.py`         | training loop (AdamW + cosine), val F-score, best-checkpoint saving            |
+| `export_onnx.py`   | ONNX export + torch/onnxruntime parity check + optional int8 quantization      |
+| `requirements.txt` | Python deps                                                                    |
+
+## Tuning
+
+- **Model size / quality:** `--base-channels` (default 16). Smaller (8) → smaller file, less capacity; larger (24–32) →
+  more capacity. Keep the exported file within the **< 5 MB** budget from the spec (use `--quantize`).
+- **Data:** start with the procedural source for volume; add real SVGs via `npm run dataset -- --source dir --corpus
+  <dir>` and regenerate. ~20k pairs to prototype, 50k–200k for production.
+- **Input size** is fixed at 256 (matches EdgeEnhancer's model input); the app tiles larger images at run time.
+- **Determinism:** `dataset.py` uses the same ImageNet mean/std as `packNchw` in `@vectorizer/ml`, and the export bakes
+  in the sigmoid, so the browser sees exactly what you trained. Verify before shipping — `export_onnx.py` asserts
+  torch/onnxruntime parity.
+
+Once `apps/web/public/models/edge-prepass.onnx` exists, `EdgeEnhancer.create()` will load it; until then it fails soft
+and the app traces classically.

--- a/scripts/train/README.md
+++ b/scripts/train/README.md
@@ -72,6 +72,17 @@ pip install -r scripts/train/requirements.txt
 
 ## One command
 
+First, on a new machine, run the **sanity check** — it exercises the whole chain (data-gen → train → ONNX export +
+parity) with a tiny throwaway config in ~30s on CPU, writing to the gitignored `checkpoints/smoke/` dir, never the
+shipped model. If it prints `smoke OK`, your toolchain works:
+
+```sh
+python scripts/train/pipeline.py --smoke                 # edge
+python scripts/train/pipeline.py --task cleanup --smoke  # cleanup
+```
+
+Then the real run:
+
 ```sh
 python scripts/train/pipeline.py --count 20000 --epochs 60 --quantize            # edge (default)
 python scripts/train/pipeline.py --task cleanup --count 20000 --epochs 60 --quantize

--- a/scripts/train/README.md
+++ b/scripts/train/README.md
@@ -105,6 +105,11 @@ export glyphs to per-file SVGs. Splits are per source family in each root, so fa
   val loss plateaus. `--patience 0` disables it.
 - **`--batch` / `--lr`** — batch as large as your VRAM allows (32–64); keep `--lr 3e-4` (AdamW). Doubling the batch, you
   can raise lr ~1.4×.
+- **Parallelism / hardware** — the model math runs on your GPU automatically (or across all CPU cores via PyTorch's
+  intra-op threads if there's no GPU). `--workers N` parallelizes CPU-side data loading (PNG decode + normalize) to keep
+  the GPU fed — set it near your core count; it defaults to `0` (safe on Windows), and `pin_memory` / `persistent_workers`
+  enable automatically. The dataset-generation step is separately multithreaded (`npm run dataset -- --jobs N`, default:
+  CPU count).
 - **Domain gap (the usual culprit)** — if the model scores well on val but poorly in the app on real photos, the fix is
   usually _more degradation_, not a bigger model: raise `noiseStdMax` / `blurSigmaMax` and lower `jpegQuality.min` in
   [`../dataset/config.mjs`](../dataset/README.md) and regenerate.

--- a/scripts/train/README.md
+++ b/scripts/train/README.md
@@ -1,9 +1,16 @@
-# Training the edge pre-pass model
+# Training the on-device pre-pass models
 
-Offline PyTorch training for the on-device edge pre-pass ([`../../docs/EDGE_PREPASS.md`](../../docs/EDGE_PREPASS.md)).
-It reads the dataset from [`../dataset`](../dataset/README.md), trains a compact U-Net, and exports an ONNX model that
-drops straight into the app at `apps/web/public/models/edge-prepass.onnx` (served same-origin — see
+Offline PyTorch training for the app's on-device pre-pass models. It reads the dataset from
+[`../dataset`](../dataset/README.md), trains a compact U-Net, and exports an ONNX model that drops straight into the app
+under `apps/web/public/models/` (served same-origin — see
 [`../../apps/web/public/models/README.md`](../../apps/web/public/models/README.md)).
+
+Two tasks share this scaffold, selected with `--task` (one generated dataset trains either — it carries both targets):
+
+| `--task`         | predicts               | target  | ships as            | spec                                                  |
+| ---------------- | ---------------------- | ------- | ------------------- | ----------------------------------------------------- |
+| `edge` (default) | boundary map (1-ch)    | `edge`  | `edge-prepass.onnx` | [`EDGE_PREPASS.md`](../../docs/EDGE_PREPASS.md)       |
+| `cleanup`        | clean RGB image (3-ch) | `clean` | `cleanup.onnx`      | [`CLEANUP_PREPASS.md`](../../docs/CLEANUP_PREPASS.md) |
 
 These scripts are **not part of the JS build or CI** — they run only when you train. The weights are not committed;
 you generate them here and drop the `.onnx` in place.
@@ -40,37 +47,41 @@ CUDA and use it when present.)
 ## One command
 
 ```sh
-python scripts/train/pipeline.py --count 20000 --epochs 60 --quantize
+python scripts/train/pipeline.py --count 20000 --epochs 60 --quantize            # edge (default)
+python scripts/train/pipeline.py --task cleanup --count 20000 --epochs 60 --quantize
 ```
 
-This generates the dataset, trains, and writes `apps/web/public/models/edge-prepass.onnx`. Add `--workers 8` to speed up
+This generates the dataset, trains, and writes `apps/web/public/models/<task>.onnx`. Add `--workers 8` to speed up
 data loading (leave it at the default `0` if you hit a multiprocessing error on Windows). Reuse an existing dataset with
-`--data dataset-out --skip-data`.
+`--data dataset-out --skip-data` — the same set trains both tasks, so generate once and run the two commands with
+`--skip-data`.
 
 ## Or step by step
 
 ```sh
-# 1. data  (→ dataset-out/, see ../dataset/README.md)
+# 1. data  (→ dataset-out/, see ../dataset/README.md; carries both edge + clean targets)
 npm run dataset -- --count 20000 --out dataset-out
 
 # 2. train (auto-uses your GPU; --data accepts several roots to mix; best → scripts/train/checkpoints/)
-python scripts/train/train.py --data dataset-out --epochs 80 --batch 32 --workers 8
+python scripts/train/train.py --task edge --data dataset-out --epochs 80 --batch 32 --workers 8
 
-# 3. export (→ apps/web/public/models/edge-prepass.onnx, with a torch/onnx parity check)
-python scripts/train/export_onnx.py --quantize
+# 3. export (→ apps/web/public/models/<task>.onnx, with a torch/onnx parity check)
+python scripts/train/export_onnx.py --task edge --quantize
 ```
+
+For the cleanup model, pass `--task cleanup` to steps 2 and 3 (reusing the same `dataset-out`).
 
 ## What each file does
 
-| File               | Role                                                                           |
-| ------------------ | ------------------------------------------------------------------------------ |
-| `pipeline.py`      | one-shot: data → train → export (cross-platform)                               |
-| `dataset.py`       | reads the generator manifest; input normalization matches EdgeEnhancer exactly |
-| `model.py`         | `TinyUNet` (compact U-Net) + the sigmoid export wrapper                        |
-| `losses.py`        | class-balanced BCE (HED-style) + soft Dice                                     |
-| `train.py`         | training loop (AdamW + cosine), val F-score, early stopping, preview montage   |
-| `export_onnx.py`   | ONNX export + torch/onnxruntime parity check + optional int8 quantization      |
-| `requirements.txt` | Python deps                                                                    |
+| File               | Role                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| `pipeline.py`      | one-shot: data → train → export (cross-platform), `--task` aware                           |
+| `dataset.py`       | reads the generator manifest; input normalization matches Edge/CleanupEnhancer exactly     |
+| `model.py`         | `TinyUNet` (compact U-Net, `out_channels` per task) + the sigmoid export wrapper           |
+| `losses.py`        | edge: class-balanced BCE (HED-style) + soft Dice · cleanup: L1                             |
+| `train.py`         | training loop (AdamW + cosine), val F-score / PSNR, early stopping, preview montage        |
+| `export_onnx.py`   | ONNX export + torch/onnxruntime parity check + optional int8 quantization (`--task` aware) |
+| `requirements.txt` | Python deps                                                                                |
 
 ## Recipes & tuning
 
@@ -116,12 +127,14 @@ export glyphs to per-file SVGs. Splits are per source family in each root, so fa
 
 ### Reading the run
 
-- **train / val loss** should fall then plateau; **val F** (an ODS-like edge F-score, a proxy) should rise.
-- **`checkpoints/preview.png`** is written on every improvement — columns are **input · prediction · target** for a few
-  val samples. Smeared predictions → add capacity or data; missed faint boundaries → increase contrast/degradation
+- **train / val loss** should fall then plateau; the val proxy metric rises — **val F** (an ODS-like edge F-score) for
+  `edge`, **val PSNR** (dB) for `cleanup`.
+- **`checkpoints/preview-<task>.png`** is written on every improvement — columns are **input · prediction · target** for
+  a few val samples. Smeared predictions → add capacity or data; missed faint boundaries → increase contrast/degradation
   variety in the data.
-- **The real metric is the app's Oklab ΔE.** Once the ONNX is in place, toggle **Edge pre-pass** on a few noisy B&W
-  inputs and compare ΔE / node count against off — that, not val F, is what ships.
+- **The real metric is the app's Oklab ΔE.** Once the ONNX is in place, use the tool it feeds (**Edge pre-pass** toggle,
+  or **Clean up (ML)** button) on a few noisy inputs and compare ΔE / node count against off — that, not the val proxy,
+  is what ships.
 
 ### Determinism
 
@@ -129,5 +142,5 @@ export glyphs to per-file SVGs. Splits are per source family in each root, so fa
 tiles larger images at run time), and the export bakes in the sigmoid — so the browser sees exactly what you trained.
 `export_onnx.py` asserts torch/onnxruntime parity before you ship.
 
-Once `apps/web/public/models/edge-prepass.onnx` exists, `EdgeEnhancer.create()` loads it; until then it fails soft and
-the app traces classically.
+Once `apps/web/public/models/<task>.onnx` exists, the matching class (`EdgeEnhancer` / `CleanupEnhancer`) loads it; until
+then it fails soft and the app traces classically (or leaves the image untouched).

--- a/scripts/train/README.md
+++ b/scripts/train/README.md
@@ -40,7 +40,7 @@ CUDA and use it when present.)
 ## One command
 
 ```sh
-python scripts/train/pipeline.py --count 20000 --epochs 40 --quantize
+python scripts/train/pipeline.py --count 20000 --epochs 60 --quantize
 ```
 
 This generates the dataset, trains, and writes `apps/web/public/models/edge-prepass.onnx`. Add `--workers 8` to speed up
@@ -53,8 +53,8 @@ data loading (leave it at the default `0` if you hit a multiprocessing error on 
 # 1. data  (→ dataset-out/, see ../dataset/README.md)
 npm run dataset -- --count 20000 --out dataset-out
 
-# 2. train (auto-uses your GPU; best checkpoint → scripts/train/checkpoints/edge-prepass.pt)
-python scripts/train/train.py --data dataset-out --epochs 40 --batch 32 --workers 8
+# 2. train (auto-uses your GPU; --data accepts several roots to mix; best → scripts/train/checkpoints/)
+python scripts/train/train.py --data dataset-out --epochs 80 --batch 32 --workers 8
 
 # 3. export (→ apps/web/public/models/edge-prepass.onnx, with a torch/onnx parity check)
 python scripts/train/export_onnx.py --quantize
@@ -68,20 +68,61 @@ python scripts/train/export_onnx.py --quantize
 | `dataset.py`       | reads the generator manifest; input normalization matches EdgeEnhancer exactly |
 | `model.py`         | `TinyUNet` (compact U-Net) + the sigmoid export wrapper                        |
 | `losses.py`        | class-balanced BCE (HED-style) + soft Dice                                     |
-| `train.py`         | training loop (AdamW + cosine), val F-score, best-checkpoint saving            |
+| `train.py`         | training loop (AdamW + cosine), val F-score, early stopping, preview montage   |
 | `export_onnx.py`   | ONNX export + torch/onnxruntime parity check + optional int8 quantization      |
 | `requirements.txt` | Python deps                                                                    |
 
-## Tuning
+## Recipes & tuning
 
-- **Model size / quality:** `--base-channels` (default 16). Smaller (8) → smaller file, less capacity; larger (24–32) →
-  more capacity. Keep the exported file within the **< 5 MB** budget from the spec (use `--quantize`).
-- **Data:** start with the procedural source for volume; add real SVGs via `npm run dataset -- --source dir --corpus
-  <dir>` and regenerate. ~20k pairs to prototype, 50k–200k for production.
-- **Input size** is fixed at 256 (matches EdgeEnhancer's model input); the app tiles larger images at run time.
-- **Determinism:** `dataset.py` uses the same ImageNet mean/std as `packNchw` in `@vectorizer/ml`, and the export bakes
-  in the sigmoid, so the browser sees exactly what you trained. Verify before shipping — `export_onnx.py` asserts
-  torch/onnxruntime parity.
+Start here, then adjust from what you see. Sizes are pairs (per `--count`).
 
-Once `apps/web/public/models/edge-prepass.onnx` exists, `EdgeEnhancer.create()` will load it; until then it fails soft
-and the app traces classically.
+| Goal                       | count    | base-channels | epochs (with `--patience 10`) | batch |
+| -------------------------- | -------- | ------------- | ----------------------------- | ----- |
+| Prototype (does it learn?) | 5k–20k   | 16            | 60                            | 32    |
+| Production                 | 50k–200k | 16–24         | 80                            | 32–64 |
+| Tiny file                  | 50k+     | 8–12          | 80                            | 32    |
+
+### Data mix (the highest-leverage knob)
+
+Train on both a **procedural** set (unlimited, exact labels — prevents overfitting) and a **real corpus** (fonts, icon
+sets — realistic shapes). `--data` takes several roots and concatenates them:
+
+```sh
+npm run dataset -- --source procedural --count 40000 --out data/proc
+npm run dataset -- --source dir --corpus /path/to/svgs --count 20000 --out data/real
+python scripts/train/train.py --data data/proc data/real --epochs 80 --workers 8
+```
+
+Rule of thumb: **~⅔ procedural + ~⅓ real**, adding more real as you collect it. Fonts are the easiest real source —
+export glyphs to per-file SVGs. Splits are per source family in each root, so families never leak across train/val/test.
+
+### The knobs
+
+- **`--base-channels`** — model width, hence size and capacity. 16 is a good default. Bump to 24 if predictions look
+  blurry or miss thin edges (and you have the data); drop to 8–12 if the ONNX must be tiny. Keep it **< 5 MB** with
+  `--quantize`.
+- **Epochs / early stopping** — don't hand-tune epochs: set a generous `--epochs 80` and let `--patience 10` stop when
+  val loss plateaus. `--patience 0` disables it.
+- **`--batch` / `--lr`** — batch as large as your VRAM allows (32–64); keep `--lr 3e-4` (AdamW). Doubling the batch, you
+  can raise lr ~1.4×.
+- **Domain gap (the usual culprit)** — if the model scores well on val but poorly in the app on real photos, the fix is
+  usually _more degradation_, not a bigger model: raise `noiseStdMax` / `blurSigmaMax` and lower `jpegQuality.min` in
+  [`../dataset/config.mjs`](../dataset/README.md) and regenerate.
+
+### Reading the run
+
+- **train / val loss** should fall then plateau; **val F** (an ODS-like edge F-score, a proxy) should rise.
+- **`checkpoints/preview.png`** is written on every improvement — columns are **input · prediction · target** for a few
+  val samples. Smeared predictions → add capacity or data; missed faint boundaries → increase contrast/degradation
+  variety in the data.
+- **The real metric is the app's Oklab ΔE.** Once the ONNX is in place, toggle **Edge pre-pass** on a few noisy B&W
+  inputs and compare ΔE / node count against off — that, not val F, is what ships.
+
+### Determinism
+
+`dataset.py` uses the same ImageNet mean/std as `packNchw` in `@vectorizer/ml`, input size is fixed at 256 (the app
+tiles larger images at run time), and the export bakes in the sigmoid — so the browser sees exactly what you trained.
+`export_onnx.py` asserts torch/onnxruntime parity before you ship.
+
+Once `apps/web/public/models/edge-prepass.onnx` exists, `EdgeEnhancer.create()` loads it; until then it fails soft and
+the app traces classically.

--- a/scripts/train/README.md
+++ b/scripts/train/README.md
@@ -15,34 +15,60 @@ Two tasks share this scaffold, selected with `--task` (one generated dataset tra
 These scripts are **not part of the JS build or CI** — they run only when you train. The weights are not committed;
 you generate them here and drop the `.onnx` in place.
 
-## Setup (Windows / macOS / Linux)
+## From scratch
 
-From the repo root. First make sure the JS deps are installed (`npm install`) — the data step uses `npm run dataset`.
+You need three things on the machine, then one bootstrap command. Everything runs from the **repo root** and installs
+nothing globally — the Python side lives entirely in a local `.venv`.
 
-Create and activate a virtualenv:
+### Prerequisites (both platforms)
+
+1. **Node 18+** and the repo's JS deps — the data step is `npm run dataset`:
+   ```sh
+   npm install
+   ```
+2. **Python 3.10+** — [python.org](https://www.python.org/downloads/) (on Windows, tick _“Add python.exe to PATH”_).
+3. **For GPU training, an NVIDIA GPU + driver.** Install/refresh the driver from
+   [nvidia.com/Download](https://www.nvidia.com/Download/index.aspx), then confirm the toolchain sees it:
+   ```sh
+   nvidia-smi          # prints your GPU + the max CUDA version the driver supports
+   ```
+   No GPU is fine — training falls back to CPU automatically (slower). You do **not** need the full CUDA Toolkit; the
+   PyTorch CUDA wheel bundles what it needs.
+
+### Bootstrap the Python env
+
+One script creates `.venv` and installs PyTorch + the training deps into it.
 
 ```powershell
-# Windows (PowerShell)
-py -m venv .venv
-.\.venv\Scripts\Activate.ps1
+# Windows (PowerShell), from the repo root
+.\scripts\train\setup.ps1 -Cuda cu124   # GPU: use the cuXXX tag ≤ the CUDA version nvidia-smi printed
+.\scripts\train\setup.ps1               # CPU-only (omit -Cuda)
 ```
 
 ```sh
-# macOS / Linux
-python3 -m venv .venv
-source .venv/bin/activate
+# Linux / macOS, from the repo root
+sh scripts/train/setup.sh --cuda cu124   # pin a specific CUDA build (e.g. an older driver)
+sh scripts/train/setup.sh                # default wheel: CUDA-enabled on Linux, CPU on macOS
 ```
 
-Install PyTorch for your GPU, then the rest. Pick the CUDA build that matches your driver from
-<https://pytorch.org/get-started/locally/> — for example:
+Pick the `cuXXX` tag from <https://pytorch.org/get-started/locally/> (e.g. `cu121`, `cu124`) — it must be **≤** the CUDA
+version `nvidia-smi` reported. The script prints `CUDA available: True` and your device name when the GPU is wired up
+correctly; if it says `False` after a `-Cuda`/`--cuda` install, the tag is wrong for your driver — re-run with a lower one.
+
+> **Windows execution-policy note:** the bootstrap calls the venv's Python directly, so it works as-is. Only _activating_
+> the venv (`.\.venv\Scripts\Activate.ps1`) can hit _“running scripts is disabled on this system”_ — either run this once,
+> `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`, or skip activation and call `.venv\Scripts\python.exe` directly
+> (the commands below show both).
+
+### Manual alternative
+
+If you'd rather not use the bootstrap script:
 
 ```sh
-pip install torch --index-url https://download.pytorch.org/whl/cu124
+python3 -m venv .venv && . .venv/bin/activate            # Windows: py -m venv .venv ; .\.venv\Scripts\Activate.ps1
+pip install torch --index-url https://download.pytorch.org/whl/cu124   # GPU only; skip for CPU
 pip install -r scripts/train/requirements.txt
 ```
-
-(No GPU? Just `pip install -r scripts/train/requirements.txt` — it works on CPU, only slower. The scripts auto-detect
-CUDA and use it when present.)
 
 ## One command
 
@@ -55,6 +81,9 @@ This generates the dataset, trains, and writes `apps/web/public/models/<task>.on
 data loading (leave it at the default `0` if you hit a multiprocessing error on Windows). Reuse an existing dataset with
 `--data dataset-out --skip-data` — the same set trains both tasks, so generate once and run the two commands with
 `--skip-data`.
+
+The examples assume the venv is activated. If you skipped activation (see the note above), just call the venv's Python:
+`.venv/bin/python …` on Linux/macOS, `.venv\Scripts\python.exe …` on Windows.
 
 ## Or step by step
 
@@ -75,6 +104,8 @@ For the cleanup model, pass `--task cleanup` to steps 2 and 3 (reusing the same 
 
 | File               | Role                                                                                       |
 | ------------------ | ------------------------------------------------------------------------------------------ |
+| `setup.sh`         | bootstrap the `.venv` + deps (Linux / macOS), optional `--cuda cuXXX`                      |
+| `setup.ps1`        | bootstrap the `.venv` + deps (Windows), optional `-Cuda cuXXX`                             |
 | `pipeline.py`      | one-shot: data → train → export (cross-platform), `--task` aware                           |
 | `dataset.py`       | reads the generator manifest; input normalization matches Edge/CleanupEnhancer exactly     |
 | `model.py`         | `TinyUNet` (compact U-Net, `out_channels` per task) + the sigmoid export wrapper           |

--- a/scripts/train/dataset.py
+++ b/scripts/train/dataset.py
@@ -1,0 +1,52 @@
+"""Torch dataset over the generator's output (scripts/dataset).
+
+Reads `manifest.json` and yields (input, edge-target) tensors for one split. The
+input normalization matches EdgeEnhancer / packNchw (packages/ml/src/imageops.ts)
+exactly — same ImageNet mean/std on [0,1] RGB — so a model trained here behaves
+the same way in the browser.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+# Must match packNchw in packages/ml/src/imageops.ts.
+IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+
+
+class EdgeDataset(Dataset):
+    def __init__(self, root: str | Path, split: str, size: int = 256, limit: int = 0) -> None:
+        self.root = Path(root)
+        manifest = json.loads((self.root / "manifest.json").read_text())
+        samples = [s for s in manifest["samples"] if s["split"] == split and s.get("edge")]
+        self.samples = samples[:limit] if limit > 0 else samples
+        self.size = size
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def _load_rgb(self, rel: str) -> np.ndarray:
+        img = Image.open(self.root / rel).convert("RGB")
+        if img.size != (self.size, self.size):
+            img = img.resize((self.size, self.size), Image.BILINEAR)
+        x = np.asarray(img, dtype=np.float32) / 255.0
+        x = (x - IMAGENET_MEAN) / IMAGENET_STD
+        return np.ascontiguousarray(x.transpose(2, 0, 1))  # CHW
+
+    def _load_edge(self, rel: str) -> np.ndarray:
+        img = Image.open(self.root / rel).convert("L")
+        if img.size != (self.size, self.size):
+            img = img.resize((self.size, self.size), Image.BILINEAR)
+        y = np.asarray(img, dtype=np.float32) / 255.0
+        return y[None, ...]  # 1HW
+
+    def __getitem__(self, i: int) -> tuple[torch.Tensor, torch.Tensor]:
+        s = self.samples[i]
+        return torch.from_numpy(self._load_rgb(s["input"])), torch.from_numpy(self._load_edge(s["edge"]))

--- a/scripts/train/dataset.py
+++ b/scripts/train/dataset.py
@@ -1,9 +1,10 @@
 """Torch dataset over the generator's output (scripts/dataset).
 
-Reads `manifest.json` and yields (input, edge-target) tensors for one split. The
-input normalization matches EdgeEnhancer / packNchw (packages/ml/src/imageops.ts)
-exactly — same ImageNet mean/std on [0,1] RGB — so a model trained here behaves
-the same way in the browser.
+Reads one or more `manifest.json` roots and yields (input, edge-target) tensors
+for a split, concatenated — so a procedural set and a real-corpus set can be
+mixed in one training run (`--data proc real`). The input normalization matches
+EdgeEnhancer / packNchw (packages/ml/src/imageops.ts) exactly, so a model
+trained here behaves the same in the browser.
 """
 
 from __future__ import annotations
@@ -22,31 +23,48 @@ IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
 
 
 class EdgeDataset(Dataset):
-    def __init__(self, root: str | Path, split: str, size: int = 256, limit: int = 0) -> None:
-        self.root = Path(root)
-        manifest = json.loads((self.root / "manifest.json").read_text())
-        samples = [s for s in manifest["samples"] if s["split"] == split and s.get("edge")]
-        self.samples = samples[:limit] if limit > 0 else samples
+    def __init__(
+        self,
+        roots: str | Path | list[str | Path],
+        split: str,
+        size: int = 256,
+        limit: int = 0,
+    ) -> None:
+        if isinstance(roots, (str, Path)):
+            roots = [roots]
         self.size = size
+        # Each sample remembers its own root so paths resolve across mixed sets.
+        self.samples: list[tuple[Path, dict]] = []
+        for r in roots:
+            root = Path(r)
+            manifest = json.loads((root / "manifest.json").read_text())
+            for s in manifest["samples"]:
+                if s["split"] == split and s.get("edge"):
+                    self.samples.append((root, s))
+        if limit > 0:
+            self.samples = self.samples[:limit]
 
     def __len__(self) -> int:
         return len(self.samples)
 
-    def _load_rgb(self, rel: str) -> np.ndarray:
-        img = Image.open(self.root / rel).convert("RGB")
+    def _load_rgb(self, root: Path, rel: str) -> np.ndarray:
+        img = Image.open(root / rel).convert("RGB")
         if img.size != (self.size, self.size):
             img = img.resize((self.size, self.size), Image.BILINEAR)
         x = np.asarray(img, dtype=np.float32) / 255.0
         x = (x - IMAGENET_MEAN) / IMAGENET_STD
         return np.ascontiguousarray(x.transpose(2, 0, 1))  # CHW
 
-    def _load_edge(self, rel: str) -> np.ndarray:
-        img = Image.open(self.root / rel).convert("L")
+    def _load_edge(self, root: Path, rel: str) -> np.ndarray:
+        img = Image.open(root / rel).convert("L")
         if img.size != (self.size, self.size):
             img = img.resize((self.size, self.size), Image.BILINEAR)
         y = np.asarray(img, dtype=np.float32) / 255.0
         return y[None, ...]  # 1HW
 
     def __getitem__(self, i: int) -> tuple[torch.Tensor, torch.Tensor]:
-        s = self.samples[i]
-        return torch.from_numpy(self._load_rgb(s["input"])), torch.from_numpy(self._load_edge(s["edge"]))
+        root, s = self.samples[i]
+        return (
+            torch.from_numpy(self._load_rgb(root, s["input"])),
+            torch.from_numpy(self._load_edge(root, s["edge"])),
+        )

--- a/scripts/train/dataset.py
+++ b/scripts/train/dataset.py
@@ -1,10 +1,14 @@
 """Torch dataset over the generator's output (scripts/dataset).
 
-Reads one or more `manifest.json` roots and yields (input, edge-target) tensors
-for a split, concatenated — so a procedural set and a real-corpus set can be
-mixed in one training run (`--data proc real`). The input normalization matches
-EdgeEnhancer / packNchw (packages/ml/src/imageops.ts) exactly, so a model
-trained here behaves the same in the browser.
+Reads one or more `manifest.json` roots and yields (input, target) tensors for a
+split, concatenated — so a procedural set and a real-corpus set can be mixed in
+one training run (`--data proc real`). The input normalization matches
+EdgeEnhancer / CleanupEnhancer / packNchw (packages/ml/src/imageops.ts) exactly,
+so a model trained here behaves the same in the browser.
+
+Two tasks:
+- edge: target is the 1-channel boundary map (`edge` field), [0,1].
+- cleanup: target is the 3-channel clean render (`clean` field), [0,1] RGB.
 """
 
 from __future__ import annotations
@@ -21,25 +25,33 @@ from torch.utils.data import Dataset
 IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
 IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
 
+# Manifest field carrying each task's ground-truth image.
+TARGET_FIELD = {"edge": "edge", "cleanup": "clean"}
 
-class EdgeDataset(Dataset):
+
+class PrepassDataset(Dataset):
     def __init__(
         self,
         roots: str | Path | list[str | Path],
         split: str,
         size: int = 256,
         limit: int = 0,
+        task: str = "edge",
     ) -> None:
+        if task not in TARGET_FIELD:
+            raise ValueError(f"unknown task {task!r} (expected one of {sorted(TARGET_FIELD)})")
         if isinstance(roots, (str, Path)):
             roots = [roots]
         self.size = size
+        self.task = task
+        self.field = TARGET_FIELD[task]
         # Each sample remembers its own root so paths resolve across mixed sets.
         self.samples: list[tuple[Path, dict]] = []
         for r in roots:
             root = Path(r)
             manifest = json.loads((root / "manifest.json").read_text())
             for s in manifest["samples"]:
-                if s["split"] == split and s.get("edge"):
+                if s["split"] == split and s.get(self.field):
                     self.samples.append((root, s))
         if limit > 0:
             self.samples = self.samples[:limit]
@@ -55,7 +67,15 @@ class EdgeDataset(Dataset):
         x = (x - IMAGENET_MEAN) / IMAGENET_STD
         return np.ascontiguousarray(x.transpose(2, 0, 1))  # CHW
 
-    def _load_edge(self, root: Path, rel: str) -> np.ndarray:
+    def _load_target(self, root: Path, rel: str) -> np.ndarray:
+        if self.task == "cleanup":
+            # Clean RGB target in [0,1], no ImageNet normalization (the model's
+            # sigmoid output lives in [0,1]).
+            img = Image.open(root / rel).convert("RGB")
+            if img.size != (self.size, self.size):
+                img = img.resize((self.size, self.size), Image.BILINEAR)
+            y = np.asarray(img, dtype=np.float32) / 255.0
+            return np.ascontiguousarray(y.transpose(2, 0, 1))  # 3HW
         img = Image.open(root / rel).convert("L")
         if img.size != (self.size, self.size):
             img = img.resize((self.size, self.size), Image.BILINEAR)
@@ -66,5 +86,9 @@ class EdgeDataset(Dataset):
         root, s = self.samples[i]
         return (
             torch.from_numpy(self._load_rgb(root, s["input"])),
-            torch.from_numpy(self._load_edge(root, s["edge"])),
+            torch.from_numpy(self._load_target(root, s[self.field])),
         )
+
+
+# Back-compat alias (the edge task's original name).
+EdgeDataset = PrepassDataset

--- a/scripts/train/export_onnx.py
+++ b/scripts/train/export_onnx.py
@@ -1,8 +1,11 @@
-"""Export a trained checkpoint to ONNX for EdgeEnhancer (packages/ml/src/edge.ts).
+"""Export a trained checkpoint to ONNX for the on-device pre-pass models.
 
-Produces a fixed [1,3,size,size] → [1,1,size,size] sigmoid model, verifies
-torch/onnxruntime parity, and (optionally) quantizes to int8. Drop the result at
-apps/web/public/models/edge-prepass.onnx to ship it same-origin with the app.
+Produces a fixed [1,3,size,size] → [1,C,size,size] sigmoid model (C=1 edge,
+C=3 cleanup), verifies torch/onnxruntime parity, and (optionally) quantizes to
+int8. Drop the result at apps/web/public/models/<name>.onnx to ship it
+same-origin with the app:
+- edge → edge-prepass.onnx   (EdgeEnhancer, packages/ml/src/edge.ts)
+- cleanup → cleanup.onnx      (CleanupEnhancer, packages/ml/src/cleanup.ts)
 """
 
 from __future__ import annotations
@@ -15,11 +18,22 @@ import torch
 
 from model import SigmoidWrapper, TinyUNet
 
+# Default ship path per task.
+DEFAULT_OUT = {
+    "edge": "apps/web/public/models/edge-prepass.onnx",
+    "cleanup": "apps/web/public/models/cleanup.onnx",
+}
+DEFAULT_CHECKPOINT = {
+    "edge": "scripts/train/checkpoints/edge-prepass.pt",
+    "cleanup": "scripts/train/checkpoints/cleanup.pt",
+}
+
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Export the edge pre-pass model to ONNX.")
-    p.add_argument("--checkpoint", default="scripts/train/checkpoints/edge-prepass.pt")
-    p.add_argument("--out", default="apps/web/public/models/edge-prepass.onnx")
+    p = argparse.ArgumentParser(description="Export a pre-pass model to ONNX.")
+    p.add_argument("--task", choices=sorted(DEFAULT_OUT), default="edge")
+    p.add_argument("--checkpoint", default=None, help="default: per-task checkpoint")
+    p.add_argument("--out", default=None, help="default: per-task ship path")
     p.add_argument("--opset", type=int, default=17)
     p.add_argument("--quantize", action="store_true", help="also emit an int8 .onnx (smaller)")
     return p.parse_args()
@@ -27,13 +41,16 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    ckpt = torch.load(args.checkpoint, map_location="cpu")
+    checkpoint = args.checkpoint or DEFAULT_CHECKPOINT[args.task]
+    out = Path(args.out or DEFAULT_OUT[args.task])
+
+    ckpt = torch.load(checkpoint, map_location="cpu")
     size = ckpt["size"]
-    model = TinyUNet(ckpt["base_channels"])
+    out_channels = ckpt.get("out_channels", 1)  # older edge checkpoints predate this
+    model = TinyUNet(ckpt["base_channels"], out_channels=out_channels)
     model.load_state_dict(ckpt["state_dict"])
     export_model = SigmoidWrapper(model).eval()
 
-    out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
     dummy = torch.zeros(1, 3, size, size)
     torch.onnx.export(
@@ -62,7 +79,7 @@ def main() -> None:
     max_diff = float(np.abs(torch_out - onnx_out).max())
     print(f"parity max|torch-onnx| = {max_diff:.2e}")
     print(f"output shape {onnx_out.shape} range [{onnx_out.min():.3f}, {onnx_out.max():.3f}]")
-    assert onnx_out.shape == (1, 1, size, size), "unexpected output shape"
+    assert onnx_out.shape == (1, out_channels, size, size), "unexpected output shape"
     assert max_diff < 1e-3, "torch/onnx parity failed"
 
     if args.quantize:
@@ -72,7 +89,7 @@ def main() -> None:
         quantize_dynamic(str(out), str(q), weight_type=QuantType.QInt8)
         print(f"quantized {q} ({q.stat().st_size / 1e6:.2f} MB)")
 
-    print("OK — place the .onnx at apps/web/public/models/edge-prepass.onnx to ship it")
+    print(f"OK — place the .onnx at {DEFAULT_OUT[args.task]} to ship it")
 
 
 if __name__ == "__main__":

--- a/scripts/train/export_onnx.py
+++ b/scripts/train/export_onnx.py
@@ -1,0 +1,79 @@
+"""Export a trained checkpoint to ONNX for EdgeEnhancer (packages/ml/src/edge.ts).
+
+Produces a fixed [1,3,size,size] → [1,1,size,size] sigmoid model, verifies
+torch/onnxruntime parity, and (optionally) quantizes to int8. Drop the result at
+apps/web/public/models/edge-prepass.onnx to ship it same-origin with the app.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from model import SigmoidWrapper, TinyUNet
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Export the edge pre-pass model to ONNX.")
+    p.add_argument("--checkpoint", default="scripts/train/checkpoints/edge-prepass.pt")
+    p.add_argument("--out", default="apps/web/public/models/edge-prepass.onnx")
+    p.add_argument("--opset", type=int, default=17)
+    p.add_argument("--quantize", action="store_true", help="also emit an int8 .onnx (smaller)")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    ckpt = torch.load(args.checkpoint, map_location="cpu")
+    size = ckpt["size"]
+    model = TinyUNet(ckpt["base_channels"])
+    model.load_state_dict(ckpt["state_dict"])
+    export_model = SigmoidWrapper(model).eval()
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    dummy = torch.zeros(1, 3, size, size)
+    torch.onnx.export(
+        export_model,
+        dummy,
+        str(out),
+        input_names=[ckpt["input_name"]],
+        output_names=[ckpt["output_name"]],
+        opset_version=args.opset,
+        do_constant_folding=True,
+        # Legacy TorchScript exporter: the widest op coverage for onnxruntime-web,
+        # and no onnxscript dependency (the newer dynamo path needs it).
+        dynamo=False,
+    )
+    print(f"exported {out} ({out.stat().st_size / 1e6:.2f} MB)")
+
+    # Parity: torch vs onnxruntime on a random input.
+    import onnxruntime as ort
+
+    rng = np.random.default_rng(0)
+    sample = rng.standard_normal((1, 3, size, size)).astype(np.float32)
+    with torch.no_grad():
+        torch_out = export_model(torch.from_numpy(sample)).numpy()
+    sess = ort.InferenceSession(str(out), providers=["CPUExecutionProvider"])
+    onnx_out = sess.run(None, {ckpt["input_name"]: sample})[0]
+    max_diff = float(np.abs(torch_out - onnx_out).max())
+    print(f"parity max|torch-onnx| = {max_diff:.2e}")
+    print(f"output shape {onnx_out.shape} range [{onnx_out.min():.3f}, {onnx_out.max():.3f}]")
+    assert onnx_out.shape == (1, 1, size, size), "unexpected output shape"
+    assert max_diff < 1e-3, "torch/onnx parity failed"
+
+    if args.quantize:
+        from onnxruntime.quantization import QuantType, quantize_dynamic
+
+        q = out.with_name(f"{out.stem}.int8.onnx")
+        quantize_dynamic(str(out), str(q), weight_type=QuantType.QInt8)
+        print(f"quantized {q} ({q.stat().st_size / 1e6:.2f} MB)")
+
+    print("OK — place the .onnx at apps/web/public/models/edge-prepass.onnx to ship it")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train/losses.py
+++ b/scripts/train/losses.py
@@ -1,9 +1,12 @@
-"""Loss for the edge pre-pass: class-balanced BCE (HED-style) + soft Dice.
+"""Losses for the on-device pre-pass models.
 
-Boundary pixels are sparse (the generator's own samples run ~5-8% edge pixels),
-so plain BCE collapses to predicting "no edge". HED's beta weighting rebalances
-positives against negatives; the Dice term further counters the imbalance. Both
-operate on the soft [0,1] target the generator produces.
+- edge: class-balanced BCE (HED-style) + soft Dice. Boundary pixels are sparse
+  (the generator's own samples run ~5-8% edge pixels), so plain BCE collapses to
+  predicting "no edge". HED's beta weighting rebalances positives against
+  negatives; the Dice term further counters the imbalance. Both operate on the
+  soft [0,1] target the generator produces.
+- cleanup: L1 on the sigmoid'd RGB output vs the clean [0,1] target. L1 (over L2)
+  keeps edges crisp instead of blurring them, which matters for a tracer input.
 """
 
 from __future__ import annotations
@@ -24,3 +27,7 @@ def edge_loss(logits: torch.Tensor, target: torch.Tensor, edge_thresh: float = 0
     inter = (prob * target).sum()
     dice = 1.0 - (2.0 * inter + 1.0) / (prob.sum() + target.sum() + 1.0)
     return bce + dice
+
+
+def cleanup_loss(logits: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    return F.l1_loss(torch.sigmoid(logits), target)

--- a/scripts/train/losses.py
+++ b/scripts/train/losses.py
@@ -1,0 +1,26 @@
+"""Loss for the edge pre-pass: class-balanced BCE (HED-style) + soft Dice.
+
+Boundary pixels are sparse (the generator's own samples run ~5-8% edge pixels),
+so plain BCE collapses to predicting "no edge". HED's beta weighting rebalances
+positives against negatives; the Dice term further counters the imbalance. Both
+operate on the soft [0,1] target the generator produces.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def edge_loss(logits: torch.Tensor, target: torch.Tensor, edge_thresh: float = 0.1) -> torch.Tensor:
+    prob = torch.sigmoid(logits)
+    edge = (target > edge_thresh).float()
+    n = edge.numel()
+    n_pos = edge.sum().clamp(min=1.0)
+    beta = 1.0 - n_pos / n  # fraction of non-edge pixels
+    weight = edge * beta + (1.0 - edge) * (1.0 - beta)
+    bce = F.binary_cross_entropy_with_logits(logits, target, weight=weight)
+
+    inter = (prob * target).sum()
+    dice = 1.0 - (2.0 * inter + 1.0) / (prob.sum() + target.sum() + 1.0)
+    return bce + dice

--- a/scripts/train/model.py
+++ b/scripts/train/model.py
@@ -1,0 +1,63 @@
+"""Compact U-Net for the edge / boundary pre-pass (docs/EDGE_PREPASS.md).
+
+The network returns logits; training uses a numerically stable
+*-with-logits loss. The ONNX export wraps it with a Sigmoid so the shipped
+model outputs probabilities in [0, 1] — exactly what EdgeEnhancer
+(packages/ml/src/edge.ts) reads back.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class DoubleConv(nn.Module):
+    def __init__(self, in_ch: int, out_ch: int) -> None:
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.Conv2d(in_ch, out_ch, 3, padding=1, bias=False),
+            nn.BatchNorm2d(out_ch),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_ch, out_ch, 3, padding=1, bias=False),
+            nn.BatchNorm2d(out_ch),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.block(x)
+
+
+class TinyUNet(nn.Module):
+    """Three-level U-Net; `base` sets the channel width, hence the model size."""
+
+    def __init__(self, base: int = 16) -> None:
+        super().__init__()
+        self.enc1 = DoubleConv(3, base)
+        self.enc2 = DoubleConv(base, base * 2)
+        self.pool = nn.MaxPool2d(2)
+        self.bottleneck = DoubleConv(base * 2, base * 4)
+        self.up2 = nn.ConvTranspose2d(base * 4, base * 2, 2, stride=2)
+        self.dec2 = DoubleConv(base * 4, base * 2)
+        self.up1 = nn.ConvTranspose2d(base * 2, base, 2, stride=2)
+        self.dec1 = DoubleConv(base * 2, base)
+        self.head = nn.Conv2d(base, 1, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        e1 = self.enc1(x)
+        e2 = self.enc2(self.pool(e1))
+        b = self.bottleneck(self.pool(e2))
+        d2 = self.dec2(torch.cat([self.up2(b), e2], dim=1))
+        d1 = self.dec1(torch.cat([self.up1(d2), e1], dim=1))
+        return self.head(d1)  # logits [N, 1, H, W]
+
+
+class SigmoidWrapper(nn.Module):
+    """Model + Sigmoid, used only for ONNX export (ships probabilities)."""
+
+    def __init__(self, model: nn.Module) -> None:
+        super().__init__()
+        self.model = model
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.sigmoid(self.model(x))

--- a/scripts/train/model.py
+++ b/scripts/train/model.py
@@ -1,9 +1,12 @@
-"""Compact U-Net for the edge / boundary pre-pass (docs/EDGE_PREPASS.md).
+"""Compact U-Net for the on-device pre-pass models.
 
-The network returns logits; training uses a numerically stable
-*-with-logits loss. The ONNX export wraps it with a Sigmoid so the shipped
-model outputs probabilities in [0, 1] — exactly what EdgeEnhancer
-(packages/ml/src/edge.ts) reads back.
+Two tasks share this network, differing only in the head width:
+- edge (docs/EDGE_PREPASS.md): 1 channel, a boundary probability map.
+- cleanup (docs/CLEANUP_PREPASS.md): 3 channels, a denoised RGB image.
+
+The network returns logits/pre-activations; training uses the matching loss.
+The ONNX export wraps it with a Sigmoid so the shipped model outputs values in
+[0, 1] — exactly what EdgeEnhancer / CleanupEnhancer (packages/ml/src) read back.
 """
 
 from __future__ import annotations
@@ -29,9 +32,12 @@ class DoubleConv(nn.Module):
 
 
 class TinyUNet(nn.Module):
-    """Three-level U-Net; `base` sets the channel width, hence the model size."""
+    """Three-level U-Net; `base` sets the channel width, hence the model size.
 
-    def __init__(self, base: int = 16) -> None:
+    `out_channels` is 1 for the edge task, 3 for the cleanup (RGB) task.
+    """
+
+    def __init__(self, base: int = 16, out_channels: int = 1) -> None:
         super().__init__()
         self.enc1 = DoubleConv(3, base)
         self.enc2 = DoubleConv(base, base * 2)
@@ -41,7 +47,7 @@ class TinyUNet(nn.Module):
         self.dec2 = DoubleConv(base * 4, base * 2)
         self.up1 = nn.ConvTranspose2d(base * 2, base, 2, stride=2)
         self.dec1 = DoubleConv(base * 2, base)
-        self.head = nn.Conv2d(base, 1, 1)
+        self.head = nn.Conv2d(base, out_channels, 1)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         e1 = self.enc1(x)
@@ -49,7 +55,7 @@ class TinyUNet(nn.Module):
         b = self.bottleneck(self.pool(e2))
         d2 = self.dec2(torch.cat([self.up2(b), e2], dim=1))
         d1 = self.dec1(torch.cat([self.up1(d2), e1], dim=1))
-        return self.head(d1)  # logits [N, 1, H, W]
+        return self.head(d1)  # [N, out_channels, H, W]
 
 
 class SigmoidWrapper(nn.Module):

--- a/scripts/train/pipeline.py
+++ b/scripts/train/pipeline.py
@@ -55,6 +55,7 @@ def main() -> None:
     p.add_argument("--base-channels", type=int, default=16, help="model width / size")
     p.add_argument("--patience", type=int, default=10, help="early-stop after N stale epochs (0 = off)")
     p.add_argument("--workers", type=int, default=0, help="dataloader workers (raise for speed)")
+    p.add_argument("--jobs", type=int, default=0, help="dataset generator threads (0 = CPU count)")
     p.add_argument("--out", default="apps/web/public/models/edge-prepass.onnx")
     p.add_argument("--skip-data", action="store_true", help="reuse an existing --data dir")
     p.add_argument("--quantize", action="store_true")
@@ -64,7 +65,7 @@ def main() -> None:
         print(f"skipping data generation, using {args.data}")
     else:
         # npm is a shell command on Windows (npm.cmd); shell=True keeps it portable.
-        run(f'npm run dataset -- --count {args.count} --out "{args.data}"', shell=True)
+        run(f'npm run dataset -- --count {args.count} --jobs {args.jobs} --out "{args.data}"', shell=True)
 
     run([
         sys.executable, str(HERE / "train.py"),

--- a/scripts/train/pipeline.py
+++ b/scripts/train/pipeline.py
@@ -3,9 +3,15 @@
 Cross-platform (Windows / macOS / Linux). Each step is also runnable on its own
 (see scripts/train/README.md). Examples:
 
+    python scripts/train/pipeline.py --smoke                     # ~30s end-to-end sanity check
     python scripts/train/pipeline.py --count 20000 --epochs 40 --quantize
     python scripts/train/pipeline.py --data dataset-out --skip-data --epochs 40
     python scripts/train/pipeline.py --task cleanup --count 20000 --quantize
+
+Run --smoke first on a new machine: it exercises the whole chain (data-gen →
+train → ONNX export + parity) with a tiny throwaway config, writing to the
+gitignored checkpoints/ dir — never the shipped model — so you confirm the
+toolchain works before committing to a full run.
 """
 
 from __future__ import annotations
@@ -52,13 +58,21 @@ DEFAULT_OUT = {
     "cleanup": "apps/web/public/models/cleanup.onnx",
 }
 
+# Fast throwaway config for --smoke: enough to run every step, small enough to
+# finish in well under a minute on CPU.
+SMOKE = {"count": 50, "epochs": 1, "batch": 8, "base_channels": 8}
+SMOKE_DIR = "scripts/train/checkpoints/smoke"  # gitignored; isolated from real checkpoints
+
+# Checkpoint filename per task (mirrors train.py TASKS / export_onnx.DEFAULT_CHECKPOINT).
+CHECKPOINT_NAME = {"edge": "edge-prepass.pt", "cleanup": "cleanup.pt"}
+
 
 def main() -> None:
     require_deps()
     p = argparse.ArgumentParser(description="Generate data, train, and export a pre-pass model.")
     p.add_argument("--task", choices=sorted(DEFAULT_OUT), default="edge", help="edge or cleanup")
     p.add_argument("--count", type=int, default=20000, help="samples to generate")
-    p.add_argument("--data", default="dataset-out")
+    p.add_argument("--data", default=None, help="dataset dir (default: dataset-out; --smoke uses its own isolated dir)")
     p.add_argument("--epochs", type=int, default=60)
     p.add_argument("--batch", type=int, default=32)
     p.add_argument("--base-channels", type=int, default=16, help="model width / size")
@@ -68,30 +82,62 @@ def main() -> None:
     p.add_argument("--out", default=None, help="ONNX ship path (default: per-task)")
     p.add_argument("--skip-data", action="store_true", help="reuse an existing --data dir")
     p.add_argument("--quantize", action="store_true")
+    p.add_argument(
+        "--smoke",
+        action="store_true",
+        help="fast end-to-end sanity check (tiny data/model, throwaway output — not the shipped model)",
+    )
     args = p.parse_args()
-    out = args.out or DEFAULT_OUT[args.task]
+
+    if args.smoke:
+        # Force the fast config; keep --task/--skip-data/--quantize/--jobs/--workers as given.
+        args.count, args.epochs, args.batch, args.base_channels = (
+            SMOKE["count"],
+            SMOKE["epochs"],
+            SMOKE["batch"],
+            SMOKE["base_channels"],
+        )
+
+    # Resolve paths: smoke stays fully isolated under SMOKE_DIR (gitignored) — its
+    # own dataset dir, checkpoint dir, and ONNX, none of them the real dataset or
+    # the shipped model.
+    data = args.data or (f"{SMOKE_DIR}/data" if args.smoke else "dataset-out")
+    ckpt_dir = SMOKE_DIR if args.smoke else "scripts/train/checkpoints"
+    out = args.out or (
+        f"{SMOKE_DIR}/{args.task}.onnx" if args.smoke else DEFAULT_OUT[args.task]
+    )
+    if args.smoke:
+        print(
+            f"SMOKE: task={args.task} · {args.count} samples · {args.epochs} epoch · "
+            f"base={args.base_channels} → {out} (throwaway, not the shipped model)"
+        )
 
     if args.skip_data:
-        print(f"skipping data generation, using {args.data}")
+        print(f"skipping data generation, using {data}")
     else:
         # The dataset carries both targets (edge + clean), so one generated set
         # trains either task. npm is npm.cmd on Windows; shell=True keeps it portable.
-        run(f'npm run dataset -- --count {args.count} --jobs {args.jobs} --out "{args.data}"', shell=True)
+        run(f'npm run dataset -- --count {args.count} --jobs {args.jobs} --out "{data}"', shell=True)
 
     run([
         sys.executable, str(HERE / "train.py"),
         "--task", args.task,
-        "--data", args.data, "--epochs", str(args.epochs),
+        "--data", data, "--epochs", str(args.epochs),
         "--batch", str(args.batch), "--base-channels", str(args.base_channels),
         "--patience", str(args.patience), "--workers", str(args.workers),
+        "--out", ckpt_dir,
     ])
 
     export = [sys.executable, str(HERE / "export_onnx.py"), "--task", args.task, "--out", out]
+    export += ["--checkpoint", f"{ckpt_dir}/{CHECKPOINT_NAME[args.task]}"]
     if args.quantize:
         export.append("--quantize")
     run(export)
 
-    print(f"\ndone -> {out} (ships same-origin with the app)")
+    if args.smoke:
+        print(f"\nsmoke OK -> {out} (throwaway). Toolchain works — now run a real training pass.")
+    else:
+        print(f"\ndone -> {out} (ships same-origin with the app)")
 
 
 if __name__ == "__main__":

--- a/scripts/train/pipeline.py
+++ b/scripts/train/pipeline.py
@@ -1,10 +1,11 @@
-"""One-shot: generate dataset -> train -> export the edge pre-pass ONNX.
+"""One-shot: generate dataset -> train -> export a pre-pass ONNX.
 
 Cross-platform (Windows / macOS / Linux). Each step is also runnable on its own
 (see scripts/train/README.md). Examples:
 
     python scripts/train/pipeline.py --count 20000 --epochs 40 --quantize
     python scripts/train/pipeline.py --data dataset-out --skip-data --epochs 40
+    python scripts/train/pipeline.py --task cleanup --count 20000 --quantize
 """
 
 from __future__ import annotations
@@ -45,9 +46,17 @@ def require_deps() -> None:
         )
 
 
+# Default ship path per task (mirrors export_onnx.DEFAULT_OUT).
+DEFAULT_OUT = {
+    "edge": "apps/web/public/models/edge-prepass.onnx",
+    "cleanup": "apps/web/public/models/cleanup.onnx",
+}
+
+
 def main() -> None:
     require_deps()
-    p = argparse.ArgumentParser(description="Generate data, train, and export the edge pre-pass model.")
+    p = argparse.ArgumentParser(description="Generate data, train, and export a pre-pass model.")
+    p.add_argument("--task", choices=sorted(DEFAULT_OUT), default="edge", help="edge or cleanup")
     p.add_argument("--count", type=int, default=20000, help="samples to generate")
     p.add_argument("--data", default="dataset-out")
     p.add_argument("--epochs", type=int, default=60)
@@ -56,30 +65,33 @@ def main() -> None:
     p.add_argument("--patience", type=int, default=10, help="early-stop after N stale epochs (0 = off)")
     p.add_argument("--workers", type=int, default=0, help="dataloader workers (raise for speed)")
     p.add_argument("--jobs", type=int, default=0, help="dataset generator threads (0 = CPU count)")
-    p.add_argument("--out", default="apps/web/public/models/edge-prepass.onnx")
+    p.add_argument("--out", default=None, help="ONNX ship path (default: per-task)")
     p.add_argument("--skip-data", action="store_true", help="reuse an existing --data dir")
     p.add_argument("--quantize", action="store_true")
     args = p.parse_args()
+    out = args.out or DEFAULT_OUT[args.task]
 
     if args.skip_data:
         print(f"skipping data generation, using {args.data}")
     else:
-        # npm is a shell command on Windows (npm.cmd); shell=True keeps it portable.
+        # The dataset carries both targets (edge + clean), so one generated set
+        # trains either task. npm is npm.cmd on Windows; shell=True keeps it portable.
         run(f'npm run dataset -- --count {args.count} --jobs {args.jobs} --out "{args.data}"', shell=True)
 
     run([
         sys.executable, str(HERE / "train.py"),
+        "--task", args.task,
         "--data", args.data, "--epochs", str(args.epochs),
         "--batch", str(args.batch), "--base-channels", str(args.base_channels),
         "--patience", str(args.patience), "--workers", str(args.workers),
     ])
 
-    export = [sys.executable, str(HERE / "export_onnx.py"), "--out", args.out]
+    export = [sys.executable, str(HERE / "export_onnx.py"), "--task", args.task, "--out", out]
     if args.quantize:
         export.append("--quantize")
     run(export)
 
-    print(f"\ndone -> {args.out} (ships same-origin with the app)")
+    print(f"\ndone -> {out} (ships same-origin with the app)")
 
 
 if __name__ == "__main__":

--- a/scripts/train/pipeline.py
+++ b/scripts/train/pipeline.py
@@ -23,7 +23,30 @@ def run(cmd: list[str] | str, shell: bool = False) -> None:
     subprocess.run(cmd, cwd=REPO_ROOT, shell=shell, check=True)
 
 
+def require_deps() -> None:
+    """Fail early with an actionable message when the Python deps are missing.
+
+    The subprocess steps use this same interpreter (sys.executable), so checking
+    here catches a mis-set venv before any work runs. A CUDA torch wheel does not
+    always pull numpy, so a torch-only install can still be missing packages.
+    """
+    missing = []
+    for mod, pkg in (("numpy", "numpy"), ("PIL", "pillow"), ("onnx", "onnx"), ("onnxruntime", "onnxruntime")):
+        try:
+            __import__(mod)
+        except ImportError:
+            missing.append(pkg)
+    if missing:
+        raise SystemExit(
+            f"missing Python deps: {', '.join(missing)}\n"
+            "activate your venv, then install them:\n"
+            "  pip install -r scripts/train/requirements.txt\n"
+            f"(this interpreter: {sys.executable})"
+        )
+
+
 def main() -> None:
+    require_deps()
     p = argparse.ArgumentParser(description="Generate data, train, and export the edge pre-pass model.")
     p.add_argument("--count", type=int, default=20000, help="samples to generate")
     p.add_argument("--data", default="dataset-out")

--- a/scripts/train/pipeline.py
+++ b/scripts/train/pipeline.py
@@ -27,8 +27,10 @@ def main() -> None:
     p = argparse.ArgumentParser(description="Generate data, train, and export the edge pre-pass model.")
     p.add_argument("--count", type=int, default=20000, help="samples to generate")
     p.add_argument("--data", default="dataset-out")
-    p.add_argument("--epochs", type=int, default=40)
+    p.add_argument("--epochs", type=int, default=60)
     p.add_argument("--batch", type=int, default=32)
+    p.add_argument("--base-channels", type=int, default=16, help="model width / size")
+    p.add_argument("--patience", type=int, default=10, help="early-stop after N stale epochs (0 = off)")
     p.add_argument("--workers", type=int, default=0, help="dataloader workers (raise for speed)")
     p.add_argument("--out", default="apps/web/public/models/edge-prepass.onnx")
     p.add_argument("--skip-data", action="store_true", help="reuse an existing --data dir")
@@ -44,7 +46,8 @@ def main() -> None:
     run([
         sys.executable, str(HERE / "train.py"),
         "--data", args.data, "--epochs", str(args.epochs),
-        "--batch", str(args.batch), "--workers", str(args.workers),
+        "--batch", str(args.batch), "--base-channels", str(args.base_channels),
+        "--patience", str(args.patience), "--workers", str(args.workers),
     ])
 
     export = [sys.executable, str(HERE / "export_onnx.py"), "--out", args.out]

--- a/scripts/train/pipeline.py
+++ b/scripts/train/pipeline.py
@@ -1,0 +1,59 @@
+"""One-shot: generate dataset -> train -> export the edge pre-pass ONNX.
+
+Cross-platform (Windows / macOS / Linux). Each step is also runnable on its own
+(see scripts/train/README.md). Examples:
+
+    python scripts/train/pipeline.py --count 20000 --epochs 40 --quantize
+    python scripts/train/pipeline.py --data dataset-out --skip-data --epochs 40
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HERE = Path(__file__).resolve().parent
+
+
+def run(cmd: list[str] | str, shell: bool = False) -> None:
+    print(f"\n$ {cmd if isinstance(cmd, str) else ' '.join(cmd)}\n", flush=True)
+    subprocess.run(cmd, cwd=REPO_ROOT, shell=shell, check=True)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Generate data, train, and export the edge pre-pass model.")
+    p.add_argument("--count", type=int, default=20000, help="samples to generate")
+    p.add_argument("--data", default="dataset-out")
+    p.add_argument("--epochs", type=int, default=40)
+    p.add_argument("--batch", type=int, default=32)
+    p.add_argument("--workers", type=int, default=0, help="dataloader workers (raise for speed)")
+    p.add_argument("--out", default="apps/web/public/models/edge-prepass.onnx")
+    p.add_argument("--skip-data", action="store_true", help="reuse an existing --data dir")
+    p.add_argument("--quantize", action="store_true")
+    args = p.parse_args()
+
+    if args.skip_data:
+        print(f"skipping data generation, using {args.data}")
+    else:
+        # npm is a shell command on Windows (npm.cmd); shell=True keeps it portable.
+        run(f'npm run dataset -- --count {args.count} --out "{args.data}"', shell=True)
+
+    run([
+        sys.executable, str(HERE / "train.py"),
+        "--data", args.data, "--epochs", str(args.epochs),
+        "--batch", str(args.batch), "--workers", str(args.workers),
+    ])
+
+    export = [sys.executable, str(HERE / "export_onnx.py"), "--out", args.out]
+    if args.quantize:
+        export.append("--quantize")
+    run(export)
+
+    print(f"\ndone -> {args.out} (ships same-origin with the app)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train/requirements.txt
+++ b/scripts/train/requirements.txt
@@ -1,0 +1,10 @@
+# Offline training deps for the edge pre-pass model (not part of the JS build/CI).
+# For an NVIDIA GPU, install a CUDA build of torch first, e.g.:
+#   pip install torch --index-url https://download.pytorch.org/whl/cu124
+# then `pip install -r requirements.txt` for the rest. On CPU-only, plain
+# `pip install -r requirements.txt` is enough (slower).
+torch>=2.2
+numpy>=1.24
+pillow>=10.0
+onnx>=1.15
+onnxruntime>=1.17

--- a/scripts/train/setup.ps1
+++ b/scripts/train/setup.ps1
@@ -1,0 +1,50 @@
+<#
+.SYNOPSIS
+  Bootstrap the Python training environment (Windows / PowerShell).
+
+.DESCRIPTION
+  Creates a repo-root .venv and installs PyTorch + the training deps into it.
+  Installs nothing globally — everything lands in .venv. It calls the venv's
+  python directly, so it works even if PowerShell's execution policy blocks
+  Activate.ps1 (to activate later, see the README).
+
+.PARAMETER Cuda
+  CUDA wheel tag matching your NVIDIA driver (e.g. cu121, cu124) from
+  https://pytorch.org/get-started/locally/. Omit for a CPU-only install.
+
+.EXAMPLE
+  .\scripts\train\setup.ps1
+.EXAMPLE
+  .\scripts\train\setup.ps1 -Cuda cu124
+#>
+param([string]$Cuda = "")
+$ErrorActionPreference = "Stop"
+
+# Prefer the 'py' launcher (standard on python.org installs); fall back to python.
+$launcher = if (Get-Command py -ErrorAction SilentlyContinue) { "py" }
+            elseif (Get-Command python -ErrorAction SilentlyContinue) { "python" }
+            else { throw "Python not found — install Python 3.10+ from python.org and re-run." }
+
+Write-Host "==> creating .venv (via $launcher)"
+& $launcher -m venv .venv
+$py = ".venv\Scripts\python.exe"
+
+Write-Host "==> upgrading pip"
+& $py -m pip install --upgrade pip
+
+if ($Cuda) {
+  Write-Host "==> installing torch (CUDA $Cuda)"
+  & $py -m pip install torch --index-url "https://download.pytorch.org/whl/$Cuda"
+}
+
+Write-Host "==> installing training deps"
+& $py -m pip install -r scripts/train/requirements.txt
+
+Write-Host "==> verifying"
+& $py -c "import torch; print('torch', torch.__version__, '| CUDA available:', torch.cuda.is_available()); print('  device:', torch.cuda.get_device_name(0)) if torch.cuda.is_available() else None"
+
+Write-Host ""
+Write-Host "done. Next (no activation needed — call the venv python directly):"
+Write-Host "  .venv\Scripts\python.exe scripts\train\pipeline.py --count 20000 --quantize"
+Write-Host "  .venv\Scripts\python.exe scripts\train\pipeline.py --task cleanup --count 20000 --quantize"
+Write-Host "(or activate first: .\.venv\Scripts\Activate.ps1 — if blocked, see the README)"

--- a/scripts/train/setup.sh
+++ b/scripts/train/setup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+# Bootstrap the Python training environment (Linux / macOS).
+#
+# Creates a repo-root .venv and installs PyTorch + the training deps into it.
+# Run from the repo root:
+#
+#   sh scripts/train/setup.sh                 # CPU (or Linux default CUDA wheel)
+#   sh scripts/train/setup.sh --cuda cu124    # install the cu124 CUDA build of torch
+#
+# Pick the --cuda tag matching your driver from https://pytorch.org/get-started/locally/
+# (e.g. cu121, cu124). It installs nothing globally — everything lands in .venv.
+set -eu
+
+CUDA=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --cuda) CUDA="${2:-}"; shift 2 ;;
+    --cuda=*) CUDA="${1#--cuda=}"; shift ;;
+    -h|--help) grep '^#' "$0" | cut -c3-; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+PY="${PYTHON:-python3}"
+if ! command -v "$PY" >/dev/null 2>&1; then
+  echo "error: '$PY' not found — install Python 3.10+ (set PYTHON=... to override)" >&2
+  exit 1
+fi
+
+echo "==> creating .venv ($("$PY" --version 2>&1))"
+"$PY" -m venv .venv
+VENV_PY=.venv/bin/python
+
+echo "==> upgrading pip"
+"$VENV_PY" -m pip install --upgrade pip
+
+if [ -n "$CUDA" ]; then
+  echo "==> installing torch (CUDA $CUDA)"
+  "$VENV_PY" -m pip install torch --index-url "https://download.pytorch.org/whl/$CUDA"
+fi
+
+echo "==> installing training deps"
+"$VENV_PY" -m pip install -r scripts/train/requirements.txt
+
+echo "==> verifying"
+"$VENV_PY" - <<'PYEOF'
+import torch
+print(f"torch {torch.__version__} | CUDA available: {torch.cuda.is_available()}")
+if torch.cuda.is_available():
+    print(f"  device: {torch.cuda.get_device_name(0)}")
+PYEOF
+
+echo
+echo "done. Next (no activation needed — call the venv python directly):"
+echo "  .venv/bin/python scripts/train/pipeline.py --count 20000 --quantize"
+echo "  .venv/bin/python scripts/train/pipeline.py --task cleanup --count 20000 --quantize"
+echo "(or 'source .venv/bin/activate' first, then use plain 'python')"

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -1,9 +1,12 @@
-"""Train the edge pre-pass model on the generator's dataset.
+"""Train an on-device pre-pass model on the generator's dataset.
 
-Auto-detects CUDA. Saves the best checkpoint (by val loss) to
-`scripts/train/checkpoints/edge-prepass.pt` and, beside it, a `preview.png`
-montage (input · prediction · target) for eyeballing quality. Early stops when
-val loss stops improving. See scripts/train/README.md.
+Two tasks (`--task`):
+- edge (default): 1-channel boundary map → checkpoints/edge-prepass.pt
+- cleanup: 3-channel denoised RGB → checkpoints/cleanup.pt
+
+Auto-detects CUDA. Saves the best checkpoint (by val loss) and, beside it, a
+`preview.png` montage (input · prediction · target) for eyeballing quality.
+Early stops when val loss stops improving. See scripts/train/README.md.
 """
 
 from __future__ import annotations
@@ -16,13 +19,20 @@ import torch
 from PIL import Image
 from torch.utils.data import DataLoader
 
-from dataset import IMAGENET_MEAN, IMAGENET_STD, EdgeDataset
-from losses import edge_loss
+from dataset import IMAGENET_MEAN, IMAGENET_STD, PrepassDataset
+from losses import cleanup_loss, edge_loss
 from model import TinyUNet
+
+# Per-task config: output channels, checkpoint name, and ONNX output tensor name.
+TASKS = {
+    "edge": {"out_channels": 1, "checkpoint": "edge-prepass.pt", "output_name": "edges"},
+    "cleanup": {"out_channels": 3, "checkpoint": "cleanup.pt", "output_name": "output"},
+}
 
 
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Train the edge pre-pass model.")
+    p = argparse.ArgumentParser(description="Train an on-device pre-pass model.")
+    p.add_argument("--task", choices=sorted(TASKS), default="edge", help="which model to train")
     # One or more dataset roots (npm run dataset outputs) — concatenated to mix.
     p.add_argument("--data", nargs="+", required=True, help="dataset root(s)")
     p.add_argument("--out", default="scripts/train/checkpoints")
@@ -49,7 +59,20 @@ def f_score(prob: torch.Tensor, target: torch.Tensor, thresh: float = 0.5, eps: 
     return float(2 * prec * rec / (prec + rec + eps))
 
 
-def save_preview(model: torch.nn.Module, ds: EdgeDataset, path: Path, device: str, n: int = 4) -> None:
+def psnr(prob: torch.Tensor, target: torch.Tensor, eps: float = 1e-8) -> float:
+    mse = ((prob - target) ** 2).mean()
+    return float(10.0 * torch.log10(1.0 / (mse + eps)))
+
+
+def to_rgb(chw: np.ndarray) -> np.ndarray:
+    """A [C,H,W] array in [0,1] → [H,W,3] uint8, tiling gray to RGB."""
+    hwc = chw.transpose(1, 2, 0)
+    if hwc.shape[2] == 1:
+        hwc = np.repeat(hwc, 3, axis=2)
+    return np.clip(hwc * 255, 0, 255).astype(np.uint8)
+
+
+def save_preview(model: torch.nn.Module, ds: PrepassDataset, path: Path, device: str, n: int = 4) -> None:
     """Save an [input | prediction | target] montage for up to n val samples."""
     n = min(n, len(ds))
     if n == 0:
@@ -59,30 +82,28 @@ def save_preview(model: torch.nn.Module, ds: EdgeDataset, path: Path, device: st
     with torch.no_grad():
         for i in range(n):
             x, y = ds[i]
-            prob = torch.sigmoid(model(x.unsqueeze(0).to(device)))[0, 0].cpu().numpy()
-            rgb = np.clip((x.numpy().transpose(1, 2, 0) * IMAGENET_STD + IMAGENET_MEAN) * 255, 0, 255)
-            pred = np.clip(prob * 255, 0, 255)
-            tgt = np.clip(y[0].numpy() * 255, 0, 255)
-            gray3 = lambda g: np.stack([g, g, g], axis=-1)  # noqa: E731
-            rows.append(np.concatenate([rgb, gray3(pred), gray3(tgt)], axis=1).astype(np.uint8))
+            pred = torch.sigmoid(model(x.unsqueeze(0).to(device)))[0].cpu().numpy()
+            rgb = np.clip((x.numpy().transpose(1, 2, 0) * IMAGENET_STD + IMAGENET_MEAN) * 255, 0, 255).astype(np.uint8)
+            rows.append(np.concatenate([rgb, to_rgb(pred), to_rgb(y.numpy())], axis=1))
     Image.fromarray(np.concatenate(rows, axis=0)).save(path)
 
 
 def main() -> None:
     args = parse_args()
+    cfg = TASKS[args.task]
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
     device = ("cuda" if torch.cuda.is_available() else "cpu") if args.device == "auto" else args.device
-    print(f"device: {device} | data: {', '.join(args.data)}")
+    print(f"task: {args.task} | device: {device} | data: {', '.join(args.data)}")
 
-    train_ds = EdgeDataset(args.data, "train", args.size, args.limit)
-    val_ds = EdgeDataset(args.data, "val", args.size)
+    train_ds = PrepassDataset(args.data, "train", args.size, args.limit, task=args.task)
+    val_ds = PrepassDataset(args.data, "val", args.size, task=args.task)
     print(f"train {len(train_ds)} | val {len(val_ds)}")
     if len(train_ds) == 0:
-        raise SystemExit("no training samples — run `npm run dataset` first")
+        raise SystemExit(f"no training samples for task {args.task!r} — run `npm run dataset` first")
     pin = device == "cuda"
 
-    def loader(ds: EdgeDataset, shuffle: bool) -> DataLoader:
+    def loader(ds: PrepassDataset, shuffle: bool) -> DataLoader:
         return DataLoader(
             ds,
             batch_size=args.batch,
@@ -95,9 +116,13 @@ def main() -> None:
     train_dl = loader(train_ds, True)
     val_dl = loader(val_ds, False)
 
-    model = TinyUNet(args.base_channels).to(device)
+    loss_fn = cleanup_loss if args.task == "cleanup" else edge_loss
+    metric_fn = psnr if args.task == "cleanup" else f_score
+    metric_name = "PSNR" if args.task == "cleanup" else "F"
+
+    model = TinyUNet(args.base_channels, out_channels=cfg["out_channels"]).to(device)
     n_params = sum(p.numel() for p in model.parameters())
-    print(f"model: TinyUNet(base={args.base_channels}) — {n_params / 1e6:.2f}M params")
+    print(f"model: TinyUNet(base={args.base_channels}, out={cfg['out_channels']}) — {n_params / 1e6:.2f}M params")
     opt = torch.optim.AdamW(model.parameters(), lr=args.lr)
     sched = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=max(1, args.epochs))
 
@@ -112,7 +137,7 @@ def main() -> None:
         for x, y in train_dl:
             x, y = x.to(device, non_blocking=pin), y.to(device, non_blocking=pin)
             opt.zero_grad()
-            loss = edge_loss(model(x), y)
+            loss = loss_fn(model(x), y)
             loss.backward()
             opt.step()
             total += loss.item() * x.size(0)
@@ -121,18 +146,18 @@ def main() -> None:
 
         model.eval()
         v_loss = 0.0
-        v_f = 0.0
+        v_m = 0.0
         v_n = 0
         with torch.no_grad():
             for x, y in val_dl:
                 x, y = x.to(device, non_blocking=pin), y.to(device, non_blocking=pin)
                 logits = model(x)
-                v_loss += edge_loss(logits, y).item() * x.size(0)
-                v_f += f_score(torch.sigmoid(logits), y) * x.size(0)
+                v_loss += loss_fn(logits, y).item() * x.size(0)
+                v_m += metric_fn(torch.sigmoid(logits), y) * x.size(0)
                 v_n += x.size(0)
         val_loss = v_loss / v_n if v_n else float("nan")
-        val_f = v_f / v_n if v_n else float("nan")
-        print(f"epoch {epoch + 1}/{args.epochs} | train {train_loss:.4f} | val {val_loss:.4f} | val F {val_f:.3f}")
+        val_m = v_m / v_n if v_n else float("nan")
+        print(f"epoch {epoch + 1}/{args.epochs} | train {train_loss:.4f} | val {val_loss:.4f} | val {metric_name} {val_m:.3f}")
 
         score = val_loss if v_n else train_loss
         if score < best - 1e-5:
@@ -142,23 +167,25 @@ def main() -> None:
             torch.save(
                 {
                     "state_dict": model.state_dict(),
+                    "task": args.task,
+                    "out_channels": cfg["out_channels"],
                     "base_channels": args.base_channels,
                     "size": args.size,
                     "mean": IMAGENET_MEAN.tolist(),
                     "std": IMAGENET_STD.tolist(),
                     "input_name": "input",
-                    "output_name": "edges",
+                    "output_name": cfg["output_name"],
                 },
-                out_dir / "edge-prepass.pt",
+                out_dir / cfg["checkpoint"],
             )
-            save_preview(model, val_ds if v_n else train_ds, out_dir / "preview.png", device)
+            save_preview(model, val_ds if v_n else train_ds, out_dir / f"preview-{args.task}.png", device)
         else:
             stale += 1
             if args.patience > 0 and stale >= args.patience:
                 print(f"early stop: no val improvement for {args.patience} epochs")
                 break
 
-    print(f"best {best:.4f} at epoch {best_epoch} → {out_dir / 'edge-prepass.pt'}")
+    print(f"best {best:.4f} at epoch {best_epoch} → {out_dir / cfg['checkpoint']}")
 
 
 if __name__ == "__main__":

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -1,0 +1,118 @@
+"""Train the edge pre-pass model on the generator's dataset.
+
+Auto-detects CUDA. Saves the best checkpoint (by val loss) to
+`scripts/train/checkpoints/edge-prepass.pt`. See scripts/train/README.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+from dataset import IMAGENET_MEAN, IMAGENET_STD, EdgeDataset
+from losses import edge_loss
+from model import TinyUNet
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Train the edge pre-pass model.")
+    p.add_argument("--data", required=True, help="dataset root (npm run dataset output)")
+    p.add_argument("--out", default="scripts/train/checkpoints")
+    p.add_argument("--epochs", type=int, default=30)
+    p.add_argument("--batch", type=int, default=32)
+    p.add_argument("--lr", type=float, default=3e-4)
+    p.add_argument("--size", type=int, default=256)
+    p.add_argument("--base-channels", type=int, default=16)
+    # 0 avoids multiprocessing (safest on Windows); raise it (e.g. 8) for speed.
+    p.add_argument("--workers", type=int, default=0)
+    p.add_argument("--limit", type=int, default=0, help="cap train samples (smoke tests)")
+    p.add_argument("--device", default="auto", help="auto | cuda | cpu")
+    p.add_argument("--seed", type=int, default=0)
+    return p.parse_args()
+
+
+def f_score(prob: torch.Tensor, target: torch.Tensor, thresh: float = 0.5, eps: float = 1e-6) -> float:
+    pred = (prob > thresh).float()
+    gt = (target > thresh).float()
+    tp = (pred * gt).sum()
+    prec = tp / (pred.sum() + eps)
+    rec = tp / (gt.sum() + eps)
+    return float(2 * prec * rec / (prec + rec + eps))
+
+
+def main() -> None:
+    args = parse_args()
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    device = ("cuda" if torch.cuda.is_available() else "cpu") if args.device == "auto" else args.device
+    print(f"device: {device}")
+
+    train_ds = EdgeDataset(args.data, "train", args.size, args.limit)
+    val_ds = EdgeDataset(args.data, "val", args.size)
+    print(f"train {len(train_ds)} | val {len(val_ds)}")
+    if len(train_ds) == 0:
+        raise SystemExit("no training samples — run `npm run dataset` first")
+    train_dl = DataLoader(train_ds, batch_size=args.batch, shuffle=True, num_workers=args.workers)
+    val_dl = DataLoader(val_ds, batch_size=args.batch, shuffle=False, num_workers=args.workers)
+
+    model = TinyUNet(args.base_channels).to(device)
+    n_params = sum(p.numel() for p in model.parameters())
+    print(f"model: TinyUNet(base={args.base_channels}) — {n_params / 1e6:.2f}M params")
+    opt = torch.optim.AdamW(model.parameters(), lr=args.lr)
+    sched = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=max(1, args.epochs))
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    best = float("inf")
+    for epoch in range(args.epochs):
+        model.train()
+        total = 0.0
+        for x, y in train_dl:
+            x, y = x.to(device), y.to(device)
+            opt.zero_grad()
+            loss = edge_loss(model(x), y)
+            loss.backward()
+            opt.step()
+            total += loss.item() * x.size(0)
+        sched.step()
+        train_loss = total / len(train_ds)
+
+        model.eval()
+        v_loss = 0.0
+        v_f = 0.0
+        v_n = 0
+        with torch.no_grad():
+            for x, y in val_dl:
+                x, y = x.to(device), y.to(device)
+                logits = model(x)
+                v_loss += edge_loss(logits, y).item() * x.size(0)
+                v_f += f_score(torch.sigmoid(logits), y) * x.size(0)
+                v_n += x.size(0)
+        val_loss = v_loss / v_n if v_n else float("nan")
+        val_f = v_f / v_n if v_n else float("nan")
+        print(f"epoch {epoch + 1}/{args.epochs} | train {train_loss:.4f} | val {val_loss:.4f} | val F {val_f:.3f}")
+
+        score = val_loss if v_n else train_loss
+        if score < best:
+            best = score
+            torch.save(
+                {
+                    "state_dict": model.state_dict(),
+                    "base_channels": args.base_channels,
+                    "size": args.size,
+                    "mean": IMAGENET_MEAN.tolist(),
+                    "std": IMAGENET_STD.tolist(),
+                    "input_name": "input",
+                    "output_name": "edges",
+                },
+                out_dir / "edge-prepass.pt",
+            )
+    print(f"best {best:.4f} → {out_dir / 'edge-prepass.pt'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -80,8 +80,20 @@ def main() -> None:
     print(f"train {len(train_ds)} | val {len(val_ds)}")
     if len(train_ds) == 0:
         raise SystemExit("no training samples — run `npm run dataset` first")
-    train_dl = DataLoader(train_ds, batch_size=args.batch, shuffle=True, num_workers=args.workers)
-    val_dl = DataLoader(val_ds, batch_size=args.batch, shuffle=False, num_workers=args.workers)
+    pin = device == "cuda"
+
+    def loader(ds: EdgeDataset, shuffle: bool) -> DataLoader:
+        return DataLoader(
+            ds,
+            batch_size=args.batch,
+            shuffle=shuffle,
+            num_workers=args.workers,
+            pin_memory=pin,  # faster host→GPU copies
+            persistent_workers=args.workers > 0 and len(ds) > 0,  # don't respawn each epoch
+        )
+
+    train_dl = loader(train_ds, True)
+    val_dl = loader(val_ds, False)
 
     model = TinyUNet(args.base_channels).to(device)
     n_params = sum(p.numel() for p in model.parameters())
@@ -98,7 +110,7 @@ def main() -> None:
         model.train()
         total = 0.0
         for x, y in train_dl:
-            x, y = x.to(device), y.to(device)
+            x, y = x.to(device, non_blocking=pin), y.to(device, non_blocking=pin)
             opt.zero_grad()
             loss = edge_loss(model(x), y)
             loss.backward()
@@ -113,7 +125,7 @@ def main() -> None:
         v_n = 0
         with torch.no_grad():
             for x, y in val_dl:
-                x, y = x.to(device), y.to(device)
+                x, y = x.to(device, non_blocking=pin), y.to(device, non_blocking=pin)
                 logits = model(x)
                 v_loss += edge_loss(logits, y).item() * x.size(0)
                 v_f += f_score(torch.sigmoid(logits), y) * x.size(0)

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -1,7 +1,9 @@
 """Train the edge pre-pass model on the generator's dataset.
 
 Auto-detects CUDA. Saves the best checkpoint (by val loss) to
-`scripts/train/checkpoints/edge-prepass.pt`. See scripts/train/README.md.
+`scripts/train/checkpoints/edge-prepass.pt` and, beside it, a `preview.png`
+montage (input · prediction · target) for eyeballing quality. Early stops when
+val loss stops improving. See scripts/train/README.md.
 """
 
 from __future__ import annotations
@@ -11,6 +13,7 @@ from pathlib import Path
 
 import numpy as np
 import torch
+from PIL import Image
 from torch.utils.data import DataLoader
 
 from dataset import IMAGENET_MEAN, IMAGENET_STD, EdgeDataset
@@ -20,9 +23,10 @@ from model import TinyUNet
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Train the edge pre-pass model.")
-    p.add_argument("--data", required=True, help="dataset root (npm run dataset output)")
+    # One or more dataset roots (npm run dataset outputs) — concatenated to mix.
+    p.add_argument("--data", nargs="+", required=True, help="dataset root(s)")
     p.add_argument("--out", default="scripts/train/checkpoints")
-    p.add_argument("--epochs", type=int, default=30)
+    p.add_argument("--epochs", type=int, default=60)
     p.add_argument("--batch", type=int, default=32)
     p.add_argument("--lr", type=float, default=3e-4)
     p.add_argument("--size", type=int, default=256)
@@ -30,6 +34,7 @@ def parse_args() -> argparse.Namespace:
     # 0 avoids multiprocessing (safest on Windows); raise it (e.g. 8) for speed.
     p.add_argument("--workers", type=int, default=0)
     p.add_argument("--limit", type=int, default=0, help="cap train samples (smoke tests)")
+    p.add_argument("--patience", type=int, default=10, help="early-stop after N stale epochs (0 = off)")
     p.add_argument("--device", default="auto", help="auto | cuda | cpu")
     p.add_argument("--seed", type=int, default=0)
     return p.parse_args()
@@ -44,12 +49,31 @@ def f_score(prob: torch.Tensor, target: torch.Tensor, thresh: float = 0.5, eps: 
     return float(2 * prec * rec / (prec + rec + eps))
 
 
+def save_preview(model: torch.nn.Module, ds: EdgeDataset, path: Path, device: str, n: int = 4) -> None:
+    """Save an [input | prediction | target] montage for up to n val samples."""
+    n = min(n, len(ds))
+    if n == 0:
+        return
+    rows = []
+    model.eval()
+    with torch.no_grad():
+        for i in range(n):
+            x, y = ds[i]
+            prob = torch.sigmoid(model(x.unsqueeze(0).to(device)))[0, 0].cpu().numpy()
+            rgb = np.clip((x.numpy().transpose(1, 2, 0) * IMAGENET_STD + IMAGENET_MEAN) * 255, 0, 255)
+            pred = np.clip(prob * 255, 0, 255)
+            tgt = np.clip(y[0].numpy() * 255, 0, 255)
+            gray3 = lambda g: np.stack([g, g, g], axis=-1)  # noqa: E731
+            rows.append(np.concatenate([rgb, gray3(pred), gray3(tgt)], axis=1).astype(np.uint8))
+    Image.fromarray(np.concatenate(rows, axis=0)).save(path)
+
+
 def main() -> None:
     args = parse_args()
     torch.manual_seed(args.seed)
     np.random.seed(args.seed)
     device = ("cuda" if torch.cuda.is_available() else "cpu") if args.device == "auto" else args.device
-    print(f"device: {device}")
+    print(f"device: {device} | data: {', '.join(args.data)}")
 
     train_ds = EdgeDataset(args.data, "train", args.size, args.limit)
     val_ds = EdgeDataset(args.data, "val", args.size)
@@ -68,6 +92,8 @@ def main() -> None:
     out_dir = Path(args.out)
     out_dir.mkdir(parents=True, exist_ok=True)
     best = float("inf")
+    best_epoch = 0
+    stale = 0
     for epoch in range(args.epochs):
         model.train()
         total = 0.0
@@ -97,8 +123,10 @@ def main() -> None:
         print(f"epoch {epoch + 1}/{args.epochs} | train {train_loss:.4f} | val {val_loss:.4f} | val F {val_f:.3f}")
 
         score = val_loss if v_n else train_loss
-        if score < best:
+        if score < best - 1e-5:
             best = score
+            best_epoch = epoch + 1
+            stale = 0
             torch.save(
                 {
                     "state_dict": model.state_dict(),
@@ -111,7 +139,14 @@ def main() -> None:
                 },
                 out_dir / "edge-prepass.pt",
             )
-    print(f"best {best:.4f} → {out_dir / 'edge-prepass.pt'}")
+            save_preview(model, val_ds if v_n else train_ds, out_dir / "preview.png", device)
+        else:
+            stale += 1
+            if args.patience > 0 and stale >= args.patience:
+                print(f"early stop: no val improvement for {args.patience} epochs")
+                break
+
+    print(f"best {best:.4f} at epoch {best_epoch} → {out_dir / 'edge-prepass.pt'}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this adds

The groundwork for making the tracer stronger on **degraded** input (JPEG blocks, resampling ringing, noise, anti-aliasing) via optional, on-device ML that conditions the *input* to the deterministic classical core — plus the dataset + training pipeline to produce the models, and a classical SVG-quality improvement along the way.

Everything ML is **Tier-2 and fail-soft**: no weights are committed, and with none present the app traces exactly as it does today. The project's own models are served **same-origin** as static app assets (not Hugging Face); the existing third-party models (u2netp, SlimSAM) keep fetching from their upstream mirrors, unchanged.

## Highlights

**Strategy & specs** — `docs/ML_STRATEGY.md` (two-tier determinism contract, dataset sizing), `docs/EDGE_PREPASS.md`, `docs/CLEANUP_PREPASS.md`, and an animated `docs/how-it-works.svg` system diagram.

**Dataset generator** (`scripts/dataset/`) — seeded, reproducible SVG→render→degrade pipeline emitting pixel-aligned `(input, edge)` and `(input, clean)` pairs, split by source family. Multithreaded across worker threads; verified byte-identical across `--jobs`.

**Training** (`scripts/train/`) — PyTorch scaffold with two tasks (`--task edge|cleanup`) over one dataset, one-command `pipeline.py`, ONNX export with torch/onnxruntime parity check + int8 quantize, cross-platform bootstrap (`setup.sh` / `setup.ps1`), a from-scratch README (Linux + Windows, incl. the GPU/CUDA and PowerShell gotchas), and a `--smoke` end-to-end sanity check.

**`@vectorizer/ml`** — `EdgeEnhancer` (boundary map) and `CleanupEnhancer` (denoised RGB), both mirroring `BackgroundRemover`: WebGPU→WASM via onnxruntime-web, Cache-Storage model store, tiled inference, reproducible-mode WASM pin. New `edge-prepass` / `cleanup` registry ids resolve same-origin.

**Engine & app integration** — the edge hint crosses the worker boundary, is discretized once (`edgeProtectMask`), and now conditions **every mode**: it guards the bw/centerline despeckle and the color/grayscale small-region merge (`MergeOptions.protect`). Studio gets an **Edge pre-pass (ML)** toggle and a **Clean up (ML)** one-shot button.

**Classical quality** — `@vectorizer/svg` now detects axis-aligned **rounded rectangles** → `<rect rx>` (SDF fit, gated behind `roundPrimitives`, off for cutout to preserve byte-identical geometry).

## Determinism

The classical path is untouched and stays byte-identical. ML output is discretized before the tracer (a threshold for the edge hint; the 8-bit RGB image for cleanup), so cross-GPU float noise is absorbed; reproducible mode pins WASM for a hard cross-device guarantee.

## Verification

- `npm run check` (lint + fmt + typecheck + test) and `npm run build` all green locally — 240 tests pass.
- Training + ONNX export verified end-to-end on CPU here for both tasks (parity ~6e-8); **the author has since confirmed the training script runs on GPU.**
- No model weights are committed; `apps/web/public/models/*.onnx` are produced by training and dropped in to ship.

Stats: 16 commits, 61 files, +4393/−51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKtj2W6thn3FzbhKujKkhh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKtj2W6thn3FzbhKujKkhh)_