### PR TITLE
feat(train): add an SSIM term to the cleanup loss

### DIFF
--- a/docs/CLEANUP_PREPASS.md
+++ b/docs/CLEANUP_PREPASS.md
@@ -70,9 +70,10 @@ Offline, in PyTorch (not part of the repo's Node/TS build). One flag switches th
 python scripts/train/pipeline.py --task cleanup --count 20000 --quantize
 ```
 
-- **Loss:** L1 on the sigmoid'd RGB vs. the clean target ([`losses.py`](../scripts/train/losses.py) `cleanup_loss`). L1
-  over L2 keeps edges crisp rather than blurring them — important for a tracer input. A perceptual/SSIM term can be added
-  later if needed.
+- **Loss:** a mix of **L1 + (1 − SSIM)** on the sigmoid'd RGB vs. the clean target
+  ([`losses.py`](../scripts/train/losses.py) `cleanup_loss`). L1 keeps colors/edges accurate; SSIM (a self-contained,
+  differentiable window statistic — no VGG/LPIPS weights) rewards local structure/contrast that L1 alone misses. Blend
+  with `--ssim-weight` (default 0.5; 0 = pure L1).
 - **Optimizer:** AdamW, cosine decay.
 - **Metrics:** PSNR on the held-out split, **plus the downstream metric that matters** — feed cleaned images through the
   tracer and compare the app's **Oklab ΔE fidelity** and node counts against tracing the degraded input directly.

--- a/scripts/train/README.md
+++ b/scripts/train/README.md
@@ -122,7 +122,7 @@ For the cleanup model, pass `--task cleanup` to steps 2 and 3 (reusing the same 
 | `pipeline.py`      | one-shot: data → train → export (cross-platform), `--task` aware                           |
 | `dataset.py`       | reads the generator manifest; input normalization matches Edge/CleanupEnhancer exactly     |
 | `model.py`         | `TinyUNet` (compact U-Net, `out_channels` per task) + the sigmoid export wrapper           |
-| `losses.py`        | edge: class-balanced BCE (HED-style) + soft Dice · cleanup: L1                             |
+| `losses.py`        | edge: class-balanced BCE (HED-style) + soft Dice · cleanup: L1 + (1−SSIM), `--ssim-weight` |
 | `train.py`         | training loop (AdamW + cosine), val F-score / PSNR, early stopping, preview montage        |
 | `export_onnx.py`   | ONNX export + torch/onnxruntime parity check + optional int8 quantization (`--task` aware) |
 | `requirements.txt` | Python deps                                                                                |
@@ -158,6 +158,9 @@ export glyphs to per-file SVGs. Splits are per source family in each root, so fa
 - **`--base-channels`** — model width, hence size and capacity. 16 is a good default. Bump to 24 if predictions look
   blurry or miss thin edges (and you have the data); drop to 8–12 if the ONNX must be tiny. Keep it **< 5 MB** with
   `--quantize`.
+- **`--ssim-weight`** (cleanup only) — blends the loss `(1-w)·L1 + w·(1-SSIM)`, default `0.5`. Raise toward `0.7–0.8`
+  for crisper structure/contrast (can slightly shift colors); drop toward `0` for pure L1 (most color-faithful). Ignored
+  for the edge task.
 - **Epochs / early stopping** — don't hand-tune epochs: set a generous `--epochs 80` and let `--patience 10` stop when
   val loss plateaus. `--patience 0` disables it.
 - **`--batch` / `--lr`** — batch as large as your VRAM allows (32–64); keep `--lr 3e-4` (AdamW). Doubling the batch, you

--- a/scripts/train/losses.py
+++ b/scripts/train/losses.py
@@ -5,8 +5,11 @@
   predicting "no edge". HED's beta weighting rebalances positives against
   negatives; the Dice term further counters the imbalance. Both operate on the
   soft [0,1] target the generator produces.
-- cleanup: L1 on the sigmoid'd RGB output vs the clean [0,1] target. L1 (over L2)
-  keeps edges crisp instead of blurring them, which matters for a tracer input.
+- cleanup: L1 + (1 - SSIM) on the sigmoid'd RGB output vs the clean [0,1] target.
+  L1 (over L2) keeps edges crisp and colors accurate; the SSIM term is a perceptual
+  measure of local structure/contrast that L1 alone misses, so the two together
+  clean up more faithfully for a tracer input. SSIM is a self-contained,
+  differentiable window statistic (no extra weights, unlike a VGG/LPIPS term).
 """
 
 from __future__ import annotations
@@ -29,5 +32,47 @@ def edge_loss(logits: torch.Tensor, target: torch.Tensor, edge_thresh: float = 0
     return bce + dice
 
 
-def cleanup_loss(logits: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-    return F.l1_loss(torch.sigmoid(logits), target)
+def _gaussian_window(
+    channels: int, size: int, sigma: float, device: torch.device, dtype: torch.dtype
+) -> torch.Tensor:
+    """Normalized 2D Gaussian kernel as depthwise conv weights `[C, 1, size, size]`."""
+    coords = torch.arange(size, device=device, dtype=dtype) - (size - 1) / 2.0
+    g = torch.exp(-(coords**2) / (2.0 * sigma**2))
+    g = g / g.sum()
+    kernel = (g[:, None] * g[None, :])  # [size, size]
+    return kernel.expand(channels, 1, size, size).contiguous()
+
+
+def ssim(x: torch.Tensor, y: torch.Tensor, window_size: int = 11, sigma: float = 1.5) -> torch.Tensor:
+    """Mean SSIM for images in [0,1], shape [N, C, H, W]. Differentiable.
+
+    Standard Wang et al. (2004) windowed SSIM with a Gaussian window applied
+    depthwise per channel. Returns a scalar in (0, 1]; 1.0 when x == y.
+    """
+    channels = x.shape[1]
+    win = _gaussian_window(channels, window_size, sigma, x.device, x.dtype)
+    pad = window_size // 2
+
+    def filt(t: torch.Tensor) -> torch.Tensor:
+        return F.conv2d(t, win, padding=pad, groups=channels)
+
+    mu_x, mu_y = filt(x), filt(y)
+    mu_x2, mu_y2, mu_xy = mu_x * mu_x, mu_y * mu_y, mu_x * mu_y
+    sigma_x2 = filt(x * x) - mu_x2
+    sigma_y2 = filt(y * y) - mu_y2
+    sigma_xy = filt(x * y) - mu_xy
+    c1, c2 = 0.01**2, 0.03**2
+    ssim_map = ((2 * mu_xy + c1) * (2 * sigma_xy + c2)) / (
+        (mu_x2 + mu_y2 + c1) * (sigma_x2 + sigma_y2 + c2)
+    )
+    return ssim_map.mean()
+
+
+def cleanup_loss(
+    logits: torch.Tensor, target: torch.Tensor, ssim_weight: float = 0.5
+) -> torch.Tensor:
+    """Mixed L1 + (1 - SSIM), blended by `ssim_weight` in [0, 1] (0 = pure L1)."""
+    prob = torch.sigmoid(logits)
+    l1 = F.l1_loss(prob, target)
+    dssim = 1.0 - ssim(prob, target)
+    return (1.0 - ssim_weight) * l1 + ssim_weight * dssim

--- a/scripts/train/pipeline.py
+++ b/scripts/train/pipeline.py
@@ -76,6 +76,7 @@ def main() -> None:
     p.add_argument("--epochs", type=int, default=60)
     p.add_argument("--batch", type=int, default=32)
     p.add_argument("--base-channels", type=int, default=16, help="model width / size")
+    p.add_argument("--ssim-weight", type=float, default=0.5, help="cleanup: (1-SSIM) vs L1 weight, [0,1]")
     p.add_argument("--patience", type=int, default=10, help="early-stop after N stale epochs (0 = off)")
     p.add_argument("--workers", type=int, default=0, help="dataloader workers (raise for speed)")
     p.add_argument("--jobs", type=int, default=0, help="dataset generator threads (0 = CPU count)")
@@ -124,6 +125,7 @@ def main() -> None:
         "--task", args.task,
         "--data", data, "--epochs", str(args.epochs),
         "--batch", str(args.batch), "--base-channels", str(args.base_channels),
+        "--ssim-weight", str(args.ssim_weight),
         "--patience", str(args.patience), "--workers", str(args.workers),
         "--out", ckpt_dir,
     ])

--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -12,6 +12,7 @@ Early stops when val loss stops improving. See scripts/train/README.md.
 from __future__ import annotations
 
 import argparse
+from functools import partial
 from pathlib import Path
 
 import numpy as np
@@ -41,6 +42,12 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--lr", type=float, default=3e-4)
     p.add_argument("--size", type=int, default=256)
     p.add_argument("--base-channels", type=int, default=16)
+    p.add_argument(
+        "--ssim-weight",
+        type=float,
+        default=0.5,
+        help="cleanup only: weight of the (1-SSIM) term vs L1, in [0,1] (0 = pure L1)",
+    )
     # 0 avoids multiprocessing (safest on Windows); raise it (e.g. 8) for speed.
     p.add_argument("--workers", type=int, default=0)
     p.add_argument("--limit", type=int, default=0, help="cap train samples (smoke tests)")
@@ -116,7 +123,11 @@ def main() -> None:
     train_dl = loader(train_ds, True)
     val_dl = loader(val_ds, False)
 
-    loss_fn = cleanup_loss if args.task == "cleanup" else edge_loss
+    loss_fn = (
+        partial(cleanup_loss, ssim_weight=args.ssim_weight)
+        if args.task == "cleanup"
+        else edge_loss
+    )
     metric_fn = psnr if args.task == "cleanup" else f_score
     metric_name = "PSNR" if args.task == "cleanup" else "F"
 


### PR DESCRIPTION
## What

Blends an **SSIM (structural) term** into the cleanup model's loss so restoration is judged on local structure/contrast, not just per-pixel error:

```
cleanup_loss = (1 − w)·L1 + w·(1 − SSIM),   w = --ssim-weight   (default 0.5)
```

L1 alone keeps colors faithful but smears the local structure and contrast the tracer later keys off. SSIM rewards exactly that structure, so cleaned tiles hold their edges and contrast better. The edge task is untouched.

## Why this SSIM

- **Self-contained & differentiable** — implemented directly (Gaussian-windowed means/variances/covariance via a depthwise conv), so there are **no new dependencies** and **no external weights** to fetch. No VGG/LPIPS.
- **Deterministic & cheap** — pure PyTorch ops, runs on the same device as training.
- **Backward-compatible** — `--ssim-weight 0` reduces *exactly* to the previous pure-L1 loss.

## Changes

| File | Change |
| --- | --- |
| `scripts/train/losses.py` | `_gaussian_window` + `ssim` helpers; `cleanup_loss` now blends L1 and `1 − SSIM` via `ssim_weight` |
| `scripts/train/train.py` | `--ssim-weight` arg, wired to `cleanup_loss` via `functools.partial` (edge task unaffected) |
| `scripts/train/pipeline.py` | `--ssim-weight` passthrough |
| `docs/CLEANUP_PREPASS.md`, `scripts/train/README.md` | document the loss and the `--ssim-weight` knob |

## Verification (CPU)

| Check | Result |
| --- | --- |
| `ssim(x, x)` | `1.0` (identity → perfect) |
| `ssim(noisy, x)` | `0.8322` (0 < s < 1) |
| `cleanup_loss` finite + `backward()` | finite, gradient OK |
| `--ssim-weight 0` == pure L1 | exact match |
| `pipeline.py --task cleanup --smoke --ssim-weight 0.6` | trains, exports, torch/onnx parity `8.9e-08`, `smoke OK` |

`py_compile` and `npm run fmt:check` clean. These scripts are training-only (not part of the JS build/CI).

## Notes

Tuning guidance is in the README: start at `0.5`, raise toward `0.7–0.8` for crisper structure/contrast (can slightly shift colors), drop toward `0` for the most color-faithful L1. The metric that actually ships is the app's Oklab ΔE via the **Clean up (ML)** button, not val PSNR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKtj2W6thn3FzbhKujKkhh)_