### PR TITLE
Cache overlay geometry to smooth pan/zoom with path inspection

### DIFF
--- a/apps/web/src/components/PreviewOverlay.vue
+++ b/apps/web/src/components/PreviewOverlay.vue
@@ -12,11 +12,13 @@ import { SHAPE_KIND_TOKEN } from '../lib/overlay'
  * primitives), so simplified shapes stand out. Purely a read-out — it never
  * captures pointer events.
  *
- * Everything is drawn in screen space and redrawn on any pan/zoom, so anchor
- * marks keep a constant on-screen size at every zoom level. Geometry points are
- * in viewBox units (== document px); the document is placed at
- * `translate(tx, ty) scale(scale)`, so a point maps to screen as
- * `tx + x * scale`, `ty + y * scale`.
+ * The scene is parsed into per-kind buckets of document-space geometry once,
+ * when the geometry changes, and reused across every pan/zoom. Outlines are
+ * cached as `Path2D` and stroked under the canvas transform (never rebuilt);
+ * anchor marks and handles keep a constant on-screen size, so each frame maps
+ * their cached coordinates to screen space. Points are in viewBox units
+ * (== document px); the document is placed at `translate(tx, ty) scale(scale)`,
+ * so a point maps to screen as `tx + x * scale`, `ty + y * scale`.
  */
 
 const props = defineProps<{
@@ -46,21 +48,129 @@ const canvas = ref<HTMLCanvasElement | null>(null)
 let observer: ResizeObserver | null = null
 let raf = 0
 
-// Anchor / control totals, refreshed when the geometry changes; drive the
-// declutter thresholds without re-walking the commands every frame.
+/**
+ * Everything drawn for one element kind, in document (viewBox) coordinates, so
+ * it survives pan and zoom. Outlines are stroked under the canvas transform;
+ * anchor/handle coordinates are flat `[x, y, …]` runs mapped to screen space
+ * each frame (they keep a constant on-screen size, so they can't be baked into
+ * the transform). `handleLines` holds `[ax, ay, bx, by, …]` segments.
+ */
+interface Bucket {
+  token: string
+  outline: Path2D
+  anchors: number[]
+  handleLines: number[]
+  dots: number[]
+}
+
+// Document-space scene, rebuilt only when the geometry changes — pan/zoom reuse
+// it. The anchor/control totals drive the declutter thresholds; the viewBox
+// size folds into the screen scale.
+let scene: Bucket[] = []
 let nodeCount = 0
 let controlCount = 0
+let sceneW: number | null = null
+let sceneH: number | null = null
 
-function countGeometry(geo: SvgGeometry | null): void {
+// Token → resolved color, cached across frames (getComputedStyle forces a style
+// flush, so it must stay out of the draw loop). Re-resolved when the theme flips.
+let resolvedColors: Map<string, string> | null = null
+let resolvedDark = false
+
+/** Rebuild the cached document-space scene from freshly parsed geometry. */
+function buildScene(geo: SvgGeometry | null): void {
+  scene = []
   nodeCount = 0
   controlCount = 0
-  if (!geo) return
+  sceneW = geo?.width ?? null
+  sceneH = geo?.height ?? null
+  resolvedColors = null
+  if (!geo || geo.shapes.length === 0) return
+
+  const byToken = new Map<string, Bucket>()
+  const bucketFor = (token: string): Bucket => {
+    let b = byToken.get(token)
+    if (b === undefined) {
+      b = { token, outline: new Path2D(), anchors: [], handleLines: [], dots: [] }
+      byToken.set(token, b)
+    }
+    return b
+  }
+
+  // Outlines (always drawn) plus the anchor/control tallies.
   for (const shape of geo.shapes) {
+    appendOutline(bucketFor(SHAPE_KIND_TOKEN[shape.kind]).outline, shape.commands)
     for (const cmd of shape.commands) {
       if (cmd.type === 'Z') continue
       nodeCount++
       if (cmd.type === 'Q') controlCount += 1
       else if (cmd.type === 'C') controlCount += 2
+    }
+  }
+  scene = [...byToken.values()]
+
+  // Anchor marks and Bézier handles — only precomputed for what the declutter
+  // limits will actually draw, so huge traces don't build arrays nobody sees.
+  const withNodes = nodeCount <= NODE_LIMIT
+  const withHandles = withNodes && controlCount > 0 && controlCount <= HANDLE_LIMIT
+  if (!withNodes && !withHandles) return
+
+  for (const shape of geo.shapes) {
+    const b = bucketFor(SHAPE_KIND_TOKEN[shape.kind])
+    let cx = 0
+    let cy = 0
+    for (const cmd of shape.commands) {
+      switch (cmd.type) {
+        case 'M':
+        case 'L':
+          if (withNodes) b.anchors.push(cmd.x, cmd.y)
+          cx = cmd.x
+          cy = cmd.y
+          break
+        case 'Q':
+          if (withHandles) {
+            b.handleLines.push(cx, cy, cmd.x1, cmd.y1, cmd.x, cmd.y, cmd.x1, cmd.y1)
+            b.dots.push(cmd.x1, cmd.y1)
+          }
+          if (withNodes) b.anchors.push(cmd.x, cmd.y)
+          cx = cmd.x
+          cy = cmd.y
+          break
+        case 'C':
+          if (withHandles) {
+            b.handleLines.push(cx, cy, cmd.x1, cmd.y1, cmd.x, cmd.y, cmd.x2, cmd.y2)
+            b.dots.push(cmd.x1, cmd.y1, cmd.x2, cmd.y2)
+          }
+          if (withNodes) b.anchors.push(cmd.x, cmd.y)
+          cx = cmd.x
+          cy = cmd.y
+          break
+        case 'Z':
+          break
+      }
+    }
+  }
+}
+
+/** Append a shape's outline to `path` in document coordinates. */
+function appendOutline(path: Path2D, commands: readonly PathCommand[]): void {
+  for (const cmd of commands) {
+    switch (cmd.type) {
+      case 'M':
+        path.moveTo(cmd.x, cmd.y)
+        break
+      case 'L':
+        path.lineTo(cmd.x, cmd.y)
+        break
+      case 'Q':
+        path.quadraticCurveTo(cmd.x1, cmd.y1, cmd.x, cmd.y)
+        break
+      case 'C':
+        path.bezierCurveTo(cmd.x1, cmd.y1, cmd.x2, cmd.y2, cmd.x, cmd.y)
+        break
+      case 'Z':
+        path.closePath()
+        break
     }
   }
 }
@@ -73,30 +183,6 @@ function schedule(): void {
   })
 }
 
-function replayOutline(path: Path2D, shape: readonly PathCommand[], sx: number, sy: number): void {
-  const mx = (x: number): number => props.tx + x * sx
-  const my = (y: number): number => props.ty + y * sy
-  for (const cmd of shape) {
-    switch (cmd.type) {
-      case 'M':
-        path.moveTo(mx(cmd.x), my(cmd.y))
-        break
-      case 'L':
-        path.lineTo(mx(cmd.x), my(cmd.y))
-        break
-      case 'Q':
-        path.quadraticCurveTo(mx(cmd.x1), my(cmd.y1), mx(cmd.x), my(cmd.y))
-        break
-      case 'C':
-        path.bezierCurveTo(mx(cmd.x1), my(cmd.y1), mx(cmd.x2), my(cmd.y2), mx(cmd.x), my(cmd.y))
-        break
-      case 'Z':
-        path.closePath()
-        break
-    }
-  }
-}
-
 function draw(): void {
   const el = canvas.value
   if (!el) return
@@ -104,166 +190,128 @@ function draw(): void {
   if (!ctx) return
 
   const dpr = window.devicePixelRatio || 1
-  const cssW = el.clientWidth
-  const cssH = el.clientHeight
-  const bw = Math.max(1, Math.round(cssW * dpr))
-  const bh = Math.max(1, Math.round(cssH * dpr))
+  const bw = Math.max(1, Math.round(el.clientWidth * dpr))
+  const bh = Math.max(1, Math.round(el.clientHeight * dpr))
   if (el.width !== bw) el.width = bw
   if (el.height !== bh) el.height = bh
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-  ctx.clearRect(0, 0, cssW, cssH)
+  ctx.setTransform(1, 0, 0, 1, 0, 0)
+  ctx.clearRect(0, 0, bw, bh)
 
-  const geo = props.geometry
-  if (!geo || geo.shapes.length === 0) return
+  if (scene.length === 0) return
 
-  if (props.clipX !== null) {
+  // Resolve each kind's token color once per theme; getComputedStyle is costly.
+  if (!resolvedColors || resolvedDark !== props.dark) {
+    const styles = getComputedStyle(el)
+    const colors = new Map<string, string>()
+    for (const b of scene) {
+      if (!colors.has(b.token)) {
+        colors.set(b.token, styles.getPropertyValue(b.token).trim() || '#6c7bff')
+      }
+    }
+    resolvedColors = colors
+    resolvedDark = props.dark
+  }
+  const colorOf = (token: string): string => resolvedColors?.get(token) ?? '#6c7bff'
+
+  // Hoisted out of the hot loops — reactive prop reads per point are not free.
+  const tx = props.tx
+  const ty = props.ty
+  // viewBox → document px (usually 1:1) folded into the screen scale.
+  const sx = props.scale * (props.docW > 0 ? props.docW / (sceneW || props.docW) : 1)
+  const sy = props.scale * (props.docH > 0 ? props.docH / (sceneH || props.docH) : 1)
+
+  // Clip to the SVG side of a split. Set in device space so it holds across the
+  // world/screen transform switches below.
+  const clipX = props.clipX
+  if (clipX !== null) {
     ctx.save()
     ctx.beginPath()
-    ctx.rect(props.clipX, 0, Math.max(0, cssW - props.clipX), cssH)
+    ctx.rect(clipX * dpr, 0, Math.max(0, bw - clipX * dpr), bh)
     ctx.clip()
-  }
-
-  // viewBox → document px (usually 1:1) folded into the screen scale.
-  const sx = props.scale * (props.docW > 0 ? props.docW / (geo.width || props.docW) : 1)
-  const sy = props.scale * (props.docH > 0 ? props.docH / (geo.height || props.docH) : 1)
-  const mx = (x: number): number => props.tx + x * sx
-  const my = (y: number): number => props.ty + y * sy
-
-  const styles = getComputedStyle(el)
-  const tokenCache = new Map<string, string>()
-  const tokenColor = (token: string): string => {
-    let c = tokenCache.get(token)
-    if (c === undefined) {
-      c = styles.getPropertyValue(token).trim() || '#6c7bff'
-      tokenCache.set(token, c)
-    }
-    return c
-  }
-  const halo = props.dark ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.55)'
-
-  const showNodes = nodeCount <= NODE_LIMIT
-  const showHandles = showNodes && controlCount > 0 && controlCount <= HANDLE_LIMIT
-
-  // Group every shape into a per-color bucket keyed by its element kind, so all
-  // paths, all rects, etc. can each be stroked in one pass in their own hue.
-  const buckets = new Map<string, Bucket>()
-  const bucketFor = (color: string): Bucket => {
-    let b = buckets.get(color)
-    if (b === undefined) {
-      b = { outline: new Path2D(), handles: new Path2D(), dots: [], marks: new Path2D() }
-      buckets.set(color, b)
-    }
-    return b
-  }
-
-  for (const shape of geo.shapes) {
-    const b = bucketFor(tokenColor(SHAPE_KIND_TOKEN[shape.kind]))
-    replayOutline(b.outline, shape.commands, sx, sy)
-    if (showNodes) {
-      for (const cmd of shape.commands) {
-        if (cmd.type !== 'Z') addCross(b.marks, mx(cmd.x), my(cmd.y))
-      }
-    }
-    if (showHandles) {
-      let cx = 0
-      let cy = 0
-      for (const cmd of shape.commands) {
-        if (cmd.type === 'M' || cmd.type === 'L') {
-          cx = cmd.x
-          cy = cmd.y
-        } else if (cmd.type === 'Q') {
-          addHandle(b.handles, b.dots, mx(cx), my(cy), mx(cmd.x1), my(cmd.y1))
-          b.handles.moveTo(mx(cmd.x), my(cmd.y))
-          b.handles.lineTo(mx(cmd.x1), my(cmd.y1))
-          cx = cmd.x
-          cy = cmd.y
-        } else if (cmd.type === 'C') {
-          addHandle(b.handles, b.dots, mx(cx), my(cy), mx(cmd.x1), my(cmd.y1))
-          addHandle(b.handles, b.dots, mx(cmd.x), my(cmd.y), mx(cmd.x2), my(cmd.y2))
-          cx = cmd.x
-          cy = cmd.y
-        }
-      }
-    }
   }
 
   ctx.lineJoin = 'round'
   ctx.lineCap = 'round'
 
-  // Outlines (bottom layer).
+  // Outlines (bottom layer): cached document-space paths stroked under the
+  // pan/zoom transform, so they are never rebuilt on pan or zoom. The line width
+  // is pre-divided by the scale to stay a constant OUTLINE_WIDTH on screen.
+  ctx.setTransform(sx * dpr, 0, 0, sy * dpr, tx * dpr, ty * dpr)
   ctx.globalAlpha = 0.85
-  ctx.lineWidth = OUTLINE_WIDTH
-  for (const [color, b] of buckets) {
-    ctx.strokeStyle = color
+  ctx.lineWidth = OUTLINE_WIDTH / (sx || 1)
+  for (const b of scene) {
+    ctx.strokeStyle = colorOf(b.token)
     ctx.stroke(b.outline)
   }
+
+  // Marks and handles keep a constant on-screen size, so they are placed in
+  // screen space each frame from the cached document-space coordinates.
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+
+  const showNodes = nodeCount <= NODE_LIMIT
+  const showHandles = showNodes && controlCount > 0 && controlCount <= HANDLE_LIMIT
 
   // Bézier handles: lines to each control point, then a small square on it.
   if (showHandles) {
     const side = CONTROL_RADIUS * 2
-    for (const [color, b] of buckets) {
+    for (const b of scene) {
+      const color = colorOf(b.token)
+      const lines = new Path2D()
+      const hl = b.handleLines
+      for (let i = 0; i < hl.length; i += 4) {
+        lines.moveTo(tx + hl[i] * sx, ty + hl[i + 1] * sy)
+        lines.lineTo(tx + hl[i + 2] * sx, ty + hl[i + 3] * sy)
+      }
       ctx.strokeStyle = color
       ctx.globalAlpha = 0.4
       ctx.lineWidth = HANDLE_WIDTH
-      ctx.stroke(b.handles)
+      ctx.stroke(lines)
       ctx.fillStyle = color
       ctx.globalAlpha = 0.6
-      for (let p = 0; p < b.dots.length; p += 2) {
-        ctx.fillRect(b.dots[p] - CONTROL_RADIUS, b.dots[p + 1] - CONTROL_RADIUS, side, side)
+      const dots = b.dots
+      for (let i = 0; i < dots.length; i += 2) {
+        ctx.fillRect(
+          tx + dots[i] * sx - CONTROL_RADIUS,
+          ty + dots[i + 1] * sy - CONTROL_RADIUS,
+          side,
+          side,
+        )
       }
     }
   }
 
   // Anchor marks — small crosses on top, haloed so they read over any fill.
   if (showNodes) {
-    for (const [color, b] of buckets) {
+    const halo = props.dark ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.55)'
+    for (const b of scene) {
+      const marks = new Path2D()
+      const a = b.anchors
+      for (let i = 0; i < a.length; i += 2) {
+        const x = tx + a[i] * sx
+        const y = ty + a[i + 1] * sy
+        marks.moveTo(x - NODE_HALF, y - NODE_HALF)
+        marks.lineTo(x + NODE_HALF, y + NODE_HALF)
+        marks.moveTo(x - NODE_HALF, y + NODE_HALF)
+        marks.lineTo(x + NODE_HALF, y - NODE_HALF)
+      }
       ctx.globalAlpha = 1
       ctx.strokeStyle = halo
       ctx.lineWidth = NODE_WIDTH + 1.5
-      ctx.stroke(b.marks)
-      ctx.strokeStyle = color
+      ctx.stroke(marks)
+      ctx.strokeStyle = colorOf(b.token)
       ctx.lineWidth = NODE_WIDTH
-      ctx.stroke(b.marks)
+      ctx.stroke(marks)
     }
   }
 
   ctx.globalAlpha = 1
-  if (props.clipX !== null) ctx.restore()
-}
-
-/** Per-color accumulation of everything drawn for one element kind. */
-interface Bucket {
-  outline: Path2D
-  handles: Path2D
-  dots: number[]
-  marks: Path2D
-}
-
-/** Add a handle line (anchor → control) and record the control point. */
-function addHandle(
-  lines: Path2D,
-  dots: number[],
-  ax: number,
-  ay: number,
-  cx: number,
-  cy: number,
-): void {
-  lines.moveTo(ax, ay)
-  lines.lineTo(cx, cy)
-  dots.push(cx, cy)
-}
-
-function addCross(path: Path2D, x: number, y: number): void {
-  path.moveTo(x - NODE_HALF, y - NODE_HALF)
-  path.lineTo(x + NODE_HALF, y + NODE_HALF)
-  path.moveTo(x - NODE_HALF, y + NODE_HALF)
-  path.lineTo(x + NODE_HALF, y - NODE_HALF)
+  if (clipX !== null) ctx.restore()
 }
 
 watch(
   () => props.geometry,
   (geo) => {
-    countGeometry(geo)
+    buildScene(geo)
     schedule()
   },
   { immediate: true },

--- a/apps/web/src/components/PreviewViewport.vue
+++ b/apps/web/src/components/PreviewViewport.vue
@@ -72,6 +72,14 @@ const svgLayerStyle = computed(() =>
   view.value === 'split' ? { clipPath: `inset(0 0 0 ${splitFrac.value * 100}%)` } : {},
 )
 
+// In split view the original only occupies the left of the divider. Without this
+// complementary clip it also fills the right, showing through the SVG's
+// transparent areas and making the trace look like it reproduced detail it did
+// not. The two halves meet exactly at the divider.
+const origLayerStyle = computed(() =>
+  view.value === 'split' ? { clipPath: `inset(0 ${(1 - splitFrac.value) * 100}% 0 0)` } : {},
+)
+
 const dividerX = computed(() => tx.value + splitFrac.value * docW.value * scale.value)
 
 // --------------------------- Complexity overlay --------------------------
@@ -471,6 +479,7 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut, toggleNodes })
           ref="origCanvas"
           class="layer layer-original"
           :class="{ pixelated, dimmed: view === 'diff' }"
+          :style="origLayerStyle"
         />
         <div
           v-show="showSvg"

--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -37,6 +37,16 @@ export interface ReleaseNote {
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
     date: '2026-08-23',
+    iteration: 4,
+    kind: 'fix',
+    title: 'Truer split view and smoother inspection',
+    items: [
+      'The side-by-side split view no longer lets the original image show through the traced result, so each side shows only its own picture.',
+      'Panning and zooming with "Show path nodes & outlines" turned on is noticeably smoother on detailed traces.',
+    ],
+  },
+  {
+    date: '2026-08-23',
     iteration: 3,
     kind: 'feature',
     title: 'Now available in French',


### PR DESCRIPTION
## Summary

Refactored the preview overlay rendering to cache document-space geometry once when it changes, rather than rebuilding it every frame during pan/zoom. This significantly improves performance when inspecting detailed traces with "Show path nodes & outlines" enabled.

Additionally fixed the split view to properly clip the original image layer, preventing it from showing through the traced result on the right side of the divider.

## Key Changes

**PreviewOverlay.vue:**
- Introduced `Bucket` interface to organize cached geometry by shape kind (token), containing:
  - `Path2D` outlines (stroked under canvas transform, never rebuilt)
  - Flat coordinate arrays for anchors, handle lines, and control point dots (mapped to screen space each frame)
- Replaced `countGeometry()` with `buildScene()` that parses geometry once into per-kind buckets and caches them in `scene` array
- Moved outline building to `appendOutline()` helper that works in document coordinates (no screen transform applied)
- Refactored `draw()` to:
  - Resolve token colors once per theme change (cached in `resolvedColors`) instead of every frame
  - Stroke cached outlines under the pan/zoom transform with pre-divided line width
  - Reconstruct anchor marks and handle lines in screen space each frame from cached document coordinates
  - Properly handle device pixel ratio in clip rect calculations
- Removed helper functions `addHandle()` and `addCross()` (logic inlined into `buildScene()` and `draw()`)

**PreviewViewport.vue:**
- Added `origLayerStyle` computed property that clips the original image layer to the left side of the split divider
- Applied the clip to the original canvas element, ensuring the two halves meet exactly at the divider without overlap

**releaseNotes.ts:**
- Added release note documenting the split view fix and performance improvement

## Implementation Details

The geometry caching strategy separates concerns:
- **Document space** (cached): outlines as `Path2D`, anchor/handle coordinates as flat arrays — survives pan/zoom unchanged
- **Screen space** (per-frame): anchor marks and handle lines reconstructed from cached coordinates using current transform — keeps constant on-screen size

This avoids rebuilding `Path2D` objects and re-walking shape commands on every frame, while maintaining the visual invariants (constant-size marks, properly transformed outlines).

https://claude.ai/code/session_01HPdsnCxAMNSuxSmtj3q327