### PR TITLE
Fix DropZone overflow handling with safe alignment

### DIFF
--- a/apps/web/src/components/DropZone.vue
+++ b/apps/web/src/components/DropZone.vue
@@ -251,8 +251,12 @@ defineExpose({ openPicker })
   inset: 0;
   z-index: 30;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  /* `safe` centers the content while it fits but pins it to the top once it's
+     taller than the viewport, so the upload target stays reachable instead of
+     scrolling off above the fold. Plain `center` clips the overflow equally top
+     and bottom, and only the bottom is scrollable — cropping the top. */
+  align-items: safe center;
+  justify-content: safe center;
   background: var(--bg-0);
   overflow: auto;
 }


### PR DESCRIPTION
## Summary
Updated the DropZone component's centering behavior to use CSS `safe` alignment, which prevents content from being clipped at the top of the viewport when it exceeds available space.

## Changes
- Modified `align-items` and `justify-content` properties from `center` to `safe center` in the DropZone overlay styles
- Added explanatory comment documenting the rationale: `safe` alignment pins content to the top once it exceeds viewport height, keeping the upload target reachable and scrollable, whereas plain `center` clips overflow equally and only allows bottom scrolling

## Implementation Details
This change improves UX for large or complex upload dialogs that may exceed viewport dimensions. With `safe center`, users can scroll to access the entire upload interface instead of having the top portion clipped off-screen.

https://claude.ai/code/session_012vdJJQCh7DHT6zqfJ3ZrLJ