### PR TITLE
ci: fetch model weights at deploy + real-corpus fetcher + clearer model-load errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,28 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      # Fetch the project's own model weights and place them where Vite copies
+      # them into the build (apps/web/public/ → dist/), so they ship same-origin
+      # WITHOUT being committed to git. Source: a GitHub Release on this repo
+      # (default tag `models`; override with the MODELS_RELEASE_TAG repo variable)
+      # with `edge-prepass.onnx` / `cleanup.onnx` attached as assets. Fail-soft:
+      # if the release or assets are absent the build proceeds with no weights and
+      # the app traces classically.
+      - name: Fetch model weights
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODELS_TAG: ${{ vars.MODELS_RELEASE_TAG || 'models' }}
+        run: |
+          mkdir -p apps/web/public/models
+          if gh release view "$MODELS_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Fetching *.onnx from release '$MODELS_TAG'…"
+            gh release download "$MODELS_TAG" --repo "$GITHUB_REPOSITORY" \
+              --dir apps/web/public/models --pattern '*.onnx' --clobber \
+              || echo "release '$MODELS_TAG' has no .onnx assets — building without weights"
+          else
+            echo "no '$MODELS_TAG' release — building without ML weights (app traces classically)"
+          fi
+          ls -la apps/web/public/models
       - run: npm run build
         env:
           # Project pages are served from /<repo>/ — the app reads this at build time.

--- a/.gitignore
+++ b/.gitignore
@@ -152,9 +152,10 @@ dist/
 e2e-artifacts/
 
 # Generated ML training datasets (scripts/dataset) and the fetched real corpus
-# (scripts/corpus). Both are reproducible from scripts — never committed.
-dataset-out/
-corpus/
+# (scripts/corpus). Both are reproducible from scripts — never committed. Anchored
+# to the repo root so the scripts/ source dirs stay tracked.
+/dataset-out/
+/corpus/
 
 # ML model weights are never committed: the deploy workflow fetches them from a
 # GitHub Release and Vite copies them into the build (served same-origin). So

--- a/.gitignore
+++ b/.gitignore
@@ -151,13 +151,15 @@ dist/
 # Local E2E artifacts
 e2e-artifacts/
 
-# Generated ML training datasets (scripts/dataset)
+# Generated ML training datasets (scripts/dataset) and the fetched real corpus
+# (scripts/corpus). Both are reproducible from scripts — never committed.
 dataset-out/
+corpus/
 
-# ML model weights: keep scratch/training weights out of git, but track the
-# project's own shipped model — served same-origin from the app's static assets.
+# ML model weights are never committed: the deploy workflow fetches them from a
+# GitHub Release and Vite copies them into the build (served same-origin). So
+# ignore *.onnx everywhere, including the app's models dir.
 *.onnx
-!apps/web/public/models/*.onnx
 
 # Training scratch: checkpoints (.pt) and preview montages (scripts/train)
 scripts/train/checkpoints/

--- a/apps/web/public/models/README.md
+++ b/apps/web/public/models/README.md
@@ -5,24 +5,34 @@ Project-owned ML weights that ship **with the app**, served same-origin (no CORS
 `${import.meta.env.BASE_URL}models/<name>.onnx` on the deployed site.
 
 This is deliberately different from the third-party models (`u2netp`, SlimSAM), which are fetched at runtime from their
-upstream mirrors. Models the project trains itself live here instead.
+upstream mirrors. Models the project trains itself are served from here instead.
 
-## edge-prepass.onnx
+## Weights are fetched at deploy, not committed
 
-The learned edge pre-pass (see [`../../../../docs/EDGE_PREPASS.md`](../../../../docs/EDGE_PREPASS.md)). Not committed yet
-— train it on data from [`../../../../scripts/dataset`](../../../../scripts/dataset/README.md), export to ONNX, and drop
-it here as `edge-prepass.onnx`. `MODEL_REGISTRY['edge-prepass']` already points at `models/edge-prepass.onnx`; the app
-resolves that against its deploy base. Until the file exists, `EdgeEnhancer.create()` fails soft and the app traces
-classically.
+`*.onnx` is **git-ignored** — no multi-MB binaries in history. Instead the deploy workflow
+([`.github/workflows/deploy.yml`](../../../../.github/workflows/deploy.yml)) downloads them into this directory just
+before `npm run build`, so they land in `dist/` and ship same-origin. The source is a **GitHub Release on this repo**
+(default tag `models`; override with the `MODELS_RELEASE_TAG` repo variable) with the `.onnx` files attached as assets.
 
-## cleanup.onnx
+To publish/refresh a model:
 
-The learned cleanup pre-pass (see [`../../../../docs/CLEANUP_PREPASS.md`](../../../../docs/CLEANUP_PREPASS.md)) — an
-image→image denoise/deblock that the studio's **Clean up (ML)** button runs before tracing, in any mode. Not committed yet
-— train it with `python scripts/train/pipeline.py --task cleanup` (same dataset as the edge model) and drop the ONNX here
-as `cleanup.onnx`. `MODEL_REGISTRY.cleanup` already points at `models/cleanup.onnx`. Until the file exists,
-`CleanupEnhancer.create()` fails soft and the working image is left untouched.
+1. Train and export it (see [`../../../../scripts/train`](../../../../scripts/train/README.md)) →
+   `edge-prepass.onnx` and/or `cleanup.onnx`.
+2. Attach it to the `models` release (create the release once, then update its assets):
+   ```sh
+   gh release create models edge-prepass.onnx cleanup.onnx --title "Model weights" --notes "on-device pre-pass weights"
+   # later, to replace:
+   gh release upload models edge-prepass.onnx --clobber
+   ```
+3. Re-run the Pages deploy (push to `main`, or trigger the workflow manually). The new weights are live.
 
-`*.onnx` here is force-tracked (the repo's root `.gitignore` keeps scratch weights out but allows this directory). The
-binary is a few MB; if the repo accumulates several models, track them with **Git LFS** (`git lfs track
-"apps/web/public/models/*.onnx"`) to keep clones lean.
+Locally you can drop a `.onnx` here by hand to test — it's git-ignored, so it won't be committed.
+
+## The models
+
+- **`edge-prepass.onnx`** — the learned edge pre-pass ([`docs/EDGE_PREPASS.md`](../../../../docs/EDGE_PREPASS.md)).
+  `MODEL_REGISTRY['edge-prepass']` points at `models/edge-prepass.onnx`. Until it exists, `EdgeEnhancer.create()` fails
+  soft and the app traces classically.
+- **`cleanup.onnx`** — the learned cleanup pre-pass ([`docs/CLEANUP_PREPASS.md`](../../../../docs/CLEANUP_PREPASS.md)),
+  run by the studio's **Clean up (ML)** button. `MODEL_REGISTRY.cleanup` points at `models/cleanup.onnx`. Until it exists,
+  `CleanupEnhancer.create()` fails soft and the working image is left untouched.

--- a/docs/CLEANUP_PREPASS.md
+++ b/docs/CLEANUP_PREPASS.md
@@ -84,10 +84,12 @@ Identical to the edge pre-pass, task-aware ([`export_onnx.py`](../scripts/train/
 
 - Export PyTorch → **ONNX**, verify torch/onnxruntime parity within tolerance, then quantize (int8/fp16).
 - Output shape is asserted `[1, 3, size, size]`.
-- **Host it as a project asset, not on a third party.** Drop the ONNX at `apps/web/public/models/cleanup.onnx`; Vite
-  serves it **same-origin** (no CORS, no external host — unlike the third-party `u2netp`/SlimSAM, which keep fetching from
-  their upstream mirrors). The registry points at `models/cleanup.onnx`; the app resolves it against its deploy base at
-  runtime with `overrideModelUrl` and `import.meta.env.BASE_URL`.
+- **Host it as a project asset, not on a third party, and don't commit it.** `*.onnx` is git-ignored; the deploy workflow
+  fetches the weights from a **GitHub Release** (tag `models`) into `apps/web/public/models/cleanup.onnx` at build time, so
+  Vite serves them **same-origin** (no CORS, no external host — unlike the third-party `u2netp`/SlimSAM, which keep
+  fetching from their upstream mirrors) with no binary in git history. The registry points at `models/cleanup.onnx`; the
+  app resolves it against its deploy base with `overrideModelUrl` and `import.meta.env.BASE_URL`. See
+  [`apps/web/public/models/README.md`](../apps/web/public/models/README.md) for the publish steps.
 
 ## Integration (`@vectorizer/ml`)
 

--- a/docs/EDGE_PREPASS.md
+++ b/docs/EDGE_PREPASS.md
@@ -81,12 +81,13 @@ Offline, in PyTorch (not part of the repo's Node/TS build):
 - Export PyTorch → **ONNX** (a widely supported opset), then quantize (int8/fp16) with `onnxruntime`'s tooling.
 - **Parity check:** assert the ONNX (WASM EP) output matches PyTorch within tolerance on a fixed sample set before
   shipping weights.
-- **Host it as a project asset, not on a third party.** Drop the ONNX at `apps/web/public/models/edge-prepass.onnx`;
-  Vite serves it **same-origin** from the deployed site, so there is no CORS and no external host (unlike the third-party
-  `u2netp`/SlimSAM, which are fetched from their upstream mirrors). The binary is a few MB and force-tracked by git (the
-  root `.gitignore` keeps scratch weights out but allows that path); reach for **Git LFS** if several models accumulate.
-  The registry already points at `models/edge-prepass.onnx`; the app resolves it against its deploy base at startup with
-  `overrideModelUrl` and `import.meta.env.BASE_URL`.
+- **Host it as a project asset, not on a third party, and don't commit it.** The weights are **not** in git (`*.onnx` is
+  git-ignored). Instead the deploy workflow fetches them from a **GitHub Release** (tag `models`) into
+  `apps/web/public/models/edge-prepass.onnx` just before the build, so Vite serves them **same-origin** from the deployed
+  site — no CORS, no external host (unlike the third-party `u2netp`/SlimSAM, which are fetched from their upstream
+  mirrors), and no multi-MB binary in history. The registry already points at `models/edge-prepass.onnx`; the app resolves
+  it against its deploy base at startup with `overrideModelUrl` and `import.meta.env.BASE_URL`. See
+  [`apps/web/public/models/README.md`](../apps/web/public/models/README.md) for the publish steps.
 
 ## Integration (`@vectorizer/ml`)
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "e2e": "node scripts/e2e.mjs",
     "test:render": "node scripts/svg-render-check.mjs",
     "dataset": "node scripts/dataset/generate.mjs",
+    "corpus": "node scripts/corpus/fetch.mjs",
     "check": "npm run lint && npm run fmt:check && npm run typecheck && npm run test"
   },
   "devDependencies": {

--- a/packages/ml/src/registry.ts
+++ b/packages/ml/src/registry.ts
@@ -35,8 +35,9 @@ export const MODEL_REGISTRY: Record<ModelSpec['id'], ModelSpec> = {
     // it from the very site it is served from — no CORS, no external host. This
     // default is relative; the app resolves it against its deploy base at startup
     // with overrideModelUrl(`${import.meta.env.BASE_URL}models/edge-prepass.onnx`).
-    // No weights exist yet: train per docs/EDGE_PREPASS.md on scripts/dataset
-    // output and drop the file in place. Until then create() fails soft (the
+    // Weights are not committed: the deploy workflow fetches them from a GitHub
+    // Release into apps/web/public/models/ at build time (train per
+    // docs/EDGE_PREPASS.md). Until a build includes them, create() fails soft (the
     // fetch 404s) and the app traces exactly as it does today.
     url: 'models/edge-prepass.onnx',
     approxBytes: 3_000_000,
@@ -47,9 +48,10 @@ export const MODEL_REGISTRY: Record<ModelSpec['id'], ModelSpec> = {
     // The project's own model (see edge-prepass above for the same-origin
     // rationale): shipped as a static app asset, resolved against the deploy base
     // at startup with overrideModelUrl(`${import.meta.env.BASE_URL}models/cleanup.onnx`).
-    // No weights exist yet: train per docs/CLEANUP_PREPASS.md (scripts/train
-    // --task cleanup) and drop the file in place. Until then create() fails soft
-    // (the fetch 404s) and the app leaves the image untouched.
+    // Weights are not committed: the deploy workflow fetches them from a GitHub
+    // Release into apps/web/public/models/ at build time (train per
+    // docs/CLEANUP_PREPASS.md, scripts/train --task cleanup). Until a build
+    // includes them, create() fails soft and the app leaves the image untouched.
     url: 'models/cleanup.onnx',
     approxBytes: 3_000_000,
     license: 'MIT',

--- a/packages/ml/src/store.ts
+++ b/packages/ml/src/store.ts
@@ -14,6 +14,27 @@ async function openCache(): Promise<Cache | null> {
   }
 }
 
+/**
+ * Reject a body that is obviously not an ONNX model — an HTML page (dev SPA
+ * fallback, an error page, a login redirect) starts with `<` after optional BOM/
+ * whitespace, whereas an ONNX protobuf starts with 0x08 (the ir_version field).
+ * Throwing here (before the caller caches) turns ORT's opaque "protobuf parsing
+ * failed" into an actionable message.
+ */
+function assertModelBytes(buffer: ArrayBuffer, spec: ModelSpec): void {
+  const bytes = new Uint8Array(buffer)
+  let i = 0
+  // Skip a UTF-8 BOM and leading ASCII whitespace.
+  if (bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) i = 3
+  while (i < bytes.length && (bytes[i] === 0x20 || (bytes[i] >= 0x09 && bytes[i] <= 0x0d))) i++
+  if (bytes.length === 0 || bytes[i] === 0x3c) {
+    throw new Error(
+      `Model for ${spec.id} is not a valid ONNX file (got ${bytes.length === 0 ? 'an empty response' : 'an HTML/XML page'}) from ${spec.url} — ` +
+        `the file is likely missing (in dev, place it at apps/web/public/models/).`,
+    )
+  }
+}
+
 async function downloadModel(spec: ModelSpec, onProgress?: MlProgressFn): Promise<ArrayBuffer> {
   if (typeof fetch === 'undefined') {
     throw new Error('Model download failed (no network access in this environment)')
@@ -27,10 +48,21 @@ async function downloadModel(spec: ModelSpec, onProgress?: MlProgressFn): Promis
   if (!response.ok) {
     throw new Error(`Model download failed (HTTP ${response.status} for ${spec.id})`)
   }
+  // A dev server's SPA fallback answers an unknown path with 200 + index.html, so
+  // response.ok is not enough: an HTML body would then be cached and later fail
+  // ORT with a cryptic "protobuf parsing failed". Reject it here with a clear
+  // message so nothing bad is cached.
+  if ((response.headers.get('Content-Type') ?? '').includes('text/html')) {
+    throw new Error(
+      `Model for ${spec.id} was served as HTML, not a model, from ${spec.url} — ` +
+        `the file is likely missing (in dev, place it at apps/web/public/models/).`,
+    )
+  }
   const total = Number(response.headers.get('Content-Length') ?? '') || 0
   const body = response.body
   if (!body) {
     const buffer = await response.arrayBuffer()
+    assertModelBytes(buffer, spec)
     onProgress?.({
       phase: 'download',
       id: spec.id,
@@ -62,6 +94,7 @@ async function downloadModel(spec: ModelSpec, onProgress?: MlProgressFn): Promis
     out.set(chunk, offset)
     offset += chunk.byteLength
   }
+  assertModelBytes(out.buffer, spec)
   return out.buffer
 }
 

--- a/packages/ml/test/store.test.ts
+++ b/packages/ml/test/store.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ModelStore } from '../src/store'
+import type { ModelSpec } from '../src/registry'
+
+const spec: ModelSpec = {
+  id: 'edge-prepass',
+  url: '/models/edge-prepass.onnx',
+  approxBytes: 1,
+  license: 'MIT',
+}
+
+function respondWith(body: BodyInit, contentType?: string): void {
+  const headers: Record<string, string> = {}
+  if (contentType) headers['Content-Type'] = contentType
+  vi.stubGlobal('fetch', async () => new Response(body, { status: 200, headers }))
+}
+
+// `caches` is undefined under vitest's node env, so ModelStore.fetch goes
+// straight to the network path — exactly where the guards live.
+describe('ModelStore.fetch model-body guards', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('rejects an HTML page served as text/html (dev SPA fallback)', async () => {
+    respondWith('<!doctype html><html><body>app</body></html>', 'text/html')
+    await expect(new ModelStore().fetch(spec)).rejects.toThrow(/HTML/)
+  })
+
+  it('rejects an HTML/XML body even without a text/html content-type', async () => {
+    respondWith('<!doctype html>\n<html></html>', 'application/octet-stream')
+    await expect(new ModelStore().fetch(spec)).rejects.toThrow(/not a valid ONNX/)
+  })
+
+  it('rejects an empty body', async () => {
+    respondWith('', 'application/octet-stream')
+    await expect(new ModelStore().fetch(spec)).rejects.toThrow(/not a valid ONNX/)
+  })
+
+  it('accepts a real model body (starts with the protobuf 0x08 tag)', async () => {
+    respondWith(new Uint8Array([0x08, 0x07, 0x12, 0x04]), 'application/octet-stream')
+    const buf = await new ModelStore().fetch(spec)
+    expect(new Uint8Array(buf)[0]).toBe(0x08)
+  })
+})

--- a/scripts/corpus/README.md
+++ b/scripts/corpus/README.md
@@ -1,0 +1,44 @@
+# Real SVG corpus fetcher
+
+`npm run corpus` downloads known, permissively-licensed SVG collections and lays them out **by category** for the dataset
+generator's real-corpus mode ([`../dataset`](../dataset/README.md)). It's the "real" half of the recommended
+**~⅔ procedural + ~⅓ real** training mix ([`../../docs/ML_STRATEGY.md`](../../docs/ML_STRATEGY.md)).
+
+Nothing here is committed — `corpus/` is git-ignored and fully reproducible from this script.
+
+## Usage
+
+```sh
+npm run corpus                        # default sources (icons, brands, flags; emoji excluded)
+npm run corpus -- --only icons,flags  # subset by category or pack id
+npm run corpus -- --all               # include optional/large sources (emoji)
+npm run corpus -- --limit-per-source 300 --buckets 16
+npm run corpus -- --clean             # wipe the npm cache first (fresh download)
+```
+
+Then feed it to the generator and mix with procedural data:
+
+```sh
+npm run corpus
+npm run dataset -- --source dir --corpus corpus --count 20000 --out data/real
+npm run dataset -- --source procedural  --count 40000 --out data/proc
+python scripts/train/train.py --data data/proc data/real --epochs 80 --workers 8
+```
+
+## How it works
+
+- Each source is an **npm package** (see [`sources.mjs`](sources.mjs)), installed into a local cache
+  (`corpus/.cache/`, ignored by the generator) — no scraping, no auth, versions resolved by npm, cross-platform.
+- Its `.svg` files are copied to `corpus/<category>/<pack>/<bucket>/`. Files are **sharded into buckets** (default 12) by
+  a stable hash of the name.
+- The generator treats each leaf directory (`<category>/<pack>/<bucket>`) as one **split family**, assigned wholesale to
+  train/val/test — so no pack straddles splits, and the many buckets keep the 80/10/10 split balanced. (A tiny
+  single-pack fetch can land an empty val/test — add more sources for a balanced split.)
+- `corpus/manifest.json` and `corpus/LICENSES.md` record what was fetched, the resolved versions, counts, and licenses.
+
+## Sources & licenses
+
+All permissive (MIT / ISC / Apache-2.0 / CC0), except OpenMoji (CC-BY-SA-4.0, opt-in via `--all`). Training on them is
+fine; if you **redistribute** the corpus, honor each pack's terms — they're listed in the generated `corpus/LICENSES.md`.
+Default set: Lucide, Tabler, Feather, Bootstrap Icons, Heroicons, Material Design Icons (icons); Simple Icons (brands);
+flag-icons (flags). Add your own by appending to [`sources.mjs`](sources.mjs) — any npm package with `.svg` files works.

--- a/scripts/corpus/fetch.mjs
+++ b/scripts/corpus/fetch.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+// Fetch known, permissively-licensed SVG collections and lay them out by category
+// for the dataset generator's `--source dir` mode. Sources are npm packages
+// (scripts/corpus/sources.mjs); each is installed into a local cache and its .svg
+// files copied into corpus/<category>/<pack>/<bucket>/, sharded into buckets so
+// the generator's per-family split (top-level-through-leaf dir = family) is
+// balanced across train/val/test. Nothing here is committed (corpus/ is ignored).
+//
+// Usage:
+//   npm run corpus                       # default sources (emoji excluded)
+//   npm run corpus -- --only icons,flags # subset by category or pack id
+//   npm run corpus -- --all              # include optional/large sources (emoji)
+//   npm run corpus -- --limit-per-source 300 --buckets 16
+//   npm run corpus -- --clean            # also wipe the npm cache first
+//
+// Then:  npm run dataset -- --source dir --corpus corpus --count 20000 --out data/real
+
+import { spawnSync } from 'node:child_process'
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { basename, join, relative, sep } from 'node:path'
+import { SOURCES } from './sources.mjs'
+
+const DEFAULTS = { out: 'corpus', limitPerSource: 600, buckets: 12 }
+
+function parseArgs(argv) {
+  const cfg = { ...DEFAULTS, only: null, all: false, clean: false, refresh: false }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    const next = () => argv[++i]
+    switch (a) {
+      case '--out':
+        cfg.out = next()
+        break
+      case '--only':
+        cfg.only = next()
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+        break
+      case '--limit-per-source':
+        cfg.limitPerSource = Math.max(0, Number(next()) || 0)
+        break
+      case '--buckets':
+        cfg.buckets = Math.max(1, Number(next()) || 1)
+        break
+      case '--all':
+        cfg.all = true
+        break
+      case '--clean':
+        cfg.clean = true
+        break
+      case '--refresh':
+        cfg.refresh = true
+        break
+      case '-h':
+      case '--help':
+        printUsage()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`unknown arg: ${a}`)
+    }
+  }
+  return cfg
+}
+
+function printUsage() {
+  console.log(
+    'corpus fetcher — download known SVG sets, laid out by category for `--source dir`\n\n' +
+      'Options:\n' +
+      '  --only <a,b>            categories or pack ids to include (default: all non-optional)\n' +
+      '  --all                  include optional/large sources (emoji)\n' +
+      '  --limit-per-source <n> cap copied files per pack (default 600; 0 = no cap)\n' +
+      '  --buckets <n>          shards per pack for a balanced split (default 12)\n' +
+      '  --out <dir>            output dir (default corpus)\n' +
+      '  --clean                wipe the npm cache before fetching\n' +
+      '  --refresh              re-install packages even if already cached\n',
+  )
+}
+
+/** FNV-1a → 32-bit, for stable bucket assignment (no crypto needed). */
+function hash32(str) {
+  let h = 0x811c9dc5
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return h >>> 0
+}
+
+function selected(cfg) {
+  let list = SOURCES.filter((s) => cfg.all || !s.optional)
+  if (cfg.only) list = list.filter((s) => cfg.only.includes(s.category) || cfg.only.includes(s.id))
+  if (list.length === 0) throw new Error('no sources selected — check --only / --all')
+  return list
+}
+
+function walkSvg(dir) {
+  const out = []
+  if (!existsSync(dir)) return out
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...walkSvg(full))
+    else if (entry.name.toLowerCase().endsWith('.svg')) out.push(full)
+  }
+  return out
+}
+
+/** Install one package into the cache prefix; return its resolved version or null. */
+function install(source, cacheDir, refresh) {
+  const pkgDir = join(cacheDir, 'node_modules', source.pkg)
+  if (!refresh && existsSync(join(pkgDir, 'package.json'))) return readVersion(pkgDir)
+  const spec = `${source.pkg}@${source.version}`
+  console.log(`  installing ${spec}…`)
+  const cmd =
+    `npm install "${spec}" --prefix "${cacheDir}" --no-save --omit=dev ` +
+    `--no-audit --no-fund --loglevel=error`
+  const r = spawnSync(cmd, { shell: true, stdio: 'inherit' })
+  if (r.status !== 0 || !existsSync(join(pkgDir, 'package.json'))) return null
+  return readVersion(pkgDir)
+}
+
+function readVersion(pkgDir) {
+  try {
+    return JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8')).version ?? 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+function main() {
+  const cfg = parseArgs(process.argv.slice(2))
+  const sources = selected(cfg)
+  const outDir = cfg.out
+  const cacheDir = join(outDir, '.cache')
+  if (cfg.clean && existsSync(cacheDir)) rmSync(cacheDir, { recursive: true, force: true })
+  mkdirSync(cacheDir, { recursive: true })
+  // npm wants a package.json at the prefix to install into its node_modules.
+  const cachePkg = join(cacheDir, 'package.json')
+  if (!existsSync(cachePkg))
+    writeFileSync(cachePkg, JSON.stringify({ name: 'corpus-cache', private: true }))
+
+  console.log(
+    `Fetching ${sources.length} source(s) → ${outDir}/ (buckets=${cfg.buckets}, limit/source=${cfg.limitPerSource || '∞'})\n`,
+  )
+
+  const report = []
+  for (const source of sources) {
+    console.log(`• ${source.category}/${source.id} (${source.pkg}, ${source.license})`)
+    const version = install(source, cacheDir, cfg.refresh)
+    if (!version) {
+      console.warn(`  ! skipped — install failed for ${source.pkg}`)
+      report.push({ ...source, version: null, count: 0, skipped: true })
+      continue
+    }
+    const pkgRoot = join(cacheDir, 'node_modules', source.pkg)
+    const srcRoot = source.dir ? join(pkgRoot, source.dir) : pkgRoot
+    let files = walkSvg(srcRoot)
+    if (files.length === 0 && source.dir) files = walkSvg(pkgRoot) // layout drifted — search all
+    files = files.toSorted()
+    if (cfg.limitPerSource > 0) files = files.slice(0, cfg.limitPerSource)
+
+    const destBase = join(outDir, source.category, source.id)
+    rmSync(destBase, { recursive: true, force: true }) // fresh per source
+    let n = 0
+    for (const file of files) {
+      // Preserve the sub-path in the name so basenames never collide, and shard.
+      const relName =
+        relative(files.length ? srcRoot : pkgRoot, file).replaceAll(sep, '-') || basename(file)
+      const bucket = String(hash32(relName) % cfg.buckets).padStart(2, '0')
+      const dest = join(destBase, bucket, relName)
+      mkdirSync(join(destBase, bucket), { recursive: true })
+      cpSync(file, dest)
+      n++
+    }
+    console.log(`  ${n} svg → ${destBase}/`)
+    report.push({ ...source, version, count: n, skipped: false })
+  }
+
+  writeReport(outDir, cfg, report)
+  summarize(report)
+}
+
+function writeReport(outDir, cfg, report) {
+  const byCategory = {}
+  for (const r of report) byCategory[r.category] = (byCategory[r.category] ?? 0) + r.count
+  const total = report.reduce((a, r) => a + r.count, 0)
+  writeFileSync(
+    join(outDir, 'manifest.json'),
+    `${JSON.stringify({ buckets: cfg.buckets, limitPerSource: cfg.limitPerSource, total, byCategory, sources: report }, null, 2)}\n`,
+  )
+  const rows = report
+    .map(
+      (r) =>
+        `| ${r.category}/${r.id} | ${r.pkg}@${r.version ?? '—'} | ${r.license} | ${r.count} | ${r.home} |`,
+    )
+    .join('\n')
+  writeFileSync(
+    join(outDir, 'LICENSES.md'),
+    '# Corpus sources & licenses\n\n' +
+      "Fetched by `npm run corpus` for local training only (not committed). Respect each pack's\n" +
+      'license if you redistribute the corpus.\n\n' +
+      '| source | package | license | files | home |\n| --- | --- | --- | --- | --- |\n' +
+      `${rows}\n`,
+  )
+}
+
+function summarize(report) {
+  const total = report.reduce((a, r) => a + r.count, 0)
+  const skipped = report.filter((r) => r.skipped).length
+  console.log(
+    `\ndone — ${total} svg across ${report.length - skipped} source(s)${skipped ? `, ${skipped} skipped` : ''}.`,
+  )
+  console.log('next: npm run dataset -- --source dir --corpus corpus --count 20000 --out data/real')
+  console.log(
+    '      then mix with procedural: python scripts/train/train.py --data data/proc data/real …',
+  )
+}
+
+main()

--- a/scripts/corpus/sources.mjs
+++ b/scripts/corpus/sources.mjs
@@ -1,0 +1,112 @@
+// Known, permissively-licensed SVG collections for the real-corpus half of the
+// training data (docs/ML_STRATEGY.md: mix procedural + real). Each is published
+// to npm, so the fetcher installs it into a cache and copies its .svg files out —
+// no scraping, no auth, version pinned by npm, cross-platform.
+//
+// `dir` is the subdirectory under the installed package that holds the .svg files
+// (''  = search the whole package). The fetcher falls back to a recursive search
+// if `dir` yields nothing, so a layout change across versions won't break a run.
+//
+// LICENSES — training on these is fine; if you redistribute the corpus, keep each
+// pack's terms. CC0/MIT/ISC/Apache are permissive; OFL is for fonts; OpenMoji is
+// CC-BY-SA (share-alike). Attribution lives in the generated corpus/LICENSES.md.
+
+/**
+ * @typedef {{ category: string, id: string, pkg: string, version: string,
+ *   dir: string, license: string, home: string, optional?: boolean }} Source
+ */
+
+/** @type {Source[]} */
+export const SOURCES = [
+  // Outline + filled icon sets — the bulk: clean, single-color, huge variety.
+  {
+    category: 'icons',
+    id: 'lucide',
+    pkg: 'lucide-static',
+    version: 'latest',
+    dir: 'icons',
+    license: 'ISC',
+    home: 'https://lucide.dev',
+  },
+  {
+    category: 'icons',
+    id: 'tabler',
+    pkg: '@tabler/icons',
+    version: 'latest',
+    dir: 'icons',
+    license: 'MIT',
+    home: 'https://tabler.io/icons',
+  },
+  {
+    category: 'icons',
+    id: 'feather',
+    pkg: 'feather-icons',
+    version: 'latest',
+    dir: 'dist/icons',
+    license: 'MIT',
+    home: 'https://feathericons.com',
+  },
+  {
+    category: 'icons',
+    id: 'bootstrap',
+    pkg: 'bootstrap-icons',
+    version: 'latest',
+    dir: 'icons',
+    license: 'MIT',
+    home: 'https://icons.getbootstrap.com',
+  },
+  {
+    category: 'icons',
+    id: 'heroicons',
+    pkg: 'heroicons',
+    version: 'latest',
+    dir: '',
+    license: 'MIT',
+    home: 'https://heroicons.com',
+  },
+  // Material Design Icons — very large (~7k). Great variety; heavy download.
+  {
+    category: 'icons',
+    id: 'mdi',
+    pkg: '@mdi/svg',
+    version: 'latest',
+    dir: 'svg',
+    license: 'Apache-2.0',
+    home: 'https://pictogrammers.com/library/mdi',
+    heavy: true,
+  },
+
+  // Brand marks — flat, geometric, distinctive silhouettes.
+  {
+    category: 'brands',
+    id: 'simple-icons',
+    pkg: 'simple-icons',
+    version: 'latest',
+    dir: 'icons',
+    license: 'CC0-1.0',
+    home: 'https://simpleicons.org',
+  },
+
+  // Country flags — multi-color, gradients, stripes: good for color/cleanup.
+  {
+    category: 'flags',
+    id: 'flag-icons',
+    pkg: 'flag-icons',
+    version: 'latest',
+    dir: 'flags/4x3',
+    license: 'MIT',
+    home: 'https://flagicons.lipis.dev',
+  },
+
+  // Emoji — colorful, complex paths. Large + CC-BY-SA, so off by default (--all).
+  {
+    category: 'emoji',
+    id: 'openmoji',
+    pkg: 'openmoji',
+    version: 'latest',
+    dir: '',
+    license: 'CC-BY-SA-4.0',
+    home: 'https://openmoji.org',
+    optional: true,
+  },
+]

--- a/scripts/dataset/generate.mjs
+++ b/scripts/dataset/generate.mjs
@@ -37,8 +37,9 @@ for (const s of SPLITS) {
 }
 
 // Assign a split from a stable hash of the split key (mulberry32 avalanches it).
-// For a real corpus the key is the source family (top-level subdir), so no source
-// SVG leaks across splits; procedural samples split on their own id.
+// For a real corpus the key is the source family (the file's subdir path), so a
+// whole pack/bucket lands in one split and no pack straddles them; procedural
+// samples split on their own id.
 function assignSplit(key) {
   const r = mulberry32(hashString(`${cfg.seed}:${key}`))()
   const { train, val } = cfg.split
@@ -105,7 +106,8 @@ function runPool(iterator, jobs, onRecord) {
       active++
       w.on('message', (msg) => {
         if (msg.type === 'record') {
-          onRecord(msg.record)
+          if (msg.record) onRecord(msg.record)
+          else skipped++
           feed(w)
         }
       })
@@ -125,6 +127,7 @@ function runPool(iterator, jobs, onRecord) {
 const records = []
 const started = Date.now()
 let n = 0
+let skipped = 0
 const onRecord = (rec) => {
   records.push(rec)
   if (++n % 64 === 0) console.log(`  ${n} samples…`)
@@ -132,7 +135,11 @@ const onRecord = (rec) => {
 
 const jobs = cfg.jobs > 0 ? cfg.jobs : (availableParallelism?.() ?? cpus().length)
 if (jobs <= 1) {
-  for (const item of buildItems()) onRecord(processItem(item, cfg))
+  for (const item of buildItems()) {
+    const rec = processItem(item, cfg)
+    if (rec) onRecord(rec)
+    else skipped++
+  }
 } else {
   await runPool(buildItems(), jobs, onRecord)
 }
@@ -160,5 +167,8 @@ writeManifest(join(cfg.out, 'manifest.json'), {
 
 console.log(
   `\ndone — ${records.length} samples (train ${counts.train}, val ${counts.val}, test ${counts.test}) ` +
-    `on ${jobs} job${jobs === 1 ? '' : 's'} in ${((Date.now() - started) / 1000).toFixed(1)}s → ${cfg.out}/`,
+    `on ${jobs} job${jobs === 1 ? '' : 's'} in ${((Date.now() - started) / 1000).toFixed(1)}s → ${cfg.out}/` +
+    (skipped > 0
+      ? `\n  (${skipped} SVG${skipped === 1 ? '' : 's'} skipped — resvg could not rasterize them)`
+      : ''),
 )

--- a/scripts/dataset/sample.mjs
+++ b/scripts/dataset/sample.mjs
@@ -13,14 +13,22 @@ import { edgeMap } from './targets.mjs'
 /**
  * @param item {{ index, id, family, split, base, svg, pipeSeed }}
  * @param cfg  resolved DatasetConfig
- * @returns the manifest record (carries `index` for a stable manifest sort)
+ * @returns the manifest record (carries `index` for a stable manifest sort), or
+ *   null when the SVG can't be rasterized (a real corpus has a few) — the caller
+ *   skips it rather than aborting the run.
  */
 export function processItem(item, cfg) {
   const { index, id, family, split, base, svg, pipeSeed } = item
   // One rng drives render → background → degrade, in that order (matches the
   // single-threaded sequence exactly).
   const rng = mulberry32(pipeSeed)
-  const shape = renderShape(svg, cfg, rng)
+  let shape
+  try {
+    shape = renderShape(svg, cfg, rng)
+  } catch {
+    // resvg rejects some real-world SVGs (invalid size, unsupported features).
+    return null
+  }
   const bg = makeBackground(cfg.resolution, cfg.resolution, rng, cfg.degrade.background)
   const clean = compositeOver(shape, bg)
   const input = degrade(clean, cfg, rng)

--- a/scripts/dataset/sources.mjs
+++ b/scripts/dataset/sources.mjs
@@ -4,7 +4,7 @@
 // drives the train/val/test split so no source family straddles splits.
 
 import { readdirSync, readFileSync } from 'node:fs'
-import { join, relative, sep } from 'node:path'
+import { dirname, join, relative, sep } from 'node:path'
 import { chance, gaussian, int, mulberry32, pick, seedFor, uniform } from './random.mjs'
 
 const ARCHETYPES = ['geo', 'blobs', 'rings', 'stripes', 'scatter']
@@ -29,9 +29,13 @@ export function* dirSource(dir, cap) {
   const list = cap > 0 ? files.slice(0, cap) : files
   for (const file of list) {
     const rel = relative(dir, file)
+    const famDir = dirname(rel)
     yield {
       id: rel.replaceAll(sep, '/'),
-      family: rel.split(sep)[0] || 'root', // top-level subdir is the source family
+      // The file's whole subdir path is the source family, so a nested corpus
+      // (e.g. category/pack/bucket) splits per leaf group and no pack straddles
+      // train/val/test. A file directly in `dir` is its own family (flat corpus).
+      family: famDir === '.' ? rel.replaceAll(sep, '/') : famDir.replaceAll(sep, '/'),
       svg: canonicalize(readFileSync(file, 'utf8')),
     }
   }
@@ -47,6 +51,7 @@ function canonicalize(svg) {
 function walkSvg(dir) {
   const out = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue // skip .cache, .git, dotfiles
     const full = join(dir, entry.name)
     if (entry.isDirectory()) out.push(...walkSvg(full))
     else if (entry.name.toLowerCase().endsWith('.svg')) out.push(full)

--- a/scripts/train/README.md
+++ b/scripts/train/README.md
@@ -12,8 +12,10 @@ Two tasks share this scaffold, selected with `--task` (one generated dataset tra
 | `edge` (default) | boundary map (1-ch)    | `edge`  | `edge-prepass.onnx` | [`EDGE_PREPASS.md`](../../docs/EDGE_PREPASS.md)       |
 | `cleanup`        | clean RGB image (3-ch) | `clean` | `cleanup.onnx`      | [`CLEANUP_PREPASS.md`](../../docs/CLEANUP_PREPASS.md) |
 
-These scripts are **not part of the JS build or CI** — they run only when you train. The weights are not committed;
-you generate them here and drop the `.onnx` in place.
+These scripts are **not part of the JS build or CI** — they run only when you train. The weights are not committed to
+git; you generate them here and publish them to the `models` GitHub Release, from which the deploy workflow fetches them
+at build time (see [`apps/web/public/models/README.md`](../../apps/web/public/models/README.md)). For a purely local
+try, dropping the `.onnx` into `apps/web/public/models/` also works — it's git-ignored.
 
 ## From scratch
 

--- a/scripts/train/README.md
+++ b/scripts/train/README.md
@@ -139,12 +139,14 @@ Start here, then adjust from what you see. Sizes are pairs (per `--count`).
 
 ### Data mix (the highest-leverage knob)
 
-Train on both a **procedural** set (unlimited, exact labels — prevents overfitting) and a **real corpus** (fonts, icon
-sets — realistic shapes). `--data` takes several roots and concatenates them:
+Train on both a **procedural** set (unlimited, exact labels — prevents overfitting) and a **real corpus** (icon sets,
+brand marks, flags — realistic shapes). Fetch a ready-made real corpus with `npm run corpus`
+([`../corpus`](../corpus/README.md)), then give `--data` several roots to concatenate:
 
 ```sh
+npm run corpus                                                      # → corpus/ (icons, brands, flags)
+npm run dataset -- --source dir --corpus corpus --count 20000 --out data/real
 npm run dataset -- --source procedural --count 40000 --out data/proc
-npm run dataset -- --source dir --corpus /path/to/svgs --count 20000 --out data/real
 python scripts/train/train.py --data data/proc data/real --epochs 80 --workers 8
 ```
 


### PR DESCRIPTION
Follow-up to #6. Three independent changes.

## 1. Deploy fetches weights instead of committing them

`*.onnx` is now fully git-ignored — no multi-MB binaries in history. The Pages deploy workflow downloads the model
weights from a **GitHub Release** on this repo (default tag `models`, override via the `MODELS_RELEASE_TAG` repo variable)
into `apps/web/public/models/` just before `npm run build`, so Vite copies them into `dist/` and they ship **same-origin**
— no CORS, no third-party host. Fail-soft: with no release/assets the build proceeds and the app traces classically.
Publish steps are in `apps/web/public/models/README.md`; docs (EDGE_PREPASS, CLEANUP_PREPASS, registry comments, train
README) updated from "drop it in place / force-tracked" to the release-fetch flow.

## 2. `npm run corpus` — fetch known training SVGs, by category

A one-command fetcher for the "real" half of the procedural+real training mix. It installs known, permissively-licensed
SVG packages (Lucide, Tabler, Feather, Bootstrap, Heroicons, MDI, Simple Icons, flag-icons; OpenMoji opt-in) from npm and
lays their `.svg` out as `corpus/<category>/<pack>/<bucket>/`, sharded so the generator's per-family split stays balanced,
with a `manifest.json` + `LICENSES.md`. Nothing committed (`corpus/` is git-ignored). Feeds straight into
`npm run dataset -- --source dir --corpus corpus`.

Two supporting fixes surfaced by testing it end-to-end:
- **dataset `dirSource`**: a file's whole subdir path is now its split family (was only the top-level segment), so a
  nested `category/pack/bucket` corpus splits per leaf and no pack straddles train/val/test. Flat corpora unchanged; dot-dirs
  (e.g. `corpus/.cache`) are skipped.
- **dataset generator**: skips an SVG resvg can't rasterize (a real corpus always has a few) instead of aborting the run,
  and reports the skip count.

## 3. Clearer model-load failures (`@vectorizer/ml`)

Hit while trying a freshly-trained model in dev: a dev server's SPA fallback answers an unknown path with `200 +
index.html`, so `response.ok` passed, the HTML got **cached**, and ORT then failed with a cryptic "protobuf parsing
failed" — and stayed failed. `ModelStore` now rejects, **before caching**, a body served as `text/html` or whose bytes
start with `<` (HTML/XML) or are empty, with a message pointing at the likely cause ("in dev, place it at
apps/web/public/models/"). Tests cover the four cases.

## Verification

`npm run check` (lint + fmt + typecheck + test) green — 268 tests — and `npm run build` green. The corpus fetcher was run
end-to-end (fetch → generate) and produced a balanced per-family split. The training scripts run on the author's GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKtj2W6thn3FzbhKujKkhh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKtj2W6thn3FzbhKujKkhh)_