### PR TITLE
feat(corpus): fetch general SVGs from non-npm sources (git + Wikimedia)

### DIFF
--- a/scripts/corpus/README.md
+++ b/scripts/corpus/README.md
@@ -9,11 +9,11 @@ Nothing here is committed — `corpus/` is git-ignored and fully reproducible fr
 ## Usage
 
 ```sh
-npm run corpus                        # default sources (icons, brands, flags; emoji excluded)
+npm run corpus                        # default: icons, brands, flags (npm) + illustrations (git)
 npm run corpus -- --only icons,flags  # subset by category or pack id
-npm run corpus -- --all               # include optional/large sources (emoji)
+npm run corpus -- --all               # also the opt-in sources: emoji + Wikimedia/openclipart
 npm run corpus -- --limit-per-source 300 --buckets 16
-npm run corpus -- --clean             # wipe the npm cache first (fresh download)
+npm run corpus -- --clean             # wipe the local cache first (fresh download)
 ```
 
 Then feed it to the generator and mix with procedural data:
@@ -27,18 +27,32 @@ python scripts/train/train.py --data data/proc data/real --epochs 80 --workers 8
 
 ## How it works
 
-- Each source is an **npm package** (see [`sources.mjs`](sources.mjs)), installed into a local cache
-  (`corpus/.cache/`, ignored by the generator) — no scraping, no auth, versions resolved by npm, cross-platform.
-- Its `.svg` files are copied to `corpus/<category>/<pack>/<bucket>/`. Files are **sharded into buckets** (default 12) by
-  a stable hash of the name.
-- The generator treats each leaf directory (`<category>/<pack>/<bucket>`) as one **split family**, assigned wholesale to
-  train/val/test — so no pack straddles splits, and the many buckets keep the 80/10/10 split balanced. (A tiny
-  single-pack fetch can land an empty val/test — add more sources for a balanced split.)
-- `corpus/manifest.json` and `corpus/LICENSES.md` record what was fetched, the resolved versions, counts, and licenses.
+Each source (see [`sources.mjs`](sources.mjs)) is fetched by its `type` into a local cache (`corpus/.cache/`, ignored by
+the generator), then its `.svg` files are copied to `corpus/<category>/<pack>/<bucket>/`:
+
+- **`npm`** — install a package, copy its SVGs (the icon/brand/flag/emoji libraries). No scraping, no auth, versioned by npm.
+- **`git`** — shallow-clone a repo, copy its SVGs (illustration packs). Just needs `git`.
+- **`wikimedia`** — download SVGs via the Wikimedia Commons API, **filtered to PD/CC0** and capped. This is how the general
+  clip-art/artwork comes in, including openclipart's CC0 library (mirrored on Commons under `Category:Openclipart`).
+
+Files are **sharded into buckets** (default 12) by a stable hash of the name. The generator treats each leaf directory
+(`<category>/<pack>/<bucket>`) as one **split family**, assigned wholesale to train/val/test — so no pack straddles
+splits, and the many buckets keep the 80/10/10 split balanced. (A tiny single-source fetch can land an empty val/test —
+add more sources for a balanced split.) `corpus/manifest.json` and `corpus/LICENSES.md` record what was fetched.
 
 ## Sources & licenses
 
-All permissive (MIT / ISC / Apache-2.0 / CC0), except OpenMoji (CC-BY-SA-4.0, opt-in via `--all`). Training on them is
-fine; if you **redistribute** the corpus, honor each pack's terms — they're listed in the generated `corpus/LICENSES.md`.
-Default set: Lucide, Tabler, Feather, Bootstrap Icons, Heroicons, Material Design Icons (icons); Simple Icons (brands);
-flag-icons (flags). Add your own by appending to [`sources.mjs`](sources.mjs) — any npm package with `.svg` files works.
+Default (verified, light): **icons** — Lucide, Tabler, Feather, Bootstrap Icons, Heroicons, Material Design Icons;
+**brands** — Simple Icons; **flags** — flag-icons; **illustrations** — free-gophers-pack (git, CC0).
+
+Opt-in (`--all`): **emoji** — OpenMoji (color, CC-BY-SA); **clipart** — openclipart (CC0, via Commons);
+**general** — Wikimedia Commons (PD/CC0). These are the general, complex artwork closest to real vectorizer inputs.
+
+> **Wikimedia/openclipart caveat:** the Commons API **rate-limits shared IPs** (CI, VPNs), so run those from your own
+> machine, and they trickle in slowly (the fetcher is polite and capped). Only PD/CC0 files are kept; a broad Commons
+> search is license-filtered, and `Category:Openclipart` is uniformly CC0.
+
+Everything is permissive (MIT / ISC / Apache-2.0 / CC0), except OpenMoji (CC-BY-SA-4.0). Training on them is fine; if you
+**redistribute** the corpus, honor each source's terms (listed in `corpus/LICENSES.md`). Add your own by appending to
+[`sources.mjs`](sources.mjs) — any npm package, git repo, or Commons category/query works. And `--source dir` on the
+generator accepts any folder of SVGs you supply yourself (e.g. a manual openclipart or SVG Repo bulk download).

--- a/scripts/corpus/fetch.mjs
+++ b/scripts/corpus/fetch.mjs
@@ -1,17 +1,21 @@
 #!/usr/bin/env node
 // Fetch known, permissively-licensed SVG collections and lay them out by category
-// for the dataset generator's `--source dir` mode. Sources are npm packages
-// (scripts/corpus/sources.mjs); each is installed into a local cache and its .svg
-// files copied into corpus/<category>/<pack>/<bucket>/, sharded into buckets so
-// the generator's per-family split (top-level-through-leaf dir = family) is
-// balanced across train/val/test. Nothing here is committed (corpus/ is ignored).
+// for the dataset generator's `--source dir` mode. Sources (scripts/corpus/sources.mjs)
+// come from three kinds of origin:
+//   - npm       — install a package, copy its .svg (icon/brand/flag/emoji libraries)
+//   - git       — shallow-clone a repo, copy its .svg (illustration packs)
+//   - wikimedia — download SVGs via the Wikimedia Commons API (general clip-art /
+//                 artwork, incl. openclipart's CC0 files); opt-in, license-filtered
+// Files are copied to corpus/<category>/<pack>/<bucket>/, sharded into buckets so the
+// generator's per-family split stays balanced. Nothing here is committed (corpus/ is
+// ignored).
 //
 // Usage:
-//   npm run corpus                       # default sources (emoji excluded)
+//   npm run corpus                       # default sources (npm + git; emoji/wikimedia off)
 //   npm run corpus -- --only icons,flags # subset by category or pack id
-//   npm run corpus -- --all              # include optional/large sources (emoji)
+//   npm run corpus -- --all              # include optional sources (emoji, wikimedia)
 //   npm run corpus -- --limit-per-source 300 --buckets 16
-//   npm run corpus -- --clean            # also wipe the npm cache first
+//   npm run corpus -- --clean            # also wipe the local cache first
 //
 // Then:  npm run dataset -- --source dir --corpus corpus --count 20000 --out data/real
 
@@ -29,6 +33,8 @@ import { basename, join, relative, sep } from 'node:path'
 import { SOURCES } from './sources.mjs'
 
 const DEFAULTS = { out: 'corpus', limitPerSource: 600, buckets: 12 }
+// Wikimedia asks API clients to send a descriptive User-Agent (their policy).
+const USER_AGENT = 'VectorizerCorpusBot/1.0 (https://github.com/PhenX/Vectorizer)'
 
 function parseArgs(argv) {
   const cfg = { ...DEFAULTS, only: null, all: false, clean: false, refresh: false }
@@ -77,12 +83,12 @@ function printUsage() {
     'corpus fetcher — download known SVG sets, laid out by category for `--source dir`\n\n' +
       'Options:\n' +
       '  --only <a,b>            categories or pack ids to include (default: all non-optional)\n' +
-      '  --all                  include optional/large sources (emoji)\n' +
-      '  --limit-per-source <n> cap copied files per pack (default 600; 0 = no cap)\n' +
+      '  --all                  include optional sources (emoji, wikimedia)\n' +
+      '  --limit-per-source <n> cap files per pack (default 600; 0 = no cap)\n' +
       '  --buckets <n>          shards per pack for a balanced split (default 12)\n' +
       '  --out <dir>            output dir (default corpus)\n' +
-      '  --clean                wipe the npm cache before fetching\n' +
-      '  --refresh              re-install packages even if already cached\n',
+      '  --clean                wipe the local cache before fetching\n' +
+      '  --refresh              re-fetch sources even if already cached\n',
   )
 }
 
@@ -107,6 +113,7 @@ function walkSvg(dir) {
   const out = []
   if (!existsSync(dir)) return out
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue
     const full = join(dir, entry.name)
     if (entry.isDirectory()) out.push(...walkSvg(full))
     else if (entry.name.toLowerCase().endsWith('.svg')) out.push(full)
@@ -114,39 +121,160 @@ function walkSvg(dir) {
   return out
 }
 
-/** Install one package into the cache prefix; return its resolved version or null. */
-function install(source, cacheDir, refresh) {
-  const pkgDir = join(cacheDir, 'node_modules', source.pkg)
-  if (!refresh && existsSync(join(pkgDir, 'package.json'))) return readVersion(pkgDir)
-  const spec = `${source.pkg}@${source.version}`
-  console.log(`  installing ${spec}…`)
-  const cmd =
-    `npm install "${spec}" --prefix "${cacheDir}" --no-save --omit=dev ` +
-    `--no-audit --no-fund --loglevel=error`
-  const r = spawnSync(cmd, { shell: true, stdio: 'inherit' })
-  if (r.status !== 0 || !existsSync(join(pkgDir, 'package.json'))) return null
-  return readVersion(pkgDir)
-}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+const sanitize = (s) => s.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'file'
 
-function readVersion(pkgDir) {
-  try {
-    return JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8')).version ?? 'unknown'
-  } catch {
-    return 'unknown'
+/** Files under `root` (recursive), falling back to `alt` when `root` has none. */
+function svgFiles(root, alt) {
+  let files = walkSvg(root)
+  let base = root
+  if (!files.length && alt && alt !== root) {
+    files = walkSvg(alt)
+    base = alt
   }
+  return { files: files.toSorted(), base }
 }
 
-function main() {
+/** npm: install the package, return its .svg files. */
+function provisionNpm(source, cacheDir, refresh) {
+  const pkgDir = join(cacheDir, 'node_modules', source.pkg)
+  if (refresh || !existsSync(join(pkgDir, 'package.json'))) {
+    const spec = `${source.pkg}@${source.version ?? 'latest'}`
+    console.log(`  installing ${spec}…`)
+    const cmd =
+      `npm install "${spec}" --prefix "${cacheDir}" --no-save --omit=dev ` +
+      `--no-audit --no-fund --loglevel=error`
+    const r = spawnSync(cmd, { shell: true, stdio: 'inherit' })
+    if (r.status !== 0 || !existsSync(join(pkgDir, 'package.json'))) return null
+  }
+  let version = 'unknown'
+  try {
+    version = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8')).version ?? 'unknown'
+  } catch {
+    /* keep 'unknown' */
+  }
+  const { files, base } = svgFiles(source.dir ? join(pkgDir, source.dir) : pkgDir, pkgDir)
+  return { files, base, version }
+}
+
+/** git: shallow-clone the repo, return its .svg files. */
+function provisionGit(source, cacheDir, refresh) {
+  const dest = join(cacheDir, 'git', source.id)
+  if (refresh && existsSync(dest)) rmSync(dest, { recursive: true, force: true })
+  if (!existsSync(join(dest, '.git'))) {
+    console.log(`  cloning ${source.repo}…`)
+    const args = ['clone', '--depth', '1']
+    if (source.ref) args.push('--branch', source.ref)
+    args.push(source.repo, dest)
+    const r = spawnSync('git', args, { stdio: 'inherit' })
+    if (r.status !== 0 || !existsSync(dest)) return null
+  }
+  let version = 'git'
+  const rev = spawnSync('git', ['-C', dest, 'rev-parse', '--short', 'HEAD'], { encoding: 'utf8' })
+  if (rev.status === 0) version = rev.stdout.trim()
+  const { files, base } = svgFiles(source.dir ? join(dest, source.dir) : dest, dest)
+  return { files, base, version }
+}
+
+/** Wikimedia Commons API: list SVG file titles (PD/CC0 only), paged to `cap`. */
+async function commonsTitles(source, cap) {
+  const base = 'https://commons.wikimedia.org/w/api.php'
+  const common =
+    'action=query&format=json&prop=imageinfo&iiprop=url|mime|extmetadata' +
+    '&iiextmetadatafilter=LicenseShortName|License'
+  const gen = source.wikimediaCategory
+    ? `generator=categorymembers&gcmtitle=Category:${encodeURIComponent(source.wikimediaCategory)}` +
+      '&gcmtype=file&gcmlimit=50'
+    : `generator=search&gsrnamespace=6&gsrlimit=50&gsrsearch=${encodeURIComponent(
+        `${source.query ?? 'svg'} filemime:image/svg+xml`,
+      )}`
+  const out = []
+  let cont = ''
+  const isOpen = /cc0|public domain|^pd$/i
+  for (let page = 0; page < 40 && out.length < cap; page++) {
+    const res = await fetch(`${base}?${common}&${gen}${cont}`, {
+      headers: { 'User-Agent': USER_AGENT },
+    })
+    if (!res.ok) throw new Error(`Commons HTTP ${res.status}`)
+    const json = await res.json()
+    for (const p of Object.values(json.query?.pages ?? {})) {
+      const ii = p.imageinfo?.[0]
+      if (!ii || ii.mime !== 'image/svg+xml' || !ii.url) continue
+      const lic = ii.extmetadata?.LicenseShortName?.value ?? ii.extmetadata?.License?.value ?? ''
+      // Openclipart is uniformly CC0/PD; a broad search needs the license gate.
+      if (!source.wikimediaCategory && !isOpen.test(lic)) continue
+      out.push({ title: p.title, url: ii.url, license: lic || 'CC0/PD' })
+      if (out.length >= cap) break
+    }
+    const c = json.continue?.gcmcontinue ?? json.continue?.sroffset
+    if (c === undefined) break
+    cont = source.wikimediaCategory
+      ? `&gcmcontinue=${encodeURIComponent(json.continue.gcmcontinue)}`
+      : `&sroffset=${json.continue.sroffset}`
+    await sleep(300) // be polite to the API
+  }
+  return out
+}
+
+/**
+ * wikimedia: download SVGs from Wikimedia Commons (PD/CC0). Opt-in and best-effort —
+ * the API rate-limits shared IPs, so run this from your own machine, not CI.
+ */
+async function provisionWikimedia(source, cacheDir, refresh, cap) {
+  const dest = join(cacheDir, 'wikimedia', source.id)
+  if (refresh && existsSync(dest)) rmSync(dest, { recursive: true, force: true })
+  mkdirSync(dest, { recursive: true })
+  const have = walkSvg(dest)
+  if (!refresh && have.length >= cap) {
+    return { files: have.toSorted().slice(0, cap), base: dest, version: 'commons' }
+  }
+  let titles
+  try {
+    titles = await commonsTitles(source, cap)
+  } catch (err) {
+    console.warn(`  ! Commons query failed (${err.message})`)
+    return null
+  }
+  for (const t of titles) {
+    const dst = join(dest, `${sanitize(t.title.replace(/^File:/, '').replace(/\.svg$/i, ''))}.svg`)
+    if (existsSync(dst)) continue
+    try {
+      // oxlint-disable-next-line no-await-in-loop
+      const r = await fetch(t.url, { headers: { 'User-Agent': USER_AGENT } })
+      if (!r.ok) continue
+      // oxlint-disable-next-line no-await-in-loop
+      const buf = Buffer.from(await r.arrayBuffer())
+      if (buf.length && buf[0] === 0x3c) writeFileSync(dst, buf) // starts with '<' → SVG/XML
+    } catch {
+      /* skip this file */
+    }
+    // oxlint-disable-next-line no-await-in-loop
+    await sleep(200)
+  }
+  return { files: walkSvg(dest).toSorted(), base: dest, version: 'commons' }
+}
+
+function provision(source, cacheDir, cfg) {
+  const type = source.type ?? 'npm'
+  if (type === 'npm') return provisionNpm(source, cacheDir, cfg.refresh)
+  if (type === 'git') return provisionGit(source, cacheDir, cfg.refresh)
+  if (type === 'wikimedia')
+    return provisionWikimedia(source, cacheDir, cfg.refresh, cfg.limitPerSource || 500)
+  throw new Error(`unknown source type '${type}' for ${source.id}`)
+}
+
+async function main() {
   const cfg = parseArgs(process.argv.slice(2))
   const sources = selected(cfg)
   const outDir = cfg.out
   const cacheDir = join(outDir, '.cache')
   if (cfg.clean && existsSync(cacheDir)) rmSync(cacheDir, { recursive: true, force: true })
-  mkdirSync(cacheDir, { recursive: true })
+  mkdirSync(join(cacheDir, 'node_modules'), { recursive: true })
   // npm wants a package.json at the prefix to install into its node_modules.
   const cachePkg = join(cacheDir, 'package.json')
-  if (!existsSync(cachePkg))
+  if (!existsSync(cachePkg)) {
     writeFileSync(cachePkg, JSON.stringify({ name: 'corpus-cache', private: true }))
+  }
 
   console.log(
     `Fetching ${sources.length} source(s) → ${outDir}/ (buckets=${cfg.buckets}, limit/source=${cfg.limitPerSource || '∞'})\n`,
@@ -154,18 +282,16 @@ function main() {
 
   const report = []
   for (const source of sources) {
-    console.log(`• ${source.category}/${source.id} (${source.pkg}, ${source.license})`)
-    const version = install(source, cacheDir, cfg.refresh)
-    if (!version) {
-      console.warn(`  ! skipped — install failed for ${source.pkg}`)
+    console.log(`• ${source.category}/${source.id} (${source.type ?? 'npm'}, ${source.license})`)
+    // Sources run one at a time on purpose (network/disk friendly, stable order).
+    // oxlint-disable-next-line no-await-in-loop
+    const prov = await provision(source, cacheDir, cfg)
+    if (!prov) {
+      console.warn(`  ! skipped — could not fetch ${source.id}`)
       report.push({ ...source, version: null, count: 0, skipped: true })
       continue
     }
-    const pkgRoot = join(cacheDir, 'node_modules', source.pkg)
-    const srcRoot = source.dir ? join(pkgRoot, source.dir) : pkgRoot
-    let files = walkSvg(srcRoot)
-    if (files.length === 0 && source.dir) files = walkSvg(pkgRoot) // layout drifted — search all
-    files = files.toSorted()
+    let files = prov.files
     if (cfg.limitPerSource > 0) files = files.slice(0, cfg.limitPerSource)
 
     const destBase = join(outDir, source.category, source.id)
@@ -173,16 +299,14 @@ function main() {
     let n = 0
     for (const file of files) {
       // Preserve the sub-path in the name so basenames never collide, and shard.
-      const relName =
-        relative(files.length ? srcRoot : pkgRoot, file).replaceAll(sep, '-') || basename(file)
+      const relName = relative(prov.base, file).replaceAll(sep, '-') || basename(file)
       const bucket = String(hash32(relName) % cfg.buckets).padStart(2, '0')
-      const dest = join(destBase, bucket, relName)
       mkdirSync(join(destBase, bucket), { recursive: true })
-      cpSync(file, dest)
+      cpSync(file, join(destBase, bucket, relName))
       n++
     }
     console.log(`  ${n} svg → ${destBase}/`)
-    report.push({ ...source, version, count: n, skipped: false })
+    report.push({ ...source, version: prov.version, count: n, skipped: false })
   }
 
   writeReport(outDir, cfg, report)
@@ -200,7 +324,7 @@ function writeReport(outDir, cfg, report) {
   const rows = report
     .map(
       (r) =>
-        `| ${r.category}/${r.id} | ${r.pkg}@${r.version ?? '—'} | ${r.license} | ${r.count} | ${r.home} |`,
+        `| ${r.category}/${r.id} | ${r.type ?? 'npm'} | ${r.license} | ${r.count} | ${r.home} |`,
     )
     .join('\n')
   writeFileSync(
@@ -208,7 +332,7 @@ function writeReport(outDir, cfg, report) {
     '# Corpus sources & licenses\n\n' +
       "Fetched by `npm run corpus` for local training only (not committed). Respect each pack's\n" +
       'license if you redistribute the corpus.\n\n' +
-      '| source | package | license | files | home |\n| --- | --- | --- | --- | --- |\n' +
+      '| source | type | license | files | home |\n| --- | --- | --- | --- | --- |\n' +
       `${rows}\n`,
   )
 }
@@ -220,9 +344,6 @@ function summarize(report) {
     `\ndone — ${total} svg across ${report.length - skipped} source(s)${skipped ? `, ${skipped} skipped` : ''}.`,
   )
   console.log('next: npm run dataset -- --source dir --corpus corpus --count 20000 --out data/real')
-  console.log(
-    '      then mix with procedural: python scripts/train/train.py --data data/proc data/real …',
-  )
 }
 
-main()
+await main()

--- a/scripts/corpus/sources.mjs
+++ b/scripts/corpus/sources.mjs
@@ -12,8 +12,15 @@
 // CC-BY-SA (share-alike). Attribution lives in the generated corpus/LICENSES.md.
 
 /**
- * @typedef {{ category: string, id: string, pkg: string, version: string,
- *   dir: string, license: string, home: string, optional?: boolean }} Source
+ * @typedef {{
+ *   category: string, id: string, license: string, home: string,
+ *   type?: 'npm' | 'git' | 'wikimedia',   // default 'npm'
+ *   pkg?: string, version?: string,       // npm
+ *   repo?: string, ref?: string,          // git
+ *   query?: string, wikimediaCategory?: string, // wikimedia (one of)
+ *   dir?: string,                         // subdir of npm/git package ('' = whole repo)
+ *   optional?: boolean,                   // excluded from the default run (needs --all)
+ * }} Source
  */
 
 /** @type {Source[]} */
@@ -98,15 +105,53 @@ export const SOURCES = [
     home: 'https://flagicons.lipis.dev',
   },
 
-  // Emoji — colorful, complex paths. Large + CC-BY-SA, so off by default (--all).
+  // Emoji — colorful, complex paths (the color set, not the monochrome one).
+  // Large + CC-BY-SA, so off by default (--all).
   {
     category: 'emoji',
     id: 'openmoji',
     pkg: 'openmoji',
     version: 'latest',
-    dir: '',
+    dir: 'color/svg',
     license: 'CC-BY-SA-4.0',
     home: 'https://openmoji.org',
+    optional: true,
+  },
+
+  // ---- Non-npm sources (general artwork, not icon glyphs) ----
+
+  // General illustrations (git) — CC0 hand-drawn illustration pack: colorful,
+  // multi-shape scenes, closer to real vectorizer inputs than icon glyphs.
+  {
+    category: 'illustrations',
+    id: 'gophers',
+    type: 'git',
+    repo: 'https://github.com/MariaLetta/free-gophers-pack',
+    dir: '',
+    license: 'CC0-1.0',
+    home: 'https://github.com/MariaLetta/free-gophers-pack',
+  },
+
+  // General clip-art & artwork via the Wikimedia Commons API (PD/CC0 only).
+  // Opt-in (--all): large, and the API rate-limits shared IPs (e.g. CI) — run it
+  // from your own machine. openclipart's CC0 library is mirrored on Commons under
+  // Category:Openclipart, so we pull it through the same reliable API.
+  {
+    category: 'clipart',
+    id: 'openclipart',
+    type: 'wikimedia',
+    wikimediaCategory: 'Openclipart',
+    license: 'CC0-1.0',
+    home: 'https://openclipart.org',
+    optional: true,
+  },
+  {
+    category: 'general',
+    id: 'wikimedia',
+    type: 'wikimedia',
+    query: 'illustration',
+    license: 'PD/CC0',
+    home: 'https://commons.wikimedia.org',
     optional: true,
   },
 ]


### PR DESCRIPTION
Follow-up to #7. The corpus fetcher was icon/glyph-heavy — all npm icon libraries. Real vectorizer inputs are general illustrations / clip-art, which don't live on npm, so the fetcher now pulls from **three source types**.

## Source types

| type | mechanism | used for |
|---|---|---|
| `npm` | install package, copy SVGs (unchanged) | icons, brands, flags, emoji |
| `git` | shallow-clone a repo, copy SVGs | illustration packs |
| `wikimedia` | Wikimedia Commons API, **PD/CC0-filtered** + capped | general clip-art / artwork |

## Wired

- **Default (verified, light):** icons (Lucide, Tabler, Feather, Bootstrap, Heroicons, MDI), brands (Simple Icons), flags (flag-icons), and **illustrations** — `free-gophers-pack` (git, CC0).
- **Opt-in (`--all`):** emoji — **OpenMoji switched to its color set** (`color/svg`; the monochrome set was being pulled before); **clipart** — openclipart (CC0, mirrored on Commons under `Category:Openclipart`); **general** — a broad license-filtered Wikimedia Commons query.

## Notes

- The Commons API **rate-limits shared IPs** (CI/VPN), so the Wikimedia sources are opt-in and best run from a normal machine; they're license-gated to PD/CC0 and **fail soft** (skip) on throttling.
- `--source dir` on the generator still accepts any folder of SVGs you supply yourself (e.g. a manual openclipart / SVG Repo bulk download).

## Verification

`npm run check` (lint + fmt + typecheck + test) green. Exercised end-to-end here: the git source cloned real gopher illustrations (~130 KB each), a live Commons fetch pulled a real openclipart SVG, and the dataset generator rendered the mixed general corpus (per-family split, un-renderable SVGs skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKtj2W6thn3FzbhKujKkhh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKtj2W6thn3FzbhKujKkhh)_