### PR TITLE
Add "What's new" release notes panel with unseen badge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,10 @@ Do not put a model identifier anywhere in a commit message, PR title/body, or co
 ### Documentation
 
 - Update the affected doc **in the same commit** as the code change.
+- **User-visible change? Add a release note in the same PR.** The app shows a "What's new" changelog; prepend an entry
+  to [`apps/web/src/lib/releaseNotes.ts`](apps/web/src/lib/releaseNotes.ts) following the rules in
+  [`apps/web/AGENTS.md`](apps/web/AGENTS.md) (dated + numbered per day, plain language). Skip only changes a user would
+  never notice.
 - [`README.md`](README.md) is the landing page and feature tour.
 - [`docs/CONTRACTS.md`](docs/CONTRACTS.md) is the exact package API surface — keep it in sync with exported signatures.
 - [`docs/REFERENCES.md`](docs/REFERENCES.md) tracks every citable algorithm and ML model. **When you add or change an

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -19,8 +19,9 @@ src/
   store/appStore.ts       the single source of truth (Pinia setup store)
   worker/vectorize.worker.ts   installWorkerHandler(self) — the engine, off the main thread
   lib/                    decode (image → RasterImage), download/copy, fidelity scoring, samples, format helpers,
-                          overlay (per-element-kind colors/labels for the complexity overlay)
-  components/             AppHeader, DropZone, SettingsPanel, MlTools, PreviewViewport, PreviewOverlay, StatsBar, ExportBar, ToastHost
+                          overlay (per-element-kind colors/labels for the complexity overlay),
+                          releaseNotes (the user-facing changelog + its date/iteration helpers)
+  components/             AppHeader, DropZone, SettingsPanel, MlTools, PreviewViewport, PreviewOverlay, StatsBar, ExportBar, ReleaseNotes, ToastHost
   components/controls/    ControlRow / SliderRow / SelectRow / SwitchRow / ColorRow / TextRow
   styles/base.css         design tokens (dark + light), shared component classes
 ```
@@ -44,6 +45,26 @@ src/
   weights via `@trazor/ml`, and the app must stay fully functional when they fail.
 - **ML is lazy and fail-soft.** Import `@trazor/ml` dynamically so `onnxruntime-web` stays out of the main bundle;
   surface every failure as a toast and continue without it.
+
+## Release notes
+
+The app ships a user-facing changelog: the **"What's new"** button in `AppHeader` opens `ReleaseNotes.vue`, which
+renders the entries from [`src/lib/releaseNotes.ts`](src/lib/releaseNotes.ts). A badge on that button counts the notes
+published since the visitor's last visit (persisted as `lastSeenRelease`; the count is the store's
+`unseenReleaseCount`), and clears when they open the panel.
+
+**On every pull request that changes something a user would notice, add a release note — in the same PR.** This is
+part of "done", like updating docs. Skip it only for changes with no user-visible effect (pure refactors, tests, CI,
+internal-doc edits).
+
+- **Prepend** one `ReleaseNote` object to the **top** of the `RELEASE_NOTES` array — newest first. The array order is
+  the source of truth for the "new since last visit" badge, so never reorder or rewrite already-published entries.
+- **Identify it by date, not a version** (there is no versioning yet): set `date` to the merge day (ISO `YYYY-MM-DD`)
+  and `iteration` to a per-day counter. If an entry for that date already exists, use the next `iteration` (…`.2`,
+  `.3`); otherwise start at `1`. Together they read as `2026-08-23.2` (`releaseId`).
+- **Write for users, not contributors.** A short `title` and one plain-language line per change in `items` — say what
+  someone can now do or what got better, not which module changed. Pick the `kind` (`feature` / `improvement` / `fix`)
+  that best fits. Keep emoji out of the notes.
 
 ## Workflow
 

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -3,6 +3,7 @@ import { onBeforeUnmount, onMounted, ref, watchEffect } from 'vue'
 import AppHeader from './components/AppHeader.vue'
 import DropZone from './components/DropZone.vue'
 import PreviewViewport from './components/PreviewViewport.vue'
+import ReleaseNotes from './components/ReleaseNotes.vue'
 import SettingsPanel from './components/SettingsPanel.vue'
 import StatsBar from './components/StatsBar.vue'
 import ToastHost from './components/ToastHost.vue'
@@ -15,6 +16,9 @@ const dropZone = ref<InstanceType<typeof DropZone> | null>(null)
 
 // Mobile only: collapse the pinned result to give the command panel more room.
 const resultHidden = ref(false)
+
+// The "What's new" release-notes overlay.
+const releaseNotesOpen = ref(false)
 
 // Reflect the theme on <html> so the token overrides in base.css apply.
 watchEffect(() => {
@@ -30,6 +34,9 @@ function isTypingTarget(target: EventTarget | null): boolean {
 }
 
 function onKeyDown(event: KeyboardEvent): void {
+  // The release-notes overlay owns the keyboard while it is open (it handles Escape itself).
+  if (releaseNotesOpen.value) return
+
   const meta = event.metaKey || event.ctrlKey
 
   if (meta && event.key.toLowerCase() === 'o') {
@@ -103,7 +110,7 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="app">
-    <AppHeader @open-file="dropZone?.openPicker()" />
+    <AppHeader @open-file="dropZone?.openPicker()" @open-release-notes="releaseNotesOpen = true" />
     <div class="body" :class="{ 'result-collapsed': resultHidden }">
       <SettingsPanel />
       <main class="main">
@@ -138,6 +145,7 @@ onBeforeUnmount(() => {
       </button>
       <DropZone ref="dropZone" />
     </div>
+    <ReleaseNotes v-if="releaseNotesOpen" @close="releaseNotesOpen = false" />
     <ToastHost />
   </div>
 </template>

--- a/apps/web/src/components/AppHeader.vue
+++ b/apps/web/src/components/AppHeader.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useAppStore } from '../store/appStore'
 
 const store = useAppStore()
 
-const emit = defineEmits<{ openFile: [] }>()
+const emit = defineEmits<{ openFile: []; openReleaseNotes: [] }>()
+
+// Compact "since last visit" badge; caps large counts so it stays little.
+const unseenBadge = computed(() =>
+  store.unseenReleaseCount > 9 ? '9+' : String(store.unseenReleaseCount),
+)
 </script>
 
 <template>
@@ -72,6 +78,48 @@ const emit = defineEmits<{ openFile: [] }>()
         </button>
         <span class="hdr-sep" aria-hidden="true" />
       </template>
+      <button
+        class="btn btn-ghost btn-icon whatsnew"
+        :title="
+          store.unseenReleaseCount > 0
+            ? `What's new — ${store.unseenReleaseCount} since your last visit`
+            : `What's new`
+        "
+        :aria-label="
+          store.unseenReleaseCount > 0
+            ? `What's new, ${store.unseenReleaseCount} new since your last visit`
+            : `What's new`
+        "
+        @click="emit('openReleaseNotes')"
+      >
+        <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+          <path
+            d="M3 6.4v3.2h2l5.2 2.6V3.8L5 6.4H3Z"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.4"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M5.4 9.6l.9 2.7 1.5-.5-.8-2.2"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.4"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M12.4 6.2a3 3 0 0 1 0 3.6"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.4"
+            stroke-linecap="round"
+          />
+        </svg>
+        <span v-if="store.unseenReleaseCount > 0" class="whatsnew-badge" aria-hidden="true">
+          {{ unseenBadge }}
+        </span>
+      </button>
       <button
         class="btn btn-ghost btn-icon"
         :title="store.theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'"
@@ -181,6 +229,33 @@ const emit = defineEmits<{ openFile: [] }>()
   height: 20px;
   margin: 0 3px;
   background: var(--border);
+}
+
+/* "What's new" trigger + its since-last-visit badge. */
+.whatsnew {
+  position: relative;
+  overflow: visible;
+}
+
+.whatsnew-badge {
+  position: absolute;
+  top: -1px;
+  right: -2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 4px;
+  border-radius: 999px;
+  border: 1.5px solid var(--bg-1);
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-size: 9.5px;
+  font-weight: 700;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
 }
 
 /* Collapse the action labels to icons on narrow screens. */

--- a/apps/web/src/components/ReleaseNotes.vue
+++ b/apps/web/src/components/ReleaseNotes.vue
@@ -1,0 +1,321 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted } from 'vue'
+import {
+  countUnseen,
+  formatReleaseDate,
+  RELEASE_NOTES,
+  releaseId,
+  type ReleaseNoteKind,
+} from '../lib/releaseNotes'
+import { useAppStore } from '../store/appStore'
+
+const store = useAppStore()
+const emit = defineEmits<{ close: [] }>()
+
+// Snapshot how many notes were unseen when the panel opened, BEFORE marking
+// them read below — so the "New" markers reflect the state at open time.
+const newCount = countUnseen(store.lastSeenRelease)
+
+function isNew(index: number): boolean {
+  return index < newCount
+}
+
+const KIND_LABEL: Record<ReleaseNoteKind, string> = {
+  feature: 'New feature',
+  improvement: 'Improvement',
+  fix: 'Fix',
+}
+
+const KIND_CLASS: Record<ReleaseNoteKind, string> = {
+  feature: 'chip--accent',
+  improvement: 'chip--success',
+  fix: 'chip--warn',
+}
+
+function close(): void {
+  emit('close')
+}
+
+function onKeyDown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    close()
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', onKeyDown)
+  // Opening the panel acknowledges every note; the header badge clears.
+  store.markReleasesSeen()
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown)
+})
+</script>
+
+<template>
+  <div class="rn-backdrop" @click.self="close">
+    <div class="rn-modal card" role="dialog" aria-modal="true" aria-labelledby="rn-title">
+      <header class="rn-head">
+        <div class="rn-head-title">
+          <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+            <path
+              d="M3 6.4v3.2h2l5.2 2.6V3.8L5 6.4H3Z"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.4"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M5.4 9.6l.9 2.7 1.5-.5-.8-2.2"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.4"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M12.4 6.2a3 3 0 0 1 0 3.6"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.4"
+              stroke-linecap="round"
+            />
+          </svg>
+          <h2 id="rn-title" class="rn-title">What's new</h2>
+        </div>
+        <button
+          class="btn btn-ghost btn-icon"
+          type="button"
+          aria-label="Close what's new"
+          @click="close"
+        >
+          <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+            <path
+              d="M4 4l8 8M12 4l-8 8"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+            />
+          </svg>
+        </button>
+      </header>
+
+      <div class="rn-scroll">
+        <article v-for="(note, i) in RELEASE_NOTES" :key="releaseId(note)" class="rn-note">
+          <div class="rn-meta">
+            <div class="rn-meta-left">
+              <span class="rn-ver mono">{{ releaseId(note) }}</span>
+              <span class="rn-date">{{ formatReleaseDate(note.date) }}</span>
+            </div>
+            <div class="rn-meta-right">
+              <span v-if="isNew(i)" class="rn-new">New</span>
+              <span class="chip" :class="KIND_CLASS[note.kind]">{{ KIND_LABEL[note.kind] }}</span>
+            </div>
+          </div>
+          <h3 class="rn-note-title">{{ note.title }}</h3>
+          <ul class="rn-items">
+            <li v-for="(item, j) in note.items" :key="`${releaseId(note)}:${j}`">{{ item }}</li>
+          </ul>
+        </article>
+      </div>
+
+      <footer class="rn-foot">
+        <span class="muted">Notes are dated and numbered per day until versioning lands.</span>
+        <a
+          class="rn-foot-link"
+          href="https://github.com/PhenX/Trazor/commits/main"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Full history
+        </a>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.rn-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: color-mix(in srgb, var(--bg-0) 62%, transparent);
+  backdrop-filter: blur(2px);
+  animation: rn-fade 0.14s ease;
+}
+
+.rn-modal {
+  display: flex;
+  flex-direction: column;
+  width: min(540px, 100%);
+  max-height: min(640px, calc(100vh - 48px));
+  box-shadow: var(--shadow-2);
+  animation: rn-rise 0.16s ease;
+}
+
+.rn-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px 12px 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.rn-head-title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--accent);
+}
+
+.rn-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 650;
+  color: var(--text-1);
+}
+
+.rn-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 16px;
+}
+
+.rn-note {
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.rn-note:last-child {
+  border-bottom: none;
+}
+
+.rn-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 7px;
+}
+
+.rn-meta-left {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.rn-ver {
+  font-size: 11.5px;
+  color: var(--text-2);
+}
+
+.rn-date {
+  font-size: 11.5px;
+  color: var(--text-3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rn-meta-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.rn-new {
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.rn-note-title {
+  margin: 0 0 6px;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-1);
+}
+
+.rn-items {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.rn-items li {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-2);
+}
+
+.rn-items li::marker {
+  color: var(--text-3);
+}
+
+.rn-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 11px 16px;
+  border-top: 1px solid var(--border);
+  font-size: 11.5px;
+}
+
+.rn-foot-link {
+  color: var(--accent);
+  text-decoration: none;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.rn-foot-link:hover {
+  text-decoration: underline;
+}
+
+@keyframes rn-fade {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes rn-rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+
+@media (max-width: 560px) {
+  .rn-backdrop {
+    padding: 0;
+    align-items: stretch;
+  }
+
+  .rn-modal {
+    width: 100%;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+}
+</style>

--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -1,0 +1,121 @@
+// User-facing release notes shown by the "What's new" panel.
+//
+// There is no formal version yet, so each note is identified by its calendar
+// date plus a per-day iteration (see `releaseId`). Add a new entry at the TOP
+// of RELEASE_NOTES on every merged pull request that changes something a user
+// would notice — the process and id scheme live in apps/web/AGENTS.md.
+
+export type ReleaseNoteKind = 'feature' | 'improvement' | 'fix'
+
+export interface ReleaseNote {
+  /** Publication date, ISO `YYYY-MM-DD`. */
+  date: string
+  /**
+   * 1-based counter distinguishing notes published on the same date — the
+   * stand-in for a version number. The first note of a day is `1`, the next
+   * `2`, and so on; the newest note of a day carries the highest number.
+   */
+  iteration: number
+  /** Dominant category of the change; drives the tag color. */
+  kind: ReleaseNoteKind
+  /** Short, plain-language headline. */
+  title: string
+  /** One plain-language line per change — no jargon. */
+  items: string[]
+}
+
+/**
+ * Every release note, newest first. The order of this array is the source of
+ * truth for "which notes are newer than the one a visitor last saw", so keep it
+ * strictly newest-to-oldest.
+ */
+export const RELEASE_NOTES: readonly ReleaseNote[] = [
+  {
+    date: '2026-08-23',
+    iteration: 2,
+    kind: 'feature',
+    title: "What's new panel",
+    items: [
+      'This "What\'s new" list opens from the button in the header, so recent changes are one click away.',
+      'A small badge on that button flags notes published since your last visit, and clears once you have read them.',
+      'Each note is stamped with its date and a daily number (for example 2026-08-23.2) until proper versioning arrives.',
+    ],
+  },
+  {
+    date: '2026-08-23',
+    iteration: 1,
+    kind: 'improvement',
+    title: 'Cleaner curves and lighter SVGs',
+    items: [
+      'Centerline (single-stroke) tracing now keeps the source colors, which suits vinyl cutting and pen plotting.',
+      'Curve fitting uses fewer points for the same shape, so exported files are smaller without looking rougher.',
+    ],
+  },
+  {
+    date: '2026-08-22',
+    iteration: 2,
+    kind: 'feature',
+    title: 'Save and reuse your settings',
+    items: [
+      'Export the current settings and target profile to a small file, then import them again whenever you need them.',
+      'Reapply the exact same look across a batch of images without setting every slider by hand.',
+    ],
+  },
+  {
+    date: '2026-08-22',
+    iteration: 1,
+    kind: 'improvement',
+    title: 'Works on phones, and shows how a trace is built',
+    items: [
+      'The studio now fits phone-sized screens, with the result pinned above a control panel that scrolls on its own.',
+      'A new overlay colors each part of the traced SVG by kind, so you can see how the drawing is put together.',
+    ],
+  },
+]
+
+/**
+ * Stable id and version label of a note: `YYYY-MM-DD.iteration`, e.g.
+ * `2026-08-23.2`. Used both as a display tag and as the "last seen" marker.
+ */
+export function releaseId(note: ReleaseNote): string {
+  return `${note.date}.${note.iteration}`
+}
+
+/** Id of the newest note, or `null` when there are none. */
+export function latestReleaseId(): string | null {
+  return RELEASE_NOTES.length > 0 ? releaseId(RELEASE_NOTES[0]) : null
+}
+
+/**
+ * How many notes are newer than the one a visitor last saw. A `null` marker
+ * (first visit, or cleared storage) counts every note as unseen; a marker that
+ * no longer matches any note does the same, so a returning visitor is never
+ * shown fewer updates than there really are.
+ */
+export function countUnseen(lastSeenId: string | null): number {
+  if (!lastSeenId) return RELEASE_NOTES.length
+  const index = RELEASE_NOTES.findIndex((note) => releaseId(note) === lastSeenId)
+  return index === -1 ? RELEASE_NOTES.length : index
+}
+
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
+
+/** Format an ISO `YYYY-MM-DD` date as, e.g., `August 23, 2026`. */
+export function formatReleaseDate(date: string): string {
+  const [year, month, day] = date.split('-').map(Number)
+  const name = MONTHS[month - 1] ?? date
+  return `${name} ${day}, ${year}`
+}

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -25,6 +25,7 @@ import { computed, reactive, ref, shallowRef, watch } from 'vue'
 import { decodeBlob } from '../lib/decode'
 import { computeFidelity } from '../lib/fidelity'
 import type { FidelityReport } from '../lib/fidelity'
+import { countUnseen, latestReleaseId } from '../lib/releaseNotes'
 import { getSample } from '../lib/samples'
 
 const STORAGE_KEY = 'trazor:v1'
@@ -61,6 +62,8 @@ interface PersistedState {
   theme?: Theme
   edgePrepass?: boolean
   autoOnLoad?: boolean
+  /** Id of the newest release note the visitor has seen (see lib/releaseNotes). */
+  lastSeenRelease?: string
 }
 
 function loadPersisted(): PersistedState {
@@ -151,6 +154,8 @@ export const useAppStore = defineStore('app', () => {
   const edgePrepass = ref(persisted.edgePrepass === true)
   /** Analyze each newly loaded image and apply recommended settings. On by default. */
   const autoOnLoad = ref(persisted.autoOnLoad !== false)
+  /** Id of the newest release note the visitor has acknowledged (What's new panel). */
+  const lastSeenRelease = ref<string | null>(persisted.lastSeenRelease ?? null)
 
   // Non-reactive machinery
   let client: TrazorClient | null = null
@@ -655,6 +660,15 @@ export const useAppStore = defineStore('app', () => {
     }
   }
 
+  // --------------------------- Release notes -----------------------------
+  /** Notes newer than the one the visitor last saw — drives the header badge. */
+  const unseenReleaseCount = computed(() => countUnseen(lastSeenRelease.value))
+
+  /** Acknowledge every note up to the newest, clearing the "new" badge. */
+  function markReleasesSeen(): void {
+    lastSeenRelease.value = latestReleaseId()
+  }
+
   // ------------------------------- Theme ---------------------------------
   function toggleTheme(): void {
     theme.value = theme.value === 'dark' ? 'light' : 'dark'
@@ -662,7 +676,7 @@ export const useAppStore = defineStore('app', () => {
 
   // ---------------------------- Persistence ------------------------------
   watch(
-    [settings, activeProfileId, profileModified, theme, edgePrepass, autoOnLoad],
+    [settings, activeProfileId, profileModified, theme, edgePrepass, autoOnLoad, lastSeenRelease],
     () => {
       try {
         const state: PersistedState = {
@@ -672,6 +686,7 @@ export const useAppStore = defineStore('app', () => {
           theme: theme.value,
           edgePrepass: edgePrepass.value,
           autoOnLoad: autoOnLoad.value,
+          lastSeenRelease: lastSeenRelease.value ?? undefined,
         }
         localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
       } catch {
@@ -704,11 +719,13 @@ export const useAppStore = defineStore('app', () => {
     magicPoints,
     edgePrepass,
     autoOnLoad,
+    lastSeenRelease,
     // derived
     hasImage,
     activeProfile,
     isWorkingModified,
     exportName,
+    unseenReleaseCount,
     // actions
     notify,
     dismissToast,
@@ -740,6 +757,7 @@ export const useAppStore = defineStore('app', () => {
     addMagicPoint,
     undoMagicPoint,
     applyMagicSelect,
+    markReleasesSeen,
     toggleTheme,
   }
 })

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -167,8 +167,56 @@ try {
     }
   }
 
+  // Verify the "What's new" release-notes panel: the header badge counts unseen
+  // notes, the panel lists them (newest first, dated + numbered per day), and
+  // opening it clears the badge for the next visit. Isolated context so it does
+  // not touch the main page's storage or the README screenshot.
+  async function checkReleaseNotes() {
+    const ctx = await browser.newContext({ viewport: { width: 1280, height: 860 } })
+    try {
+      const rp = await ctx.newPage()
+      await rp.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'domcontentloaded' })
+      await rp.waitForSelector('.whatsnew', { timeout: 20000 })
+
+      const badgeBefore = (await rp.locator('.whatsnew-badge').textContent())?.trim() ?? ''
+      if (!badgeBefore) fail('release notes: a first visit should show the unseen badge')
+
+      await rp.locator('.whatsnew').click()
+      await rp.waitForSelector('.rn-modal', { timeout: 5000 })
+      const notes = await rp.locator('.rn-note').count()
+      const newMarks = await rp.locator('.rn-new').count()
+      const firstVer = (await rp.locator('.rn-ver').first().textContent())?.trim() ?? ''
+      if (notes < 1) fail('release notes: panel listed no notes')
+      if (newMarks < 1) fail('release notes: unseen notes should be flagged "New"')
+      if (!/^\d{4}-\d{2}-\d{2}\.\d+$/.test(firstVer)) {
+        fail(`release notes: version tag should read YYYY-MM-DD.n, got "${firstVer}"`)
+      }
+      const expected = notes > 9 ? '9+' : String(notes)
+      if (badgeBefore !== expected) {
+        fail(`release notes: badge "${badgeBefore}" should match ${expected} unseen notes`)
+      }
+
+      // Opening acknowledges the notes; the badge is gone on the next visit.
+      await rp.keyboard.press('Escape')
+      await rp.waitForSelector('.rn-modal', { state: 'detached', timeout: 5000 })
+      await rp.reload({ waitUntil: 'domcontentloaded' })
+      await rp.waitForSelector('.whatsnew', { timeout: 20000 })
+      if ((await rp.locator('.whatsnew-badge').count()) !== 0) {
+        fail('release notes: badge should clear after the panel is opened')
+      }
+      console.log(
+        `  release notes: badge ${badgeBefore} ✓  ${notes} notes ✓  New flags ✓  clears ✓`,
+      )
+    } finally {
+      await ctx.close()
+    }
+  }
+
   console.log('E2E: mobile layout — pinned result + toggle (390×844)…')
   await checkMobileLayout()
+
+  console.log("E2E: release notes — What's new panel + unseen badge…")
+  await checkReleaseNotes()
 
   console.log('E2E: sample "Badge" (color, stacked)…')
   const badge = await loadSampleAndTrace(0, 'badge')


### PR DESCRIPTION
Adds a user-facing changelog accessible from the app header, allowing visitors to see recent changes at a glance.

## Summary

Implements a "What's new" release notes system with:
- A new `ReleaseNotes.vue` modal panel showing dated, categorized changelog entries
- A header button with a badge counting unseen notes since the last visit
- Persistent tracking of the last-seen release note in app state
- E2E test coverage for the feature

## Changes

- **`src/lib/releaseNotes.ts`** — New module defining the release note schema (`ReleaseNote`, `ReleaseNoteKind`) and helpers:
  - `RELEASE_NOTES` array (newest-first) with sample entries
  - `releaseId()` — stable identifier format `YYYY-MM-DD.iteration`
  - `countUnseen()` — counts notes newer than the visitor's last-seen marker
  - `formatReleaseDate()` — human-readable date formatting

- **`src/components/ReleaseNotes.vue`** — New modal component:
  - Displays all release notes with version, date, category badge, and description
  - Marks notes as "New" based on the unseen count at open time
  - Closes on Escape key or backdrop click
  - Calls `store.markReleasesSeen()` on mount to acknowledge all notes

- **`src/components/AppHeader.vue`** — Enhanced header:
  - New "What's new" button with speaker icon
  - Badge showing unseen count (capped at "9+" for compact display)
  - Dynamic title/aria-label reflecting unseen count
  - Emits `openReleaseNotes` event

- **`src/store/appStore.ts`** — Extended app state:
  - `lastSeenRelease` ref to persist the last-acknowledged note ID
  - `unseenReleaseCount` computed property
  - `markReleasesSeen()` method to update the marker

- **`src/App.vue`** — Integrated the modal:
  - `releaseNotesOpen` ref to control visibility
  - Renders `ReleaseNotes` component when open
  - Wires header button to toggle the panel

- **`scripts/e2e.mjs`** — Added `checkReleaseNotes()` test:
  - Verifies badge displays unseen count on first visit
  - Confirms panel lists notes with proper version format and "New" flags
  - Validates badge clears after opening the panel and reloading

- **Documentation** — Updated `apps/web/AGENTS.md` and root `AGENTS.md`:
  - Explains the release notes workflow and file locations
  - Instructs contributors to add a note in every PR with user-visible changes
  - Documents the date.iteration versioning scheme

## Implementation notes

- Release notes are identified by `YYYY-MM-DD.iteration` (e.g., `2026-08-23.2`) until formal versioning arrives
- The unseen count is snapshotted when the panel opens, so the "New" markers reflect the state at that moment
- Opening the panel automatically marks all notes as seen; the badge clears on the next page load
- The modal uses a fixed z-index (200) and includes smooth fade/rise animations
- Responsive design: full-width on mobile, constrained to 540px on desktop

https://claude.ai/code/session_01SkKRPDZ4iM7fFmdDK3tsZ6