### PR TITLE
fix(web): run palette suggestion in a worker so loading doesn't freeze the UI

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -18,7 +18,9 @@ src/
   App.vue                layout grid, keyboard shortcuts, theme binding
   store/appStore.ts       the single source of truth (Pinia setup store)
   worker/vectorize.worker.ts   installWorkerHandler(self) — the engine, off the main thread
+  worker/assist.worker.ts      installAssistWorker(self) — palette suggestion, off the main thread
   lib/                    decode (image → RasterImage), download/copy, fidelity scoring, samples, format helpers,
+                          assistClient (main-thread handle on the assist worker),
                           overlay (per-element-kind colors/labels for the complexity overlay),
                           layers (group traced SVG geometry into color layers + contours for the layer panel),
                           releaseNotes (the user-facing changelog + its date/iteration helpers)
@@ -38,6 +40,10 @@ src/
   (matched by `error.name`, cross-realm safe) and is swallowed silently. Never call the engine on the main thread.
 - **The worker copies the pixel buffer before transferring** (`client.ts`) — the store passes `workingImage` without
   cloning and relies on that. Don't remove the copy or the caller's image detaches.
+- **Whole-image work runs in a worker, never on the main thread.** Palette suggestion (`suggestPalettes`, a full-image
+  k-means pass) goes through one `AssistClient` (`lib/assistClient.ts` + `worker/assist.worker.ts`), like vectorization
+  through `TrazorClient`. Only the cheap, sampled `analyzeImage` stays on the main thread — auto-recommend needs it
+  synchronously before the debounced trace. Anything that touches every pixel of a full-size image belongs off-thread.
 - **Settings come from `@trazor/core`.** Use `DEFAULT_SETTINGS`, `normalizeSettings`, `TARGET_PROFILES`; never
   hand-maintain a parallel list of fields or clamps.
 - **Theme-aware and responsive.** Every color is a token in `base.css` defined for both dark and default/light; respect

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -19,8 +19,10 @@ src/
   store/appStore.ts       the single source of truth (Pinia setup store)
   worker/vectorize.worker.ts   installWorkerHandler(self) — the engine, off the main thread
   worker/assist.worker.ts      installAssistWorker(self) — palette suggestion, off the main thread
-  lib/                    decode (image → RasterImage), download/copy, fidelity scoring, samples, format helpers,
-                          assistClient (main-thread handle on the assist worker),
+  worker/fidelity.worker.ts    installFidelityWorker(self) — the ΔE fidelity pass, off the main thread
+  lib/                    decode (image → RasterImage), download/copy, samples, format helpers,
+                          fidelity (rasterize on the main thread; score via the fidelity worker),
+                          assistClient / fidelityClient (main-thread handles on those workers),
                           overlay (per-element-kind colors/labels for the complexity overlay),
                           layers (group traced SVG geometry into color layers + contours for the layer panel),
                           releaseNotes (the user-facing changelog + its date/iteration helpers)
@@ -41,9 +43,12 @@ src/
 - **The worker copies the pixel buffer before transferring** (`client.ts`) — the store passes `workingImage` without
   cloning and relies on that. Don't remove the copy or the caller's image detaches.
 - **Whole-image work runs in a worker, never on the main thread.** Palette suggestion (`suggestPalettes`, a full-image
-  k-means pass) goes through one `AssistClient` (`lib/assistClient.ts` + `worker/assist.worker.ts`), like vectorization
-  through `TrazorClient`. Only the cheap, sampled `analyzeImage` stays on the main thread — auto-recommend needs it
-  synchronously before the debounced trace. Anything that touches every pixel of a full-size image belongs off-thread.
+  k-means pass) goes through one `AssistClient`; the fidelity ΔE pass (two Oklab conversions per pixel + heatmap) goes
+  through one `FidelityClient` — each its own worker, so they run in parallel with each other and the trace. Only work
+  that _must_ touch the DOM stays on the main thread: fidelity's SVG/source rasterization (`createImageBitmap` can't
+  rasterize SVG reliably across browsers) hands the two RGBA rasters to the worker for the per-pixel pass. The cheap,
+  sampled `analyzeImage` also stays on the main thread — auto-recommend needs it synchronously before the debounced
+  trace. Anything else that touches every pixel of a full-size image belongs off-thread.
 - **Settings come from `@trazor/core`.** Use `DEFAULT_SETTINGS`, `normalizeSettings`, `TARGET_PROFILES`; never
   hand-maintain a parallel list of fields or clamps.
 - **Theme-aware and responsive.** Every color is a token in `base.css` defined for both dark and default/light; respect

--- a/apps/web/src/lib/assistClient.ts
+++ b/apps/web/src/lib/assistClient.ts
@@ -1,0 +1,74 @@
+import type { RasterImage } from '@trazor/core'
+import type { ImageAnalysis, PaletteSuggestion } from '@trazor/assist'
+import type { AssistInMessage, AssistOutMessage } from '../worker/assistProtocol'
+
+interface PendingJob {
+  resolve: (suggestions: PaletteSuggestion[]) => void
+  reject: (error: Error) => void
+}
+
+/**
+ * Main-thread handle on the assist worker. Palette suggestion is a full-image
+ * k-means pass (several, for a photo), so it runs off the UI thread. Jobs are
+ * matched by id; the caller drops results for a superseded image. The worker is
+ * spawned lazily and respawned after a crash.
+ */
+export class AssistClient {
+  private worker: Worker | null = null
+  private nextId = 1
+  private jobs = new Map<number, PendingJob>()
+
+  constructor(private createWorker: () => Worker) {}
+
+  suggestPalettes(image: RasterImage, analysis: ImageAnalysis): Promise<PaletteSuggestion[]> {
+    const worker = this.ensureWorker()
+    const id = this.nextId++
+    return new Promise<PaletteSuggestion[]>((resolve, reject) => {
+      this.jobs.set(id, { resolve, reject })
+      // Copy: transferring the original buffer would detach the caller's image.
+      const buffer = image.data.slice().buffer
+      const msg: AssistInMessage = {
+        type: 'suggestPalettes',
+        id,
+        width: image.width,
+        height: image.height,
+        buffer,
+        analysis,
+      }
+      worker.postMessage(msg, [buffer])
+    })
+  }
+
+  dispose(): void {
+    this.worker?.terminate()
+    this.worker = null
+    this.jobs.clear()
+  }
+
+  private ensureWorker(): Worker {
+    if (this.worker) return this.worker
+    const worker = this.createWorker()
+    worker.addEventListener('message', (ev: MessageEvent) => {
+      this.handleMessage(ev.data as AssistOutMessage)
+    })
+    worker.addEventListener('error', (ev: ErrorEvent) => {
+      // A crashed worker fails every pending job and gets respawned lazily.
+      for (const job of this.jobs.values()) {
+        job.reject(new Error(ev.message || 'assist worker crashed'))
+      }
+      this.jobs.clear()
+      worker.terminate()
+      if (this.worker === worker) this.worker = null
+    })
+    this.worker = worker
+    return worker
+  }
+
+  private handleMessage(msg: AssistOutMessage): void {
+    const job = this.jobs.get(msg.id)
+    if (!job) return
+    this.jobs.delete(msg.id)
+    if (msg.type === 'palettes') job.resolve(msg.suggestions)
+    else job.reject(new Error(msg.message))
+  }
+}

--- a/apps/web/src/lib/fidelity.ts
+++ b/apps/web/src/lib/fidelity.ts
@@ -1,6 +1,6 @@
-import { clamp, deltaEOk, rgbToOklab } from '@trazor/core'
 import type { RasterImage, VectorizeResult } from '@trazor/core'
 import { create2dCanvas } from './decode'
+import type { FidelityClient } from './fidelityClient'
 
 export interface FidelityReport {
   /** 0..1 — perceptual similarity between source and traced SVG. */
@@ -8,11 +8,6 @@ export interface FidelityReport {
   /** Per-pixel ΔE heatmap at result size (transparent where faithful). */
   diff: RasterImage
 }
-
-const SAMPLE_BUDGET = 200_000
-const CHUNK_PIXELS = 250_000
-/** ΔE(Oklab) mapped to full heat. */
-const HEAT_FULL = 0.25
 
 function loadSvgImage(svg: string): Promise<HTMLImageElement> {
   const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' })
@@ -27,20 +22,18 @@ function loadSvgImage(svg: string): Promise<HTMLImageElement> {
   }).finally(() => URL.revokeObjectURL(url))
 }
 
-function yieldToUi(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0))
-}
-
 /**
  * Perceptual fidelity of a vectorization result.
  *
- * Rasterizes the result SVG at its own pixel size, composites both it and the
- * (downscaled) source over white, then measures mean ΔE in Oklab over up to
- * 200k sampled pixels. Also produces a heatmap raster for the Difference view.
+ * Rasterizes the result SVG at its own pixel size and composites both it and
+ * the (downscaled) source over white — DOM-bound work that stays on the main
+ * thread. The heavy per-pixel Oklab ΔE pass (mean similarity + heatmap) runs in
+ * the fidelity worker via `client`, so a large result never janks the UI.
  */
 export async function computeFidelity(
   sourceImage: RasterImage,
   result: VectorizeResult,
+  client: FidelityClient,
 ): Promise<FidelityReport> {
   const w = result.width
   const h = result.height
@@ -69,39 +62,6 @@ export async function computeFidelity(
   reference.ctx.drawImage(srcCanvas.canvas, 0, 0, w, h)
   const b = reference.ctx.getImageData(0, 0, w, h).data
 
-  const pixels = w * h
-  const stride = Math.max(1, Math.floor(pixels / SAMPLE_BUDGET))
-  const diffData = new Uint8ClampedArray(pixels * 4)
-
-  let sum = 0
-  let count = 0
-  for (let start = 0; start < pixels; start += CHUNK_PIXELS) {
-    const end = Math.min(pixels, start + CHUNK_PIXELS)
-    for (let p = start; p < end; p++) {
-      const i = p * 4
-      const [l1, a1, b1] = rgbToOklab(a[i] / 255, a[i + 1] / 255, a[i + 2] / 255)
-      const [l2, a2, b2] = rgbToOklab(b[i] / 255, b[i + 1] / 255, b[i + 2] / 255)
-      const dE = deltaEOk(l1, a1, b1, l2, a2, b2)
-      if (p % stride === 0) {
-        sum += dE
-        count++
-      }
-      // Heatmap: faithful → transparent, unfaithful → amber to hot red.
-      const t = clamp(dE / HEAT_FULL, 0, 1)
-      if (t > 0.02) {
-        diffData[i] = 255
-        diffData[i + 1] = 170 - t * 130
-        diffData[i + 2] = 40 + t * 50
-        diffData[i + 3] = Math.sqrt(t) * 235
-      }
-    }
-    // oxlint-disable-next-line no-await-in-loop -- sequential on purpose: yield to the UI between chunks
-    if (end < pixels) await yieldToUi()
-  }
-
-  const meanDeltaE = count > 0 ? sum / count : 0
-  return {
-    score: clamp(1 - meanDeltaE * 4, 0, 1),
-    diff: { width: w, height: h, data: diffData },
-  }
+  // Heavy per-pixel ΔE + heatmap — off the main thread.
+  return client.score(w, h, a, b)
 }

--- a/apps/web/src/lib/fidelityClient.ts
+++ b/apps/web/src/lib/fidelityClient.ts
@@ -1,0 +1,94 @@
+import type { RasterImage } from '@trazor/core'
+import type { FidelityInMessage, FidelityOutMessage } from '../worker/fidelityProtocol'
+
+/** The scored difference the worker returns: score plus the heatmap raster. */
+export interface ScoredDifference {
+  score: number
+  diff: RasterImage
+}
+
+interface PendingJob {
+  resolve: (result: ScoredDifference) => void
+  reject: (error: Error) => void
+}
+
+/**
+ * Main-thread handle on the fidelity worker. The per-pixel Oklab ΔE pass (twice
+ * per pixel, at result resolution) runs off the UI thread; the caller does the
+ * DOM-bound rasterization and hands over the two RGBA rasters. Jobs are matched
+ * by id; the caller drops results for a superseded run. The worker is spawned
+ * lazily and respawned after a crash.
+ */
+export class FidelityClient {
+  private worker: Worker | null = null
+  private nextId = 1
+  private jobs = new Map<number, PendingJob>()
+
+  constructor(private createWorker: () => Worker) {}
+
+  /**
+   * Score a rendered raster against a reference raster (both RGBA, `width`×
+   * `height`, composited over white). The buffers are transferred, so the
+   * caller must not reuse them afterward.
+   */
+  score(
+    width: number,
+    height: number,
+    rendered: Uint8ClampedArray<ArrayBuffer>,
+    reference: Uint8ClampedArray<ArrayBuffer>,
+  ): Promise<ScoredDifference> {
+    const worker = this.ensureWorker()
+    const id = this.nextId++
+    return new Promise<ScoredDifference>((resolve, reject) => {
+      this.jobs.set(id, { resolve, reject })
+      const msg: FidelityInMessage = {
+        type: 'score',
+        id,
+        width,
+        height,
+        rendered: rendered.buffer,
+        reference: reference.buffer,
+      }
+      worker.postMessage(msg, [rendered.buffer, reference.buffer])
+    })
+  }
+
+  dispose(): void {
+    this.worker?.terminate()
+    this.worker = null
+    this.jobs.clear()
+  }
+
+  private ensureWorker(): Worker {
+    if (this.worker) return this.worker
+    const worker = this.createWorker()
+    worker.addEventListener('message', (ev: MessageEvent) => {
+      this.handleMessage(ev.data as FidelityOutMessage)
+    })
+    worker.addEventListener('error', (ev: ErrorEvent) => {
+      // A crashed worker fails every pending job and gets respawned lazily.
+      for (const job of this.jobs.values()) {
+        job.reject(new Error(ev.message || 'fidelity worker crashed'))
+      }
+      this.jobs.clear()
+      worker.terminate()
+      if (this.worker === worker) this.worker = null
+    })
+    this.worker = worker
+    return worker
+  }
+
+  private handleMessage(msg: FidelityOutMessage): void {
+    const job = this.jobs.get(msg.id)
+    if (!job) return
+    this.jobs.delete(msg.id)
+    if (msg.type === 'result') {
+      job.resolve({
+        score: msg.score,
+        diff: { width: msg.width, height: msg.height, data: new Uint8ClampedArray(msg.diff) },
+      })
+    } else {
+      job.reject(new Error(msg.message))
+    }
+  }
+}

--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -36,6 +36,15 @@ export interface ReleaseNote {
  */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    date: '2026-08-24',
+    iteration: 1,
+    kind: 'fix',
+    title: 'Smoother image loading',
+    items: [
+      'Opening a photo no longer freezes the studio while palette suggestions are prepared — that work now happens in the background, so the interface stays responsive.',
+    ],
+  },
+  {
     date: '2026-08-23',
     iteration: 6,
     kind: 'improvement',

--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -39,9 +39,10 @@ export const RELEASE_NOTES: readonly ReleaseNote[] = [
     date: '2026-08-24',
     iteration: 1,
     kind: 'fix',
-    title: 'Smoother image loading',
+    title: 'A smoother, more responsive studio',
     items: [
       'Opening a photo no longer freezes the studio while palette suggestions are prepared — that work now happens in the background, so the interface stays responsive.',
+      'Scoring how closely a trace matches the original (the fidelity score and Difference view) also runs in the background now, so adjusting settings on large images stays smooth.',
     ],
   },
   {

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -16,7 +16,7 @@ import type {
   VectorizeResult,
   VectorizeSettings,
 } from '@trazor/core'
-import { analyzeImage, recommendSettings, suggestPalettes } from '@trazor/assist'
+import { analyzeImage, recommendSettings } from '@trazor/assist'
 import type { ImageAnalysis, PaletteSuggestion, RationaleKey } from '@trazor/assist'
 import { TrazorClient } from '@trazor/engine'
 import { extractGeometry } from '@trazor/svg'
@@ -26,6 +26,7 @@ import { defineStore } from 'pinia'
 import { computed, reactive, ref, shallowRef, watch } from 'vue'
 import { applyLocale, pickInitialLocale, translate as t } from '../i18n'
 import type { LocaleCode } from '../i18n'
+import { AssistClient } from '../lib/assistClient'
 import { decodeBlob } from '../lib/decode'
 import { computeFidelity } from '../lib/fidelity'
 import type { FidelityReport } from '../lib/fidelity'
@@ -108,15 +109,6 @@ function errorMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e)
 }
 
-/** Run work off the critical path (idle callback when available). */
-function deferToIdle(fn: () => void): void {
-  if (typeof requestIdleCallback === 'function') {
-    requestIdleCallback(() => fn(), { timeout: 1500 })
-  } else {
-    setTimeout(fn, 0)
-  }
-}
-
 function mlPhaseInfo(p: MlProgress): { progress: number | null; phase: string } {
   if (p.phase === 'download') {
     const frac = p.total > 0 ? (p.loaded / p.total) * 0.85 : null
@@ -191,6 +183,7 @@ export const useAppStore = defineStore('app', () => {
 
   // Non-reactive machinery
   let client: TrazorClient | null = null
+  let assistClient: AssistClient | null = null
   let runCounter = 0
   let runTimer: ReturnType<typeof setTimeout> | null = null
   let toastCounter = 0
@@ -403,9 +396,17 @@ export const useAppStore = defineStore('app', () => {
   }
 
   // -------------------------- Palette suggestions ------------------------
-  // Derived from image stats by @trazor/assist. Recomputed (deferred, so
-  // first paint isn't blocked) whenever the working image changes; cached per
-  // image so restoring the original is instant.
+  // Derived from image stats by @trazor/assist. Computed in a worker (a
+  // full-image k-means pass) whenever the working image changes, so loading an
+  // image never blocks the UI thread; cached per image so restoring the
+  // original is instant.
+  function getAssistClient(): AssistClient {
+    assistClient ??= new AssistClient(
+      () => new Worker(new URL('../worker/assist.worker.ts', import.meta.url), { type: 'module' }),
+    )
+    return assistClient
+  }
+
   function refreshPaletteSuggestions(image: RasterImage): void {
     const cached = suggestionCache.get(image)
     if (cached) {
@@ -414,19 +415,20 @@ export const useAppStore = defineStore('app', () => {
       return
     }
     paletteSuggestionsPending.value = true
-    deferToIdle(() => {
-      // The image may have been replaced while we waited.
-      if (workingImage.value !== image) return
-      try {
-        const suggestions = suggestPalettes(image, getAnalysis(image))
-        suggestionCache.set(image, suggestions)
-        paletteSuggestions.value = suggestions
-      } catch {
-        paletteSuggestions.value = []
-      } finally {
-        paletteSuggestionsPending.value = false
-      }
-    })
+    void computePaletteSuggestions(image)
+  }
+
+  async function computePaletteSuggestions(image: RasterImage): Promise<void> {
+    try {
+      const suggestions = await getAssistClient().suggestPalettes(image, getAnalysis(image))
+      suggestionCache.set(image, suggestions)
+      // The image may have been replaced while the worker ran.
+      if (workingImage.value === image) paletteSuggestions.value = suggestions
+    } catch {
+      if (workingImage.value === image) paletteSuggestions.value = []
+    } finally {
+      if (workingImage.value === image) paletteSuggestionsPending.value = false
+    }
   }
 
   watch(workingImage, (image) => {

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -30,6 +30,7 @@ import { AssistClient } from '../lib/assistClient'
 import { decodeBlob } from '../lib/decode'
 import { computeFidelity } from '../lib/fidelity'
 import type { FidelityReport } from '../lib/fidelity'
+import { FidelityClient } from '../lib/fidelityClient'
 import { buildLayers } from '../lib/layers'
 import type { LayerModel } from '../lib/layers'
 import { countUnseen, latestReleaseId } from '../lib/releaseNotes'
@@ -184,6 +185,7 @@ export const useAppStore = defineStore('app', () => {
   // Non-reactive machinery
   let client: TrazorClient | null = null
   let assistClient: AssistClient | null = null
+  let fidelityClient: FidelityClient | null = null
   let runCounter = 0
   let runTimer: ReturnType<typeof setTimeout> | null = null
   let toastCounter = 0
@@ -480,6 +482,14 @@ export const useAppStore = defineStore('app', () => {
     return client
   }
 
+  function getFidelityClient(): FidelityClient {
+    fidelityClient ??= new FidelityClient(
+      () =>
+        new Worker(new URL('../worker/fidelity.worker.ts', import.meta.url), { type: 'module' }),
+    )
+    return fidelityClient
+  }
+
   async function doRun(): Promise<void> {
     const image = workingImage.value
     if (!image) return
@@ -505,7 +515,7 @@ export const useAppStore = defineStore('app', () => {
       busy.value = false
       progress.value = null
       try {
-        const report = await computeFidelity(image, res)
+        const report = await computeFidelity(image, res, getFidelityClient())
         if (runId === runCounter) fidelity.value = report
       } catch {
         if (runId === runCounter) fidelity.value = null

--- a/apps/web/src/worker/assist.worker.ts
+++ b/apps/web/src/worker/assist.worker.ts
@@ -1,0 +1,3 @@
+import { installAssistWorker } from './assistWorker'
+
+installAssistWorker(self as never)

--- a/apps/web/src/worker/assistProtocol.ts
+++ b/apps/web/src/worker/assistProtocol.ts
@@ -1,0 +1,24 @@
+import type { ImageAnalysis, PaletteSuggestion } from '@trazor/assist'
+
+/** Messages accepted by the assist worker. */
+export interface AssistInMessage {
+  type: 'suggestPalettes'
+  id: number
+  width: number
+  height: number
+  /** RGBA bytes, transferred. */
+  buffer: ArrayBuffer
+  /** Image statistics computed on the main thread (cheap, sampled). */
+  analysis: ImageAnalysis
+}
+
+/** Messages emitted by the assist worker. */
+export type AssistOutMessage =
+  | { type: 'palettes'; id: number; suggestions: PaletteSuggestion[] }
+  | { type: 'error'; id: number; message: string }
+
+/** Minimal worker-global surface — keeps this module free of lib.webworker. */
+export interface AssistWorkerScope {
+  addEventListener(type: 'message', listener: (ev: { data: unknown }) => void): void
+  postMessage(message: unknown, transfer?: Transferable[]): void
+}

--- a/apps/web/src/worker/assistWorker.ts
+++ b/apps/web/src/worker/assistWorker.ts
@@ -1,0 +1,26 @@
+import type { RasterImage } from '@trazor/core'
+import { suggestPalettes } from '@trazor/assist'
+import type { AssistInMessage, AssistOutMessage, AssistWorkerScope } from './assistProtocol'
+
+/**
+ * Wire palette suggestion to a worker scope. `suggestPalettes` runs several
+ * full-image k-means passes, so it must stay off the UI thread (Selinger-class
+ * tracing already does, via @trazor/engine). Deterministic for a given image.
+ */
+export function installAssistWorker(scope: AssistWorkerScope): void {
+  const post = (msg: AssistOutMessage, transfer?: Transferable[]): void =>
+    scope.postMessage(msg, transfer)
+
+  scope.addEventListener('message', (ev) => {
+    const msg = ev.data as AssistInMessage
+    if (msg.type !== 'suggestPalettes') return
+    const { id, width, height, buffer, analysis } = msg
+    try {
+      const image: RasterImage = { width, height, data: new Uint8ClampedArray(buffer) }
+      const suggestions = suggestPalettes(image, analysis)
+      post({ type: 'palettes', id, suggestions })
+    } catch (err) {
+      post({ type: 'error', id, message: err instanceof Error ? err.message : String(err) })
+    }
+  })
+}

--- a/apps/web/src/worker/fidelity.worker.ts
+++ b/apps/web/src/worker/fidelity.worker.ts
@@ -1,0 +1,3 @@
+import { installFidelityWorker } from './fidelityWorker'
+
+installFidelityWorker(self as never)

--- a/apps/web/src/worker/fidelityProtocol.ts
+++ b/apps/web/src/worker/fidelityProtocol.ts
@@ -1,0 +1,30 @@
+/** Messages accepted by the fidelity worker. */
+export interface FidelityInMessage {
+  type: 'score'
+  id: number
+  width: number
+  height: number
+  /** Rendered SVG over white, RGBA at result size, transferred. */
+  rendered: ArrayBuffer
+  /** Source downscaled over white, RGBA at result size, transferred. */
+  reference: ArrayBuffer
+}
+
+/** Messages emitted by the fidelity worker. */
+export type FidelityOutMessage =
+  | {
+      type: 'result'
+      id: number
+      score: number
+      width: number
+      height: number
+      /** ΔE heatmap, RGBA at result size, transferred. */
+      diff: ArrayBuffer
+    }
+  | { type: 'error'; id: number; message: string }
+
+/** Minimal worker-global surface — keeps this module free of lib.webworker. */
+export interface FidelityWorkerScope {
+  addEventListener(type: 'message', listener: (ev: { data: unknown }) => void): void
+  postMessage(message: unknown, transfer?: Transferable[]): void
+}

--- a/apps/web/src/worker/fidelityWorker.ts
+++ b/apps/web/src/worker/fidelityWorker.ts
@@ -1,0 +1,77 @@
+import { clamp, deltaEOk, rgbToOklab } from '@trazor/core'
+import type { FidelityInMessage, FidelityOutMessage, FidelityWorkerScope } from './fidelityProtocol'
+
+const SAMPLE_BUDGET = 200_000
+/** ΔE(Oklab) mapped to full heat. */
+const HEAT_FULL = 0.25
+
+export interface DifferenceScore {
+  /** 0..1 — perceptual similarity between the two rasters. */
+  score: number
+  /** Per-pixel ΔE heatmap, RGBA (transparent where faithful). */
+  diff: Uint8ClampedArray<ArrayBuffer>
+}
+
+/**
+ * Mean Oklab ΔE between two RGBA rasters of the same size (composited over
+ * white beforehand), plus the heatmap for the Difference view. `a` is the
+ * rendered result, `b` the reference source. Deterministic and DOM-free, so it
+ * runs in a worker; the mean is sampled over up to `SAMPLE_BUDGET` pixels.
+ */
+export function scoreDifference(
+  width: number,
+  height: number,
+  a: Uint8ClampedArray,
+  b: Uint8ClampedArray,
+): DifferenceScore {
+  const pixels = width * height
+  const stride = Math.max(1, Math.floor(pixels / SAMPLE_BUDGET))
+  const diffData = new Uint8ClampedArray(pixels * 4)
+
+  let sum = 0
+  let count = 0
+  for (let p = 0; p < pixels; p++) {
+    const i = p * 4
+    const [l1, a1, b1] = rgbToOklab(a[i] / 255, a[i + 1] / 255, a[i + 2] / 255)
+    const [l2, a2, b2] = rgbToOklab(b[i] / 255, b[i + 1] / 255, b[i + 2] / 255)
+    const dE = deltaEOk(l1, a1, b1, l2, a2, b2)
+    if (p % stride === 0) {
+      sum += dE
+      count++
+    }
+    // Heatmap: faithful → transparent, unfaithful → amber to hot red.
+    const t = clamp(dE / HEAT_FULL, 0, 1)
+    if (t > 0.02) {
+      diffData[i] = 255
+      diffData[i + 1] = 170 - t * 130
+      diffData[i + 2] = 40 + t * 50
+      diffData[i + 3] = Math.sqrt(t) * 235
+    }
+  }
+
+  const meanDeltaE = count > 0 ? sum / count : 0
+  return { score: clamp(1 - meanDeltaE * 4, 0, 1), diff: diffData }
+}
+
+/**
+ * Wire the fidelity ΔE pass to a worker scope. The rasterization (SVG → pixels)
+ * is DOM-bound and stays on the main thread; only this per-pixel pass runs here.
+ */
+export function installFidelityWorker(scope: FidelityWorkerScope): void {
+  const post = (msg: FidelityOutMessage, transfer?: Transferable[]): void =>
+    scope.postMessage(msg, transfer)
+
+  scope.addEventListener('message', (ev) => {
+    const msg = ev.data as FidelityInMessage
+    if (msg.type !== 'score') return
+    const { id, width, height, rendered, reference } = msg
+    try {
+      const a = new Uint8ClampedArray(rendered)
+      const b = new Uint8ClampedArray(reference)
+      const { score, diff } = scoreDifference(width, height, a, b)
+      post({ type: 'result', id, score, width, height, diff: diff.buffer }, [diff.buffer])
+    } catch (err) {
+      post({ type: 'error', id, message: err instanceof Error ? err.message : String(err) })
+    }
+  })
+}

--- a/apps/web/test/assistClient.test.ts
+++ b/apps/web/test/assistClient.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { analyzeImage } from '@trazor/assist'
+import type { RasterImage } from '@trazor/core'
+import { AssistClient } from '../src/lib/assistClient'
+import type {
+  AssistInMessage,
+  AssistOutMessage,
+  AssistWorkerScope,
+} from '../src/worker/assistProtocol'
+import { installAssistWorker } from '../src/worker/assistWorker'
+
+function checkerImage(): RasterImage {
+  const width = 8
+  const height = 8
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4
+      const on = (x + y) % 2 === 0
+      data[i] = on ? 220 : 30
+      data[i + 1] = on ? 40 : 120
+      data[i + 2] = on ? 60 : 200
+      data[i + 3] = 255
+    }
+  }
+  return { width, height, data }
+}
+
+/** A fake Worker that records postMessage and lets the test drive replies. */
+class FakeWorker {
+  posted: Array<{ msg: AssistInMessage; transfer?: Transferable[] }> = []
+  private messageListeners: Array<(ev: MessageEvent) => void> = []
+
+  addEventListener(type: string, fn: (ev: MessageEvent) => void): void {
+    if (type === 'message') this.messageListeners.push(fn)
+  }
+
+  postMessage(msg: AssistInMessage, transfer?: Transferable[]): void {
+    this.posted.push({ msg, transfer })
+  }
+
+  terminate(): void {}
+
+  reply(msg: AssistOutMessage): void {
+    for (const fn of this.messageListeners) fn({ data: msg } as MessageEvent)
+  }
+}
+
+describe('AssistClient', () => {
+  it('copies the caller image buffer instead of detaching it', () => {
+    const fake = new FakeWorker()
+    const client = new AssistClient(() => fake as unknown as Worker)
+    const image = checkerImage()
+    void client.suggestPalettes(image, analyzeImage(image))
+    // The caller's pixels stay intact — the worker received a copy, not the original.
+    expect(image.data.byteLength).toBe(image.width * image.height * 4)
+    const posted = fake.posted[0]
+    expect(posted.msg.type).toBe('suggestPalettes')
+    expect(posted.transfer?.[0]).toBe(posted.msg.buffer)
+    expect(posted.msg.buffer).not.toBe(image.data.buffer)
+  })
+
+  it('resolves with the worker reply matched by id', async () => {
+    const fake = new FakeWorker()
+    const client = new AssistClient(() => fake as unknown as Worker)
+    const image = checkerImage()
+    const promise = client.suggestPalettes(image, analyzeImage(image))
+    const { id } = fake.posted[0].msg
+    const suggestions = [
+      { id: 'balanced', label: 'Balanced', colors: ['#000000', '#ffffff'], description: '' },
+    ]
+    fake.reply({ type: 'palettes', id, suggestions })
+    await expect(promise).resolves.toEqual(suggestions)
+  })
+
+  it('rejects when the worker reports an error', async () => {
+    const fake = new FakeWorker()
+    const client = new AssistClient(() => fake as unknown as Worker)
+    const image = checkerImage()
+    const promise = client.suggestPalettes(image, analyzeImage(image))
+    const { id } = fake.posted[0].msg
+    fake.reply({ type: 'error', id, message: 'boom' })
+    await expect(promise).rejects.toThrow('boom')
+  })
+})
+
+describe('installAssistWorker', () => {
+  it('round-trips palette suggestion through a fake scope', () => {
+    let listener: ((ev: { data: unknown }) => void) | null = null
+    const outbox: AssistOutMessage[] = []
+    const scope: AssistWorkerScope = {
+      addEventListener: (_type, fn) => {
+        listener = fn
+      },
+      postMessage: (msg) => {
+        outbox.push(msg as AssistOutMessage)
+      },
+    }
+    installAssistWorker(scope)
+    expect(listener).not.toBeNull()
+
+    const image = checkerImage()
+    listener!({
+      data: {
+        type: 'suggestPalettes',
+        id: 3,
+        width: image.width,
+        height: image.height,
+        buffer: image.data.slice().buffer,
+        analysis: analyzeImage(image),
+      } satisfies AssistInMessage,
+    })
+
+    expect(outbox).toHaveLength(1)
+    const out = outbox[0]
+    expect(out.id).toBe(3)
+    expect(out.type).toBe('palettes')
+    const palettes = out as Extract<AssistOutMessage, { type: 'palettes' }>
+    expect(palettes.suggestions.length).toBeGreaterThan(0)
+    for (const suggestion of palettes.suggestions) {
+      expect(suggestion.colors.length).toBeGreaterThanOrEqual(2)
+    }
+  })
+})

--- a/apps/web/test/fidelityWorker.test.ts
+++ b/apps/web/test/fidelityWorker.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+import { FidelityClient } from '../src/lib/fidelityClient'
+import type {
+  FidelityInMessage,
+  FidelityOutMessage,
+  FidelityWorkerScope,
+} from '../src/worker/fidelityProtocol'
+import { installFidelityWorker, scoreDifference } from '../src/worker/fidelityWorker'
+
+function solid(
+  width: number,
+  height: number,
+  r: number,
+  g: number,
+  b: number,
+): Uint8ClampedArray<ArrayBuffer> {
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let p = 0; p < width * height; p++) {
+    data[p * 4] = r
+    data[p * 4 + 1] = g
+    data[p * 4 + 2] = b
+    data[p * 4 + 3] = 255
+  }
+  return data
+}
+
+describe('scoreDifference', () => {
+  it('scores identical rasters as a perfect, fully transparent match', () => {
+    const w = 6
+    const h = 6
+    const raster = solid(w, h, 40, 120, 200)
+    const { score, diff } = scoreDifference(w, h, raster, solid(w, h, 40, 120, 200))
+    expect(score).toBeCloseTo(1, 5)
+    // Faithful pixels stay transparent in the heatmap.
+    for (let p = 0; p < w * h; p++) expect(diff[p * 4 + 3]).toBe(0)
+  })
+
+  it('scores very different rasters below a match and marks the heatmap', () => {
+    const w = 6
+    const h = 6
+    const { score, diff } = scoreDifference(w, h, solid(w, h, 0, 0, 0), solid(w, h, 255, 255, 255))
+    expect(score).toBeLessThan(0.5)
+    let painted = 0
+    for (let p = 0; p < w * h; p++) if (diff[p * 4 + 3] > 0) painted++
+    expect(painted).toBeGreaterThan(0)
+  })
+})
+
+describe('installFidelityWorker', () => {
+  it('round-trips a score through a fake scope', () => {
+    let listener: ((ev: { data: unknown }) => void) | null = null
+    const outbox: FidelityOutMessage[] = []
+    const scope: FidelityWorkerScope = {
+      addEventListener: (_type, fn) => {
+        listener = fn
+      },
+      postMessage: (msg) => {
+        outbox.push(msg as FidelityOutMessage)
+      },
+    }
+    installFidelityWorker(scope)
+    expect(listener).not.toBeNull()
+
+    const w = 4
+    const h = 4
+    listener!({
+      data: {
+        type: 'score',
+        id: 5,
+        width: w,
+        height: h,
+        rendered: solid(w, h, 10, 20, 30).buffer,
+        reference: solid(w, h, 200, 180, 160).buffer,
+      } satisfies FidelityInMessage,
+    })
+
+    expect(outbox).toHaveLength(1)
+    const out = outbox[0]
+    expect(out.id).toBe(5)
+    expect(out.type).toBe('result')
+    const result = out as Extract<FidelityOutMessage, { type: 'result' }>
+    expect(result.score).toBeLessThan(1)
+    expect(result.diff.byteLength).toBe(w * h * 4)
+  })
+})
+
+/** A fake Worker that records postMessage and lets the test drive replies. */
+class FakeWorker {
+  posted: Array<{ msg: FidelityInMessage; transfer?: Transferable[] }> = []
+  private messageListeners: Array<(ev: MessageEvent) => void> = []
+
+  addEventListener(type: string, fn: (ev: MessageEvent) => void): void {
+    if (type === 'message') this.messageListeners.push(fn)
+  }
+
+  postMessage(msg: FidelityInMessage, transfer?: Transferable[]): void {
+    this.posted.push({ msg, transfer })
+  }
+
+  terminate(): void {}
+
+  reply(msg: FidelityOutMessage): void {
+    for (const fn of this.messageListeners) fn({ data: msg } as MessageEvent)
+  }
+}
+
+describe('FidelityClient', () => {
+  it('transfers both rasters and reconstructs the heatmap from the reply', async () => {
+    const fake = new FakeWorker()
+    const client = new FidelityClient(() => fake as unknown as Worker)
+    const w = 4
+    const h = 4
+    const rendered = solid(w, h, 10, 20, 30)
+    const reference = solid(w, h, 200, 180, 160)
+    const promise = client.score(w, h, rendered, reference)
+
+    const posted = fake.posted[0]
+    expect(posted.msg.type).toBe('score')
+    expect(posted.transfer).toEqual([posted.msg.rendered, posted.msg.reference])
+
+    const diff = new Uint8ClampedArray(w * h * 4)
+    diff[3] = 200
+    fake.reply({
+      type: 'result',
+      id: posted.msg.id,
+      score: 0.75,
+      width: w,
+      height: h,
+      diff: diff.buffer,
+    })
+
+    const out = await promise
+    expect(out.score).toBe(0.75)
+    expect(out.diff.width).toBe(w)
+    expect(out.diff.height).toBe(h)
+    expect(out.diff.data[3]).toBe(200)
+  })
+
+  it('rejects when the worker reports an error', async () => {
+    const fake = new FakeWorker()
+    const client = new FidelityClient(() => fake as unknown as Worker)
+    const promise = client.score(2, 2, solid(2, 2, 0, 0, 0), solid(2, 2, 0, 0, 0))
+    fake.reply({ type: 'error', id: fake.posted[0].msg.id, message: 'boom' })
+    await expect(promise).rejects.toThrow('boom')
+  })
+})

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -284,8 +284,9 @@ pool (navigator.hardwareConcurrency-capped) on the layer/chain granularity would
   insertion into sorted position (toggles per row are tiny) avoids the allocation churn on speckly masks.
 - `analyzeSvg` regex-parses the multi-MB string the serializer just built, to recover counts the shape model
   already knows. Compute stats during serialization; keep `analyzeSvg` for foreign SVGs.
-- `fidelity.ts` runs 2× full-image `rgbToOklab` on the main thread (chunked); move to the worker and reuse
-  the engine's Oklab buffer for the reference side.
+- `fidelity.ts` rasterizes on the main thread (DOM-bound) and runs the 2× full-image `rgbToOklab` ΔE pass in
+  `worker/fidelity.worker.ts`. Remaining: reuse the engine's Oklab buffer for the reference side instead of
+  reconverting it.
 - The `fit` stage exists in `STAGE_BUDGET` (0.06) but every pipeline calls `run.stage('fit'); run.progress(1)`
   — it never contains work, so the progress bar jumps and the stage timing is always 0. Fold it into `trace`
   or move open-path fitting under it.


### PR DESCRIPTION
Palette suggestion (`suggestPalettes`) runs several full-image k-means
passes; it was executed on the main thread — merely deferred to an idle
callback, which delays the work but still blocks the UI thread for seconds
on a large photo, freezing the studio right after an image loads. Only the
Selinger-class trace ran off-thread.

Move palette suggestion into a dedicated worker, mirroring the engine's
protocol/worker/client/entry split:

- worker/assistProtocol.ts — message types + minimal worker scope
- worker/assistWorker.ts    — installAssistWorker(scope) runs suggestPalettes
- worker/assist.worker.ts   — thin worker entry
- lib/assistClient.ts       — main-thread handle; copies the pixel buffer
  before transferring so the caller's working image never detaches

The store keeps one AssistClient and drops results for a superseded image.
The cheap, sampled `analyzeImage` stays on the main thread because
auto-recommend needs it synchronously before the debounced trace fires.

Add an apps/web test covering the buffer-copy invariant, the id-matched
reply/error round-trip, and installAssistWorker through a fake scope.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QWCJn2ALLNa6aYbkvDbgwW