### PR TITLE
feat(assist): keep clean anti-aliased artwork a faithful color trace

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,7 +43,7 @@ The engine runs one of four modes; every mode ends at the SVG serializer. Stage 
 ```
 decode (app)
   → resize → denoise → flatten alpha            [raster]         preprocess
-  → color/grayscale:  Oklab k-means++ quantize  [raster]         palette
+  → color/grayscale:  Oklab k-means++ quantize, or region growing [raster]     palette
                       region cleanup             [raster]         segment
                       stacked:  per-layer Potrace chain           trace
                       cutout:   shared boundary graph  [trace]
@@ -76,7 +76,8 @@ decode (app)
 - **`raster`** — everything that takes pixels and returns pixels, masks or labels: area-average resize, gaussian/median/
   bilateral filters, alpha flattening, deterministic k-means++ quantization (with exact- and fixed-palette paths),
   Otsu + integral-image adaptive thresholds, connected-component cleanup, morphology, Zhang-Suen thinning, chamfer
-  distance / stroke-width estimation.
+  distance / stroke-width estimation, and marker-controlled **region-growing** segmentation (an alternative to global
+  quantization for flat art — soft edges split between neighbors instead of inventing a rim color).
 - **`trace`** — the tracer. Crack-boundary decomposition, the Potrace curve chain, the seam-free boundary graph, and
   centerline extraction. Its own map: [`packages/trace/ARCHITECTURE.md`](packages/trace/ARCHITECTURE.md).
 - **`svg`** — `SvgDocument`/`SvgShape` → compact, valid SVG (px/mm units, evenodd holes, gap-fill strokes, metadata),

--- a/apps/web/src/components/SettingsPanel.vue
+++ b/apps/web/src/components/SettingsPanel.vue
@@ -296,6 +296,17 @@ function isActiveSuggestion(sug: PaletteSuggestion): boolean {
         </div>
 
         <template v-if="fixedPalette === null">
+          <SelectRow
+            :label="t('settings.segmentation.label')"
+            :model-value="s.segmentation"
+            :options="[
+              { value: 'quantize', label: t('settings.segmentation.quantize') },
+              { value: 'regions', label: t('settings.segmentation.regions') },
+            ]"
+            :default-value="D.segmentation"
+            :hint="t('settings.segmentation.hint')"
+            @update:model-value="set('segmentation', $event)"
+          />
           <SliderRow
             :label="t('settings.colors.label')"
             :model-value="s.paletteSize"

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -520,7 +520,10 @@ export const en = {
     pickCompressedFlat: 'Compression noise over a few flat colors — cleaning up as flat art.',
     pickPhoto: 'Photographic content — posterized profile.',
     pickLogo: 'Flat shapes with few colors — logo profile with seam-free cutout layers.',
+    pickFlatArt: 'Clean flat art with anti-aliased edges — faithful color illustration.',
     pickIllustration: 'Mixed flat artwork — illustration profile.',
+    flatArtCleanup:
+      'Anti-aliased edges — merging rim specks below {area} px² and dissolving hairline seams.',
   },
 
   profiles: {

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -121,6 +121,12 @@ export const en = {
       label: 'Alpha cutoff',
       hint: 'Alpha below this counts as empty',
     },
+    segmentation: {
+      label: 'Segmentation',
+      hint: 'How pixels become flat regions. Region growing keeps anti-aliased edges of flat art clean; global palette suits photos and gradients',
+      quantize: 'Global palette',
+      regions: 'Region growing',
+    },
     colors: {
       label: 'Colors',
       hint: 'Number of output colors',
@@ -522,8 +528,8 @@ export const en = {
     pickLogo: 'Flat shapes with few colors — logo profile with seam-free cutout layers.',
     pickFlatArt: 'Clean flat art with anti-aliased edges — faithful color illustration.',
     pickIllustration: 'Mixed flat artwork — illustration profile.',
-    flatArtCleanup:
-      'Anti-aliased edges — merging rim specks below {area} px² and dissolving hairline seams.',
+    flatArtRegions:
+      'Crisp flat art — growing regions from the flat interiors (no global palette) so anti-aliased edges stay clean.',
   },
 
   profiles: {

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -540,7 +540,10 @@ export const fr: MessageSchema = {
     pickPhoto: 'Contenu photographique — profil postérisé.',
     pickLogo:
       'Formes plates avec peu de couleurs — profil logo avec calques en découpe sans jointure.',
+    pickFlatArt: 'Dessin plat net aux bords anticrénelés — illustration couleur fidèle.',
     pickIllustration: 'Dessin plat mixte — profil illustration.',
+    flatArtCleanup:
+      'Bords anticrénelés — fusion des points de bord sous {area} px² et dissolution des jointures fines.',
   },
 
   profiles: {

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -122,6 +122,12 @@ export const fr: MessageSchema = {
       label: 'Seuil alpha',
       hint: 'Un alpha inférieur est considéré comme vide',
     },
+    segmentation: {
+      label: 'Segmentation',
+      hint: 'Comment les pixels deviennent des régions plates. La croissance de régions garde nets les bords anticrénelés des dessins plats ; la palette globale convient aux photos et dégradés',
+      quantize: 'Palette globale',
+      regions: 'Croissance de régions',
+    },
     colors: {
       label: 'Couleurs',
       hint: 'Nombre de couleurs en sortie',
@@ -542,8 +548,8 @@ export const fr: MessageSchema = {
       'Formes plates avec peu de couleurs — profil logo avec calques en découpe sans jointure.',
     pickFlatArt: 'Dessin plat net aux bords anticrénelés — illustration couleur fidèle.',
     pickIllustration: 'Dessin plat mixte — profil illustration.',
-    flatArtCleanup:
-      'Bords anticrénelés — fusion des points de bord sous {area} px² et dissolution des jointures fines.',
+    flatArtRegions:
+      'Dessin plat net — croissance des régions depuis les intérieurs plats (sans palette globale) pour garder les bords anticrénelés propres.',
   },
 
   profiles: {

--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -37,6 +37,16 @@ export interface ReleaseNote {
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
     date: '2026-08-24',
+    iteration: 4,
+    kind: 'feature',
+    title: 'Cleaner edges for flat art and line art',
+    items: [
+      'A new region-growing segmentation traces cartoons, logos and clip art far more faithfully. Instead of matching every pixel to one global palette — which turned the soft edge between two colors into a hairline rim of a third color — it grows each color region outward from its flat interior, so an anti-aliased edge is split cleanly between its two real neighbors. No more rim halos or speckled outlines, and the linework stays smooth.',
+      'Auto-detect switches to it automatically for crisp flat art; you can also pick it under Segmentation → Region growing, or keep Global palette for photos and gradients.',
+    ],
+  },
+  {
+    date: '2026-08-24',
     iteration: 3,
     kind: 'improvement',
     title: 'Sharper auto-detect for clean artwork',

--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -37,6 +37,17 @@ export interface ReleaseNote {
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
     date: '2026-08-24',
+    iteration: 3,
+    kind: 'improvement',
+    title: 'Sharper auto-detect for clean artwork',
+    items: [
+      'Crisp cartoons, logos and clip art are no longer mistaken for photographs. The soft anti-aliased edges of clean art used to read as photographic texture, which picked the wrong profile — posterizing, over-smoothing, or even dropping all color and tracing in grayscale. Auto-detect now recognizes the large flat areas that only clean art has and keeps it as a faithful color illustration.',
+      'A vivid subject on a big black or white background stays in color. The background no longer dilutes the color measurement enough to flip the image to grayscale.',
+      'Far fewer tiny speck shapes along edges. Anti-aliased borders used to scatter thousands of hairline slivers of an in-between color; auto-detect now merges those specks and dissolves the seams, so the trace is the real shapes — cleaner and much smaller — without blurring the linework.',
+    ],
+  },
+  {
+    date: '2026-08-24',
     iteration: 2,
     kind: 'improvement',
     title: 'Cleaner layered vinyl',

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -146,6 +146,40 @@ export function quantize(image: RasterImage, opts: QuantizeOptions): QuantizeRes
 - Palette ordered by pixel count descending. Hex via core `rgbToHex`.
 
 ```ts
+// segment.ts — region-growing alternative to global quantization (flat art)
+export interface SegmentOptions {
+  flatThreshold?: number // Oklab gradient below which a pixel is a flat-region interior (marker); default 0.02
+  mergeThreshold?: number // fold regions whose mean Oklab ΔE is under this; default 0.1
+  minRegionArea?: number // regions below this (px) fold into their most similar neighbor; default 16
+  maxRegions?: number // soft cap: fold the closest pair (within 2·mergeThreshold) until met; 0 = none
+  mask?: BinaryMask | null // only in-mask pixels segmented; others get -1
+}
+export interface SegmentResult {
+  labels: LabelMap // compact 0..count-1; -1 masked-out (mirrors QuantizeResult)
+  paletteHex: string[]
+  paletteRgb: Uint8Array // count*3
+  counts: Uint32Array
+}
+export function segmentRegions(image: RasterImage, opts?: SegmentOptions): SegmentResult
+```
+
+`segmentRegions` requirements (marker-controlled watershed; Meyer 1991):
+
+- Oklab gradient = max ΔE to any 4-neighbor. Markers are 4-connected components
+  of in-mask pixels with gradient < `flatThreshold`, each seeded with its mean.
+- A priority flood (binary min-heap keyed by Oklab distance to the claiming
+  marker's mean; ties by pixel index) grows markers over the remaining
+  edge/ramp pixels — an anti-aliased ramp splits between its two neighbors, so
+  no third color is ever created on a boundary.
+- A region-adjacency-graph merge folds adjacent pairs under `mergeThreshold` and
+  regions under `minRegionArea` (closest first), then consolidates non-adjacent
+  near-duplicates globally; `maxRegions` folds the closest pair only within a
+  perceptual ceiling, so a budget never collapses genuinely different hues.
+- Fully deterministic (fixed scan/neighbor order, index tie-break, sorted merge
+  candidates). Result mirrors `QuantizeResult` so the engine consumes it
+  identically. Selected by `VectorizeSettings.segmentation === 'regions'`.
+
+```ts
 // threshold.ts
 export function otsuThreshold(gray: GrayImage, mask?: BinaryMask | null): number // in [0,1], 256-bin
 export function binarize(

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -67,6 +67,15 @@ where it is used. Keep this file up to date when adding or changing algorithms.
 - **Nobuyuki Otsu, “A Threshold Selection Method from Gray-Level Histograms”,
   _IEEE Trans. SMC_ 9(1), 1979.** Automatic binarization threshold
   (`packages/raster/src/threshold.ts`).
+- **Fernand Meyer, “Color image segmentation”, _ICIP_ 1992**, and **Luc Vincent
+  & Pierre Soille, “Watersheds in digital spaces: an efficient algorithm based on
+  immersion simulations”, _IEEE Trans. PAMI_ 13(6), 1991.** Marker-controlled
+  watershed by priority flooding: flat interiors seed the regions, a
+  color-distance priority queue grows them over anti-aliased edges. The
+  region-growing color segmentation front-end for flat art
+  (`packages/raster/src/segment.ts`), which avoids the third-color rim a global
+  palette invents on soft edges. Followed by a region-adjacency-graph
+  agglomerative merge (near-duplicate and small-region folding).
 - **Frank Crow, “Summed-area tables for texture mapping”, _SIGGRAPH_ 1984.**
   Integral images backing the adaptive (local-mean) threshold
   (`packages/raster/src/threshold.ts`).

--- a/packages/assist/src/analyze.ts
+++ b/packages/assist/src/analyze.ts
@@ -14,6 +14,14 @@ export interface ImageAnalysis {
   edgeDensity: number
   /** Fraction of pixels with a small-but-nonzero gradient — the texture photos have and flat art lacks. */
   microGradientDensity: number
+  /**
+   * Fraction of pixels identical to their right and down neighbors — the large
+   * uniform interiors flat art has (even anti-aliased, whose soft ramps sit only
+   * along edges) and photographs/compressed graphics lack (sensor/block noise
+   * leaves almost no exactly-flat pixel). Separates clean vector art from
+   * photographic texture regardless of how many colors anti-aliasing invents.
+   */
+  flatDensity: number
   /** Fraction of pixels covered by the two most common colors. */
   twoToneCoverage: number
   /** 0..1 likelihood the image is photographic. */
@@ -26,7 +34,18 @@ export interface ImageAnalysis {
   contrast: number
   /** Mean Oklab chroma (√(a²+b²)). Near 0 for grayscale, higher for saturated art. */
   colorfulness: number
+  /**
+   * Fraction of pixels whose Oklab chroma exceeds `COLORED_CHROMA` — a
+   * background-robust measure of how colored the content is. Unlike mean
+   * `colorfulness`, a large neutral (black/white) field cannot dilute it: a
+   * vivid subject on a black backdrop still reports a meaningful fraction, so it
+   * is not mistaken for grayscale.
+   */
+  coloredFraction: number
 }
+
+/** Oklab chroma above which a pixel counts as meaningfully colored (not neutral). */
+const COLORED_CHROMA = 0.05
 
 /**
  * One statistical pass over the image, feeding the settings recommender.
@@ -45,6 +64,8 @@ export function analyzeImage(image: RasterImage): ImageAnalysis {
   let sampleCount = 0
   let edgeCount = 0
   let microCount = 0
+  let flatCount = 0
+  let coloredCount = 0
   let sumL = 0
   let sumL2 = 0
   let sumChroma = 0
@@ -68,7 +89,9 @@ export function analyzeImage(image: RasterImage): ImageAnalysis {
       const [L, oa, ob] = rgbToOklab(r / 255, g / 255, b / 255)
       sumL += L
       sumL2 += L * L
-      sumChroma += Math.hypot(oa, ob)
+      const chroma = Math.hypot(oa, ob)
+      sumChroma += chroma
+      if (chroma > COLORED_CHROMA) coloredCount++
 
       if (x + step < width && y + step < height) {
         const iR = (row + x + step) * 4
@@ -78,6 +101,7 @@ export function analyzeImage(image: RasterImage): ImageAnalysis {
         const grad = Math.max(gx, gy)
         if (grad > 72) edgeCount++
         else if (grad > 3) microCount++
+        else if (grad === 0) flatCount++
       }
     }
   }
@@ -108,6 +132,8 @@ export function analyzeImage(image: RasterImage): ImageAnalysis {
 
   const edgeDensity = sampleCount === 0 ? 0 : edgeCount / sampleCount
   const microGradientDensity = sampleCount === 0 ? 0 : microCount / sampleCount
+  const flatDensity = sampleCount === 0 ? 0 : flatCount / sampleCount
+  const coloredFraction = sampleCount === 0 ? 0 : coloredCount / sampleCount
 
   const colorRichness = clamp(Math.log2(Math.max(1, colorSet.size)) / 15, 0, 1)
   const photoScore = clamp(
@@ -131,6 +157,7 @@ export function analyzeImage(image: RasterImage): ImageAnalysis {
     entropyBits,
     edgeDensity,
     microGradientDensity,
+    flatDensity,
     twoToneCoverage,
     photoScore,
     pixelArtScore,
@@ -138,5 +165,6 @@ export function analyzeImage(image: RasterImage): ImageAnalysis {
     meanLightness,
     contrast,
     colorfulness,
+    coloredFraction,
   }
 }

--- a/packages/assist/src/recommend.ts
+++ b/packages/assist/src/recommend.ts
@@ -34,13 +34,55 @@ class Rationale {
 const ACHROMATIC_CHROMA = 0.03
 
 /**
+ * A pixel gradient of exactly 0 covering at least this fraction of the image
+ * marks clean flat art (illustration, logo, cartoon). Anti-aliasing invents
+ * thousands of rim colors and a high `photoScore`, but its soft ramps sit only
+ * along edges — the large interiors stay perfectly flat. Photographs and
+ * compressed/rescaled graphics carry noise everywhere and never reach this.
+ */
+const FLAT_ART_MIN_DENSITY = 0.15
+
+/** With at least this fraction of genuinely colored pixels, an image is not grayscale. */
+const COLORED_FRACTION_MIN = 0.05
+
+/** Sub-this-size rim specks are merged away when cleaning anti-aliased flat art. */
+const FLAT_ART_MIN_REGION = 16
+
+/**
+ * Clean flat art (vector illustration, logo, cartoon) rather than a photograph
+ * or a degraded graphic. Anti-aliased edges make such art score as photographic
+ * (many colors, dense micro-gradients), so `photoScore` alone misroutes it; the
+ * flat interiors it keeps — which photos and compression noise destroy — are the
+ * reliable tell. Kept in color and traced faithfully, not denoised or posterized.
+ */
+function isCleanFlatArt(a: ImageAnalysis): boolean {
+  return a.flatDensity >= FLAT_ART_MIN_DENSITY
+}
+
+/**
+ * Effectively grayscale: not only is mean chroma low, but almost no pixel is
+ * genuinely colored. The `coloredFraction` guard keeps a vivid subject on a
+ * large neutral (black/white) backdrop — whose mean chroma the backdrop drags
+ * below `ACHROMATIC_CHROMA` — from being flattened to gray.
+ */
+function isAchromatic(a: ImageAnalysis): boolean {
+  return a.colorfulness < ACHROMATIC_CHROMA && a.coloredFraction < COLORED_FRACTION_MIN
+}
+
+/**
  * Photographic-looking texture (noise, blocking, ringing) sitting on top of a
  * few dominant flat colors — a compressed or rescaled flat graphic (a JPEG
  * logo, a screenshot) rather than a true photograph, whose colors spread out
- * so no two dominate. These want strong cleanup, not photo posterization.
+ * so no two dominate. These want strong cleanup, not photo posterization. Clean
+ * flat art is excluded: its crisp anti-aliased edges are not compression damage.
  */
 function isCompressedFlat(a: ImageAnalysis): boolean {
-  return a.photoScore > 0.6 && a.twoToneCoverage > 0.55 && a.colorfulness >= ACHROMATIC_CHROMA
+  return (
+    a.photoScore > 0.6 &&
+    a.twoToneCoverage > 0.55 &&
+    a.colorfulness >= ACHROMATIC_CHROMA &&
+    !isCleanFlatArt(a)
+  )
 }
 
 /**
@@ -70,12 +112,15 @@ export function recommendSettings(
     return { profileId, patch, rationale: r.text, rationaleKeys: r.keys }
   }
 
-  // A near-grayscale photo traces as tonal gray layers, not a color palette.
-  if (profileId === 'photo' && a.colorfulness < ACHROMATIC_CHROMA) {
+  // A near-grayscale photo traces as tonal gray layers, not a color palette. A
+  // colored subject on a neutral backdrop (low mean chroma but real colored
+  // pixels) stays in color — `isAchromatic` accounts for the backdrop.
+  if (profileId === 'photo' && isAchromatic(a)) {
     patch.mode = 'grayscale'
     r.add('grayscale', 'Nearly grayscale — tracing as tonal grayscale layers.')
   }
 
+  const flatArt = isCleanFlatArt(a)
   // Respect an explicit photo goal; otherwise treat compressed-flat art specially.
   const compressedFlat = profileId !== 'photo' && isCompressedFlat(a)
 
@@ -103,9 +148,24 @@ export function recommendSettings(
         { count: a.distinctColors, size: chosen },
       )
     }
-    if (a.photoScore > 0.55 && patch.denoise === undefined && !compressedFlat) {
+    // Clean flat art is exempt from photo denoise (its edges are crisp, not
+    // noisy) — bilateral blur would only soften the linework.
+    if (a.photoScore > 0.55 && patch.denoise === undefined && !compressedFlat && !flatArt) {
       patch.denoise = 'bilateral'
       r.add('photoTexture', 'Photographic texture detected — bilateral denoise keeps edges clean.')
+    }
+    // Anti-aliased flat art: the soft rim between two flat colors quantizes into
+    // hairline slivers of a third color, scattering thousands of speck shapes.
+    // Merge sub-`FLAT_ART_MIN_REGION` regions and dissolve 1px seam bands so the
+    // trace is the clean shapes, not the anti-aliasing — no photo-style blur.
+    if (flatArt && rich) {
+      patch.minRegionArea = Math.max(patch.minRegionArea ?? 0, FLAT_ART_MIN_REGION)
+      if ((patch.dissolveBands ?? 0) < 2) patch.dissolveBands = 2
+      r.add(
+        'flatArtCleanup',
+        `Anti-aliased edges — merging rim specks below ${FLAT_ART_MIN_REGION} px² and dissolving hairline seams.`,
+        { area: FLAT_ART_MIN_REGION },
+      )
     }
   }
 
@@ -144,7 +204,7 @@ function pickProfile(a: ImageAnalysis, r: Rationale): ProfileId {
   }
   // Two-tone only routes to B&W when it is genuinely achromatic; a saturated
   // two-color mark (navy on white, say) keeps its color through a flat profile.
-  if (a.twoToneCoverage > 0.92 && a.contrast > 0.25 && a.colorfulness < ACHROMATIC_CHROMA) {
+  if (a.twoToneCoverage > 0.92 && a.contrast > 0.25 && isAchromatic(a)) {
     r.add(
       'pickBwSketch',
       'Essentially two-tone with high contrast — black & white tracing fits best.',
@@ -155,19 +215,17 @@ function pickProfile(a: ImageAnalysis, r: Rationale): ProfileId {
   // crisp strokes and few distinct tones — unlike a mid-toned grayscale photo,
   // which fills the tonal range with smooth micro-gradients. Threshold B&W keeps
   // the lines crisp and compact instead of stacking tonal gray layers.
-  if (
-    a.colorfulness < ACHROMATIC_CHROMA &&
-    a.meanLightness > 0.7 &&
-    a.edgeDensity > 0.1 &&
-    a.distinctColors <= 4096
-  ) {
+  if (isAchromatic(a) && a.meanLightness > 0.7 && a.edgeDensity > 0.1 && a.distinctColors <= 4096) {
     r.add(
       'pickInkLineart',
       'Achromatic line art with crisp edges and few tones — black & white tracing.',
     )
     return 'bw-sketch'
   }
-  if (a.photoScore > 0.6) {
+  // Photographic routing is vetoed for clean flat art: anti-aliasing makes crisp
+  // vector art score as photographic, but its flat interiors give it away, so it
+  // stays a faithful color trace instead of being posterized or over-cleaned.
+  if (!isCleanFlatArt(a) && a.photoScore > 0.6) {
     if (isCompressedFlat(a)) {
       r.add(
         'pickCompressedFlat',
@@ -181,6 +239,10 @@ function pickProfile(a: ImageAnalysis, r: Rationale): ProfileId {
   if (a.distinctColors <= 24 && a.microGradientDensity < 0.08) {
     r.add('pickLogo', 'Flat shapes with few colors — logo profile with seam-free cutout layers.')
     return 'logo'
+  }
+  if (isCleanFlatArt(a)) {
+    r.add('pickFlatArt', 'Clean flat art with anti-aliased edges — faithful color illustration.')
+    return 'illustration'
   }
   r.add('pickIllustration', 'Mixed flat artwork — illustration profile.')
   return 'illustration'

--- a/packages/assist/src/recommend.ts
+++ b/packages/assist/src/recommend.ts
@@ -154,17 +154,18 @@ export function recommendSettings(
       patch.denoise = 'bilateral'
       r.add('photoTexture', 'Photographic texture detected — bilateral denoise keeps edges clean.')
     }
-    // Anti-aliased flat art: the soft rim between two flat colors quantizes into
-    // hairline slivers of a third color, scattering thousands of speck shapes.
-    // Merge sub-`FLAT_ART_MIN_REGION` regions and dissolve 1px seam bands so the
-    // trace is the clean shapes, not the anti-aliasing — no photo-style blur.
-    if (flatArt && rich) {
+    // Anti-aliased flat art: global k-means maps the soft rim between two flat
+    // colors to a nearest *third* palette color, drawing hairline slivers along
+    // every edge. Region growing instead grows each region from its flat
+    // interior, so a soft edge is split between its two real neighbors and no
+    // third rim color can form — the faithful, seam-free choice. Small regions
+    // below `FLAT_ART_MIN_REGION` still fold into their surroundings.
+    if (flatArt) {
+      patch.segmentation = 'regions'
       patch.minRegionArea = Math.max(patch.minRegionArea ?? 0, FLAT_ART_MIN_REGION)
-      if ((patch.dissolveBands ?? 0) < 2) patch.dissolveBands = 2
       r.add(
-        'flatArtCleanup',
-        `Anti-aliased edges — merging rim specks below ${FLAT_ART_MIN_REGION} px² and dissolving hairline seams.`,
-        { area: FLAT_ART_MIN_REGION },
+        'flatArtRegions',
+        'Crisp flat art — growing regions from the flat interiors (no global palette) so anti-aliased edges stay clean.',
       )
     }
   }

--- a/packages/assist/test/assist.test.ts
+++ b/packages/assist/test/assist.test.ts
@@ -287,9 +287,10 @@ describe('recommendSettings', () => {
     expect(rec.profileId).toBe('illustration')
     expect(rec.patch.mode).toBe('color')
     expect(rec.patch.denoise).not.toBe('bilateral') // crisp edges, not photo blur
-    // Anti-sliver cleanup so the anti-aliasing does not scatter speck shapes.
+    // Region growing (not global quantization) so the anti-aliased edges never
+    // invent a third rim color, with small rim regions folded away.
+    expect(rec.patch.segmentation).toBe('regions')
     expect(rec.patch.minRegionArea ?? 0).toBeGreaterThanOrEqual(16)
-    expect(rec.patch.dissolveBands ?? 0).toBeGreaterThanOrEqual(2)
   })
 
   it('keeps a colored subject on a black backdrop in color, not grayscale', () => {

--- a/packages/assist/test/assist.test.ts
+++ b/packages/assist/test/assist.test.ts
@@ -107,6 +107,88 @@ function compressedFlat() {
   return img
 }
 
+/** Soft radial coverage of a disc at a pixel center → an anti-aliased rim. */
+function discCoverage(x: number, y: number, cx: number, cy: number, rad: number, ramp: number) {
+  const d = Math.hypot(x + 0.5 - cx, y + 0.5 - cy)
+  return Math.max(0, Math.min(1, (rad + ramp / 2 - d) / ramp))
+}
+function mixByte(a: number, b: number, t: number) {
+  return Math.round(a * (1 - t) + b * t)
+}
+
+/** Many anti-aliased colored discs on white. Crisp flat art, but its soft rims
+ *  invent thousands of colors and dense micro-gradients, so it scores as
+ *  photographic — while the large disc/background interiors stay perfectly flat.
+ *  This is the web-clip-art case that the photoScore heuristic alone misroutes. */
+function antialiasedField() {
+  const w = 320
+  const h = 320
+  const img = createRaster(w, h)
+  fillRaster(img, 255, 255, 255)
+  const cols = [
+    [220, 40, 60],
+    [30, 70, 200],
+    [250, 210, 20],
+    [40, 160, 90],
+    [180, 60, 190],
+  ]
+  const rnd = mulberry32(12345)
+  const discs: number[][] = []
+  for (let i = 0; i < 280; i++) {
+    discs.push([
+      12 + rnd() * (w - 24),
+      12 + rnd() * (h - 24),
+      6 + rnd() * 9,
+      (rnd() * cols.length) | 0,
+    ])
+  }
+  const ramp = 3.5
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      let r = 255
+      let g = 255
+      let b = 255
+      for (const [cx, cy, rad, ci] of discs) {
+        if (Math.abs(x - cx) > rad + ramp || Math.abs(y - cy) > rad + ramp) continue
+        const cov = discCoverage(x, y, cx, cy, rad, ramp)
+        if (cov > 0) {
+          const c = cols[ci]
+          r = mixByte(r, c[0], cov)
+          g = mixByte(g, c[1], cov)
+          b = mixByte(b, c[2], cov)
+        }
+      }
+      setPixel(img, x, y, r, g, b)
+    }
+  }
+  return img
+}
+
+/** A vivid disc on a large black field — the mean chroma is dragged below the
+ *  achromatic line by the black, but the colored pixels are unmistakable, so it
+ *  must not be flattened to grayscale. */
+function coloredOnBlack() {
+  const img = createRaster(200, 200)
+  fillRaster(img, 0, 0, 0)
+  for (let y = 0; y < 200; y++) {
+    for (let x = 0; x < 200; x++) {
+      let r = 0
+      let g = 0
+      let b = 0
+      const cr = discCoverage(x, y, 100, 100, 42, 2)
+      r = mixByte(r, 220, cr)
+      g = mixByte(g, 40, cr)
+      b = mixByte(b, 60, cr)
+      const cb = discCoverage(x, y, 100, 100, 22, 2)
+      r = mixByte(r, 30, cb)
+      g = mixByte(g, 70, cb)
+      b = mixByte(b, 200, cb)
+      if (r || g || b) setPixel(img, x, y, r, g, b)
+    }
+  }
+  return img
+}
+
 describe('analyzeImage', () => {
   it('measures a flat logo as non-photographic with few colors', () => {
     const a = analyzeImage(flatLogo())
@@ -118,6 +200,18 @@ describe('analyzeImage', () => {
   it('measures a grayscale image as achromatic and a colored one as chromatic', () => {
     expect(analyzeImage(grayPhoto()).colorfulness).toBeLessThan(0.03)
     expect(analyzeImage(navyOnWhite()).colorfulness).toBeGreaterThan(0.03)
+  })
+
+  it('measures large flat interiors that anti-aliasing does not erase', () => {
+    // Anti-aliased flat art keeps big exactly-flat fields; photo noise leaves none.
+    expect(analyzeImage(antialiasedField()).flatDensity).toBeGreaterThan(0.3)
+    expect(analyzeImage(noisyPhoto()).flatDensity).toBeLessThan(0.05)
+  })
+
+  it('measures a vivid subject on black as colored despite low mean chroma', () => {
+    const a = analyzeImage(coloredOnBlack())
+    expect(a.colorfulness).toBeLessThan(0.03) // mean chroma dragged down by the black field
+    expect(a.coloredFraction).toBeGreaterThan(0.05) // yet a clear fraction is genuinely colored
   })
 
   it('measures noise/gradients as photographic', () => {
@@ -181,6 +275,26 @@ describe('recommendSettings', () => {
     const rec = recommendSettings(analyzeImage(navyOnWhite()))
     expect(rec.profileId).not.toBe('bw-sketch')
     expect(['logo', 'illustration']).toContain(rec.profileId)
+  })
+
+  it('keeps anti-aliased flat art as a color illustration, not a photo', () => {
+    const a = analyzeImage(antialiasedField())
+    // The adversarial condition: it scores as photographic, yet its flat
+    // interiors mark it as clean art — the flat-art veto must win.
+    expect(a.photoScore).toBeGreaterThan(0.6)
+    expect(a.flatDensity).toBeGreaterThan(0.15)
+    const rec = recommendSettings(a)
+    expect(rec.profileId).toBe('illustration')
+    expect(rec.patch.mode).toBe('color')
+    expect(rec.patch.denoise).not.toBe('bilateral') // crisp edges, not photo blur
+    // Anti-sliver cleanup so the anti-aliasing does not scatter speck shapes.
+    expect(rec.patch.minRegionArea ?? 0).toBeGreaterThanOrEqual(16)
+    expect(rec.patch.dissolveBands ?? 0).toBeGreaterThanOrEqual(2)
+  })
+
+  it('keeps a colored subject on a black backdrop in color, not grayscale', () => {
+    const rec = recommendSettings(analyzeImage(coloredOnBlack()))
+    expect(rec.patch.mode).not.toBe('grayscale')
   })
 
   it('cleans up a degraded flat graphic instead of posterizing it as a photo', () => {

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -36,6 +36,17 @@ export type BackgroundMode = 'auto' | 'transparent' | 'custom'
 
 export type DenoiseMode = 'none' | 'median' | 'bilateral'
 
+/**
+ * How color/grayscale modes turn pixels into flat regions:
+ * - `quantize`: global k-means palette, then spatial cleanup. General-purpose;
+ *   best when the image has real tonal variation (photos, gradients).
+ * - `regions`: marker-controlled region growing (watershed). No global palette,
+ *   so an anti-aliased edge is split between its two neighbors instead of
+ *   inventing a third rim color — the faithful choice for flat art (logos,
+ *   cartoons, line art) with crisp anti-aliased boundaries.
+ */
+export type SegmentationMode = 'quantize' | 'regions'
+
 export interface VectorizeSettings {
   mode: VectorizeMode
 
@@ -52,7 +63,13 @@ export interface VectorizeSettings {
   alphaThreshold: number
 
   // ---- Palette (color / grayscale modes) ----
-  /** Number of output colors (2-64). */
+  /**
+   * How pixels become flat regions in color/grayscale modes. `quantize` is the
+   * global-palette default; `regions` grows regions from flat interiors so
+   * anti-aliased edges never invent a rim color (best for flat art / line art).
+   */
+  segmentation: SegmentationMode
+  /** Number of output colors (2-64). With `regions`, an upper budget rather than an exact count. */
   paletteSize: number
   /** Let the engine lower `paletteSize` when the image needs fewer colors. */
   autoPaletteSize: boolean
@@ -165,6 +182,7 @@ export const DEFAULT_SETTINGS: Readonly<VectorizeSettings> = Object.freeze({
   backgroundColor: '#ffffff',
   alphaThreshold: 8,
 
+  segmentation: 'quantize',
   paletteSize: 16,
   autoPaletteSize: false,
   colorSpace: 'oklab',
@@ -235,6 +253,7 @@ export function normalizeSettings(
     }
     s.palette = valid.length > 0 ? valid : null
   }
+  s.segmentation = s.segmentation === 'regions' ? 'regions' : 'quantize'
   s.minRegionArea = clampInt(s.minRegionArea, 0, 4096)
   s.dissolveBands = clampInt(s.dissolveBands, 0, 4)
   s.colorCoherence = clamp(s.colorCoherence, 0, 1)

--- a/packages/engine/src/native.ts
+++ b/packages/engine/src/native.ts
@@ -41,6 +41,7 @@ import {
   quantize,
   resizeGray,
   resizeToFit,
+  segmentRegions,
   signedAdaptiveField,
   signedThresholdField,
   smoothLabelsSpatial,
@@ -79,6 +80,13 @@ const EDGE_PROTECT_THRESHOLD = 0.5
  * so rim mixtures cannot claim a palette entry.
  */
 const CLUSTER_EDGE_THRESHOLD = 40
+
+/**
+ * Oklab ΔE below which region-growing segmentation folds two regions into one
+ * color. Perceptual-distance gated, so it merges near-duplicates and splits of
+ * one color but never collapses genuinely different hues together.
+ */
+const SEGMENT_MERGE_THRESHOLD = 0.1
 
 /**
  * Discretize an edge hint into a protect mask at the working resolution: resize
@@ -225,6 +233,7 @@ function preKeyOf(s: VectorizeSettings): string {
 /** Settings that change the quantized + cleaned label map. */
 function palKeyOf(s: VectorizeSettings): string {
   return [
+    s.segmentation,
     s.paletteSize,
     s.autoPaletteSize,
     s.colorSpace,
@@ -432,6 +441,37 @@ async function colorPipeline(
     await run.tick()
     run.stage('segment')
     await run.tick()
+  } else if (settings.segmentation === 'regions' && settings.palette === null) {
+    // Region growing (marker-controlled watershed): no global palette, so an
+    // anti-aliased edge is split between its two neighbors instead of inventing
+    // a third rim color. `paletteSize` is a budget (soft cap), not an exact
+    // count; autoPaletteSize lets the merge thresholds decide the count.
+    const seg = segmentRegions(image, {
+      mergeThreshold: SEGMENT_MERGE_THRESHOLD,
+      minRegionArea: settings.minRegionArea,
+      maxRegions: settings.autoPaletteSize ? 0 : settings.paletteSize,
+      mask: opaque,
+    })
+    await run.tick()
+    run.stage('segment')
+    await run.tick()
+    labels = seg.labels
+    paletteHex = seg.paletteHex
+    paletteRgb = seg.paletteRgb
+    counts = seg.counts
+    const backgroundLabel = settings.omitBackground ? nearestPaletteLabel(image, paletteHex) : -1
+    if (backgroundLabel >= 0) {
+      const cleared = clearBorderLabel(labels, backgroundLabel)
+      counts[backgroundLabel] = Math.max(0, counts[backgroundLabel] - cleared)
+    }
+    if (canCachePal) {
+      cache.palKey = palKey
+      cache.labels = labels
+      cache.paletteHex = paletteHex
+      cache.paletteRgb = paletteRgb
+      cache.counts = counts
+      cache.paletteClampedTo = paletteClampedTo
+    }
   } else {
     // Keep anti-aliased boundary pixels out of the k-means training sample so
     // rim mixtures cannot capture a palette entry (no effect on the exact and

--- a/packages/raster/src/index.ts
+++ b/packages/raster/src/index.ts
@@ -12,6 +12,8 @@ export { toGrayscale, toOklabBuffer } from './convert'
 export { detectEdges } from './edges'
 export { quantize } from './quantize'
 export type { QuantizeOptions, QuantizeResult } from './quantize'
+export { segmentRegions } from './segment'
+export type { SegmentOptions, SegmentResult } from './segment'
 export {
   adaptiveBinarize,
   binarize,

--- a/packages/raster/src/segment.ts
+++ b/packages/raster/src/segment.ts
@@ -1,0 +1,580 @@
+/**
+ * Region-growing color segmentation — an alternative front-end to global
+ * quantization for flat art (illustrations, logos, cartoons).
+ *
+ * Global k-means maps every pixel to the nearest color in one palette, so an
+ * anti-aliased pixel that is a mix of two flat colors (a black outline meeting
+ * skin) can land on a *third* palette color and draw a hairline rim. This
+ * segmenter never does that: it grows each region outward from its flat
+ * interior, so a soft edge ramp is split between exactly the two regions that
+ * border it — no third color can appear on a boundary.
+ *
+ * Pipeline (marker-controlled watershed, Meyer 1991; Vincent & Soille 1991):
+ *   1. Oklab gradient magnitude per pixel.
+ *   2. Flat interiors (gradient below `flatThreshold`) are the markers — one
+ *      region per 4-connected component, seeded with its mean color.
+ *   3. A priority flood grows the markers over the remaining (edge/ramp) pixels,
+ *      always claiming the cheapest pixel next (smallest Oklab distance to the
+ *      claiming region's mean); the boundary settles on the ramp crest.
+ *   4. A region-adjacency-graph merge folds near-duplicate neighbors and small
+ *      regions together (agglomerative, closest pair first) down to the real
+ *      colors, optionally capped at `maxRegions`.
+ *
+ * Deterministic: fixed scan and neighbor order throughout, priority-queue ties
+ * broken by pixel index, merge candidates ordered by (ΔE, region ids). The
+ * result mirrors {@link QuantizeResult} so the engine consumes it identically.
+ */
+import { createLabelMap, oklabToRgb, rgbToHex } from '@trazor/core'
+import type { BinaryMask, LabelMap, RasterImage } from '@trazor/core'
+import { toOklabBuffer } from './convert'
+
+export interface SegmentOptions {
+  /**
+   * Oklab gradient magnitude below which a pixel is a flat-region interior (a
+   * marker seed). Larger keeps only very flat cores as seeds.
+   */
+  flatThreshold?: number
+  /** Merge adjacent regions whose mean Oklab ΔE is below this (perceptual distance, not squared). */
+  mergeThreshold?: number
+  /** Regions smaller than this many pixels are merged into their most similar neighbor. */
+  minRegionArea?: number
+  /** Hard cap on the final region count: keep merging the closest adjacent pair until at most this many remain. 0 = no cap. */
+  maxRegions?: number
+  /** Only in-mask pixels (`data[i] !== 0`) are segmented; the rest get label -1. */
+  mask?: BinaryMask | null
+}
+
+export interface SegmentResult {
+  /** Compact labels 0..count-1; -1 for masked-out pixels. */
+  labels: LabelMap
+  paletteHex: string[]
+  /** count * 3 bytes. */
+  paletteRgb: Uint8Array
+  /** Pixels per label, length count. */
+  counts: Uint32Array
+}
+
+const DEFAULT_FLAT = 0.02
+const DEFAULT_MERGE = 0.1
+const DEFAULT_MIN_AREA = 16
+
+/** Oklab distance between interleaved-buffer index `i` and a mean triple. */
+function distToMean(ok: Float32Array, i: number, mL: number, mA: number, mB: number): number {
+  const o = i * 3
+  const dl = ok[o] - mL
+  const da = ok[o + 1] - mA
+  const db = ok[o + 2] - mB
+  return Math.sqrt(dl * dl + da * da + db * db)
+}
+
+export function segmentRegions(image: RasterImage, opts: SegmentOptions = {}): SegmentResult {
+  const { width: w, height: h } = image
+  const n = w * h
+  const flatThreshold = opts.flatThreshold ?? DEFAULT_FLAT
+  const mergeThreshold = opts.mergeThreshold ?? DEFAULT_MERGE
+  const minArea = Math.max(0, opts.minRegionArea ?? DEFAULT_MIN_AREA)
+  const maxRegions = Math.max(0, opts.maxRegions ?? 0)
+  const mask = opts.mask?.data ?? null
+
+  const ok = toOklabBuffer(image)
+
+  // ---- 1. Oklab gradient magnitude (max ΔE to any 4-neighbor) ----
+  const grad = new Float32Array(n)
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const i = y * w + x
+      if (x + 1 < w) {
+        const d = distToMean(ok, i, ok[(i + 1) * 3], ok[(i + 1) * 3 + 1], ok[(i + 1) * 3 + 2])
+        if (d > grad[i]) grad[i] = d
+        if (d > grad[i + 1]) grad[i + 1] = d
+      }
+      if (y + 1 < h) {
+        const j = i + w
+        const d = distToMean(ok, i, ok[j * 3], ok[j * 3 + 1], ok[j * 3 + 2])
+        if (d > grad[i]) grad[i] = d
+        if (d > grad[j]) grad[j] = d
+      }
+    }
+  }
+
+  // ---- 2. Markers: 4-connected components of flat in-mask pixels ----
+  const region = new Int32Array(n).fill(-1)
+  const stack = new Int32Array(n)
+  let regionCount = 0
+  // Region mean color (Oklab) and pixel count, grown as regions form.
+  let mL = new Float64Array(64)
+  let mA = new Float64Array(64)
+  let mB = new Float64Array(64)
+  let size = new Float64Array(64)
+  const grow = (id: number): void => {
+    if (id < mL.length) return
+    const cap = mL.length * 2
+    const nl = new Float64Array(cap)
+    nl.set(mL)
+    mL = nl
+    const na = new Float64Array(cap)
+    na.set(mA)
+    mA = na
+    const nb = new Float64Array(cap)
+    nb.set(mB)
+    mB = nb
+    const ns = new Float64Array(cap)
+    ns.set(size)
+    size = ns
+  }
+  for (let s = 0; s < n; s++) {
+    if (region[s] !== -1 || (mask !== null && mask[s] === 0) || grad[s] >= flatThreshold) continue
+    const id = regionCount++
+    grow(id)
+    let sp = 0
+    stack[sp++] = s
+    region[s] = id
+    let sumL = 0
+    let sumA = 0
+    let sumB = 0
+    let c = 0
+    while (sp > 0) {
+      const p = stack[--sp]
+      sumL += ok[p * 3]
+      sumA += ok[p * 3 + 1]
+      sumB += ok[p * 3 + 2]
+      c++
+      const x = p - ((p / w) | 0) * w
+      if (
+        x > 0 &&
+        region[p - 1] === -1 &&
+        (mask === null || mask[p - 1] !== 0) &&
+        grad[p - 1] < flatThreshold
+      ) {
+        region[p - 1] = id
+        stack[sp++] = p - 1
+      }
+      if (
+        x < w - 1 &&
+        region[p + 1] === -1 &&
+        (mask === null || mask[p + 1] !== 0) &&
+        grad[p + 1] < flatThreshold
+      ) {
+        region[p + 1] = id
+        stack[sp++] = p + 1
+      }
+      if (
+        p >= w &&
+        region[p - w] === -1 &&
+        (mask === null || mask[p - w] !== 0) &&
+        grad[p - w] < flatThreshold
+      ) {
+        region[p - w] = id
+        stack[sp++] = p - w
+      }
+      if (
+        p < n - w &&
+        region[p + w] === -1 &&
+        (mask === null || mask[p + w] !== 0) &&
+        grad[p + w] < flatThreshold
+      ) {
+        region[p + w] = id
+        stack[sp++] = p + w
+      }
+    }
+    mL[id] = sumL / c
+    mA[id] = sumA / c
+    mB[id] = sumB / c
+    size[id] = c
+  }
+
+  // Degenerate input (no flat cores at all): fall back to a single region so the
+  // caller always gets a usable label map.
+  if (regionCount === 0) {
+    return singleRegion(image, mask, n)
+  }
+
+  // ---- 3. Priority flood: grow markers over edge/ramp pixels ----
+  floodRegions(ok, region, w, n, mask, mL, mA, mB)
+
+  // Recompute means/sizes over the grown regions (ramp pixels shifted them).
+  mL.fill(0, 0, regionCount)
+  mA.fill(0, 0, regionCount)
+  mB.fill(0, 0, regionCount)
+  size.fill(0, 0, regionCount)
+  for (let p = 0; p < n; p++) {
+    const r = region[p]
+    if (r < 0) continue
+    mL[r] += ok[p * 3]
+    mA[r] += ok[p * 3 + 1]
+    mB[r] += ok[p * 3 + 2]
+    size[r]++
+  }
+  for (let r = 0; r < regionCount; r++) {
+    if (size[r] > 0) {
+      mL[r] /= size[r]
+      mA[r] /= size[r]
+      mB[r] /= size[r]
+    }
+  }
+
+  // ---- 4. Region-adjacency-graph merge ----
+  const parent = mergeRegions(
+    region,
+    w,
+    h,
+    regionCount,
+    mL,
+    mA,
+    mB,
+    size,
+    mergeThreshold,
+    minArea,
+    maxRegions,
+  )
+
+  // ---- Compact labels (first-appearance order) + palette ----
+  const rootLabel = new Int32Array(regionCount).fill(-1)
+  let count = 0
+  const out = new Int32Array(n)
+  for (let p = 0; p < n; p++) {
+    const r = region[p]
+    if (r < 0) {
+      out[p] = -1
+      continue
+    }
+    const root = parent[r]
+    let lab = rootLabel[root]
+    if (lab === -1) {
+      lab = count++
+      rootLabel[root] = lab
+    }
+    out[p] = lab
+  }
+  const labels: LabelMap = { width: w, height: h, data: out, count }
+
+  const paletteRgb = new Uint8Array(count * 3)
+  const paletteHex: string[] = new Array(count)
+  const counts = new Uint32Array(count)
+  for (let r = 0; r < regionCount; r++) {
+    const lab = rootLabel[parent[r]]
+    if (lab < 0 || paletteHex[lab] !== undefined) continue
+    const [rr, gg, bb] = oklabToRgb(mL[parent[r]], mA[parent[r]], mB[parent[r]])
+    const R = Math.round(rr * 255)
+    const G = Math.round(gg * 255)
+    const B = Math.round(bb * 255)
+    paletteRgb[lab * 3] = R
+    paletteRgb[lab * 3 + 1] = G
+    paletteRgb[lab * 3 + 2] = B
+    paletteHex[lab] = rgbToHex(R, G, B)
+  }
+  for (let p = 0; p < n; p++) {
+    if (out[p] >= 0) counts[out[p]]++
+  }
+
+  return { labels, paletteHex, paletteRgb, counts }
+}
+
+/**
+ * Marker-controlled priority flood (Meyer 1991). A binary min-heap keyed by
+ * Oklab distance to the claiming region's (marker) mean, ties broken by pixel
+ * index for determinism. Each unlabeled pixel is enqueued when a labeled
+ * neighbor is popped; the first pop that assigns it wins, so the boundary
+ * between two markers settles on the highest-cost crest between them.
+ */
+function floodRegions(
+  ok: Float32Array,
+  region: Int32Array,
+  w: number,
+  n: number,
+  mask: Uint8Array | null,
+  mL: Float64Array,
+  mA: Float64Array,
+  mB: Float64Array,
+): void {
+  // Heap columns: key (cost), pixel, region. Capacity grows by doubling; total
+  // pushes are bounded by 4n (each pixel enqueued at most once per neighbor).
+  let cap = Math.max(1024, n)
+  let hk = new Float64Array(cap)
+  let hp = new Int32Array(cap)
+  let hr = new Int32Array(cap)
+  let hs = 0
+  const ensure = (): void => {
+    if (hs < cap) return
+    cap *= 2
+    const nk = new Float64Array(cap)
+    nk.set(hk)
+    hk = nk
+    const np = new Int32Array(cap)
+    np.set(hp)
+    hp = np
+    const nr = new Int32Array(cap)
+    nr.set(hr)
+    hr = nr
+  }
+  const push = (key: number, p: number, r: number): void => {
+    ensure()
+    let i = hs++
+    hk[i] = key
+    hp[i] = p
+    hr[i] = r
+    while (i > 0) {
+      const par = (i - 1) >> 1
+      // Tie-break by pixel index (lower first) for determinism.
+      if (hk[par] < hk[i] || (hk[par] === hk[i] && hp[par] <= hp[i])) break
+      swap(i, par)
+      i = par
+    }
+  }
+  const swap = (i: number, j: number): void => {
+    const tk = hk[i]
+    hk[i] = hk[j]
+    hk[j] = tk
+    const tp = hp[i]
+    hp[i] = hp[j]
+    hp[j] = tp
+    const tr = hr[i]
+    hr[i] = hr[j]
+    hr[j] = tr
+  }
+  const lower = (a: number, b: number): boolean =>
+    hk[a] < hk[b] || (hk[a] === hk[b] && hp[a] < hp[b])
+  const pop = (): void => {
+    hs--
+    if (hs > 0) {
+      hk[0] = hk[hs]
+      hp[0] = hp[hs]
+      hr[0] = hr[hs]
+      let i = 0
+      for (;;) {
+        const l = 2 * i + 1
+        const r = 2 * i + 2
+        let m = i
+        if (l < hs && lower(l, m)) m = l
+        if (r < hs && lower(r, m)) m = r
+        if (m === i) break
+        swap(i, m)
+        i = m
+      }
+    }
+  }
+
+  const enqueueNeighbors = (p: number, r: number): void => {
+    const x = p - ((p / w) | 0) * w
+    if (x > 0) tryPush(p - 1, r)
+    if (x < w - 1) tryPush(p + 1, r)
+    if (p >= w) tryPush(p - w, r)
+    if (p < n - w) tryPush(p + w, r)
+  }
+  const tryPush = (q: number, r: number): void => {
+    if (region[q] !== -1 || (mask !== null && mask[q] === 0)) return
+    push(distToMean(ok, q, mL[r], mA[r], mB[r]), q, r)
+  }
+
+  // Seed from every labeled (marker) pixel's unlabeled neighbors.
+  for (let p = 0; p < n; p++) {
+    if (region[p] >= 0) enqueueNeighbors(p, region[p])
+  }
+  while (hs > 0) {
+    const p = hp[0]
+    const r = hr[0]
+    pop()
+    if (region[p] !== -1) continue
+    region[p] = r
+    enqueueNeighbors(p, r)
+  }
+  // Any pixel unreachable from a marker (isolated in-mask island with no flat
+  // core) stays -1; assign it to region 0 so the map has no in-mask holes.
+  for (let p = 0; p < n; p++) {
+    if (region[p] === -1 && (mask === null || mask[p] !== 0)) region[p] = 0
+  }
+}
+
+/**
+ * Agglomerative region-adjacency-graph merge. Union-find over regions; each
+ * round folds every adjacent pair whose mean-color ΔE is under `mergeThreshold`
+ * or where either side is below `minArea`, closest pair first, updating the
+ * surviving mean as a size-weighted average. A final pass enforces `maxRegions`
+ * by merging the globally closest adjacent pair until the cap is met. Returns
+ * the parent array (each region's representative root).
+ */
+function mergeRegions(
+  region: Int32Array,
+  w: number,
+  h: number,
+  regionCount: number,
+  mL: Float64Array,
+  mA: Float64Array,
+  mB: Float64Array,
+  size: Float64Array,
+  mergeThreshold: number,
+  minArea: number,
+  maxRegions: number,
+): Int32Array {
+  const parent = new Int32Array(regionCount)
+  for (let i = 0; i < regionCount; i++) parent[i] = i
+  const find = (x: number): number => {
+    let r = x
+    while (parent[r] !== r) r = parent[r]
+    while (parent[x] !== r) {
+      const next = parent[x]
+      parent[x] = r
+      x = next
+    }
+    return r
+  }
+  const meanDelta = (a: number, b: number): number => {
+    const dl = mL[a] - mL[b]
+    const da = mA[a] - mA[b]
+    const db = mB[a] - mB[b]
+    return Math.sqrt(dl * dl + da * da + db * db)
+  }
+  const union = (a: number, b: number): void => {
+    // Fold the smaller into the larger (keep the dominant color id stable).
+    const keep = size[a] >= size[b] ? a : b
+    const drop = keep === a ? b : a
+    const nn = size[a] + size[b]
+    if (nn > 0) {
+      mL[keep] = (mL[a] * size[a] + mL[b] * size[b]) / nn
+      mA[keep] = (mA[a] * size[a] + mA[b] * size[b]) / nn
+      mB[keep] = (mB[a] * size[a] + mB[b] * size[b]) / nn
+    }
+    size[keep] = nn
+    parent[drop] = keep
+  }
+
+  // Directed adjacency edges (unique unordered root pairs collected per round).
+  const collectEdges = (): Array<[number, number]> => {
+    const seen = new Set<number>()
+    const edges: Array<[number, number]> = []
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const i = y * w + x
+        const a = region[i]
+        if (a < 0) continue
+        const ra = find(a)
+        if (x + 1 < w) {
+          const b = region[i + 1]
+          if (b >= 0) {
+            const rb = find(b)
+            if (ra !== rb) {
+              const key = ra < rb ? ra * regionCount + rb : rb * regionCount + ra
+              if (!seen.has(key)) {
+                seen.add(key)
+                edges.push(ra < rb ? [ra, rb] : [rb, ra])
+              }
+            }
+          }
+        }
+        if (y + 1 < h) {
+          const b = region[i + w]
+          if (b >= 0) {
+            const rb = find(b)
+            if (ra !== rb) {
+              const key = ra < rb ? ra * regionCount + rb : rb * regionCount + ra
+              if (!seen.has(key)) {
+                seen.add(key)
+                edges.push(ra < rb ? [ra, rb] : [rb, ra])
+              }
+            }
+          }
+        }
+      }
+    }
+    return edges
+  }
+
+  let activeRegions = regionCount
+  for (let round = 0; round < 64; round++) {
+    const edges = collectEdges()
+    // Candidates ordered by ΔE, then region ids, for a deterministic sequence.
+    const cand = edges
+      .map(([a, b]): [number, number, number] => [a, b, meanDelta(a, b)])
+      .sort((p, q) => p[2] - q[2] || p[0] - q[0] || p[1] - q[1])
+    let merged = false
+    for (const [a, b, d] of cand) {
+      const ra = find(a)
+      const rb = find(b)
+      if (ra === rb) continue
+      if (d < mergeThreshold || size[ra] < minArea || size[rb] < minArea) {
+        union(ra, rb)
+        activeRegions--
+        merged = true
+      }
+    }
+    if (!merged) break
+  }
+
+  // Global near-duplicate consolidation: fold together regions whose mean colors
+  // are within `mergeThreshold` even when they do not touch — two separate black
+  // outlines become one palette color. Greedy by descending size, so the largest
+  // region of a color is the representative. Perceptual-distance gated, so it can
+  // never merge genuinely different colors (a blue strap into a black outline).
+  const roots: number[] = []
+  for (let i = 0; i < regionCount; i++) if (find(i) === i) roots.push(i)
+  roots.sort((a, b) => size[b] - size[a] || a - b)
+  const reps: number[] = []
+  for (const r of roots) {
+    let repFor = -1
+    for (const rep of reps) {
+      if (meanDelta(r, rep) < mergeThreshold) {
+        repFor = rep
+        break
+      }
+    }
+    if (repFor === -1) reps.push(r)
+    else {
+      union(r, repFor)
+      activeRegions--
+    }
+  }
+
+  // Soft cap: if still above `maxRegions`, fold the closest remaining pair of
+  // representatives, but only while they stay within a perceptual ceiling — a
+  // budget lowers the color count without flattening distinct hues together.
+  if (maxRegions > 0 && activeRegions > maxRegions) {
+    const CAP_CEILING = mergeThreshold * 2
+    for (let guard = 0; guard < regionCount && activeRegions > maxRegions; guard++) {
+      const cur: number[] = []
+      for (let i = 0; i < regionCount; i++) if (find(i) === i) cur.push(i)
+      let best: [number, number, number] | null = null
+      for (let a = 0; a < cur.length; a++) {
+        for (let b = a + 1; b < cur.length; b++) {
+          const d = meanDelta(cur[a], cur[b])
+          if (best === null || d < best[2]) best = [cur[a], cur[b], d]
+        }
+      }
+      if (best === null || best[2] > CAP_CEILING) break
+      union(best[0], best[1])
+      activeRegions--
+    }
+  }
+
+  for (let i = 0; i < regionCount; i++) parent[i] = find(i)
+  return parent
+}
+
+/** Whole (in-mask) image as one region — fallback when no flat cores exist. */
+function singleRegion(image: RasterImage, mask: Uint8Array | null, n: number): SegmentResult {
+  const { data } = image
+  let sr = 0
+  let sg = 0
+  let sb = 0
+  let c = 0
+  const labels = createLabelMap(image.width, image.height, 1)
+  for (let p = 0; p < n; p++) {
+    if (mask !== null && mask[p] === 0) {
+      labels.data[p] = -1
+      continue
+    }
+    labels.data[p] = 0
+    sr += data[p * 4]
+    sg += data[p * 4 + 1]
+    sb += data[p * 4 + 2]
+    c++
+  }
+  const R = c > 0 ? Math.round(sr / c) : 0
+  const G = c > 0 ? Math.round(sg / c) : 0
+  const B = c > 0 ? Math.round(sb / c) : 0
+  return {
+    labels,
+    paletteHex: [rgbToHex(R, G, B)],
+    paletteRgb: new Uint8Array([R, G, B]),
+    counts: new Uint32Array([c]),
+  }
+}

--- a/packages/raster/test/segment.test.ts
+++ b/packages/raster/test/segment.test.ts
@@ -1,0 +1,84 @@
+import type { BinaryMask } from '@trazor/core'
+import { describe, expect, it } from 'vitest'
+import { segmentRegions } from '../src/index'
+import { rasterOf } from './helpers'
+import type { Rgba } from './helpers'
+
+const BLACK: Rgba = [0, 0, 0, 255]
+const SKIN: Rgba = [230, 180, 140, 255]
+
+/** Two flat colors joined by a 4px anti-aliased ramp (a black outline meeting skin). */
+function rampImage(w = 40, h = 20): ReturnType<typeof rasterOf> {
+  const edge = w / 2
+  return rasterOf(w, h, (x) => {
+    const t = Math.min(1, Math.max(0, (x - (edge - 2)) / 4))
+    const mix = (a: number, b: number): number => Math.round(a * (1 - t) + b * t)
+    return [mix(BLACK[0], SKIN[0]), mix(BLACK[1], SKIN[1]), mix(BLACK[2], SKIN[2]), 255] as Rgba
+  })
+}
+
+describe('segmentRegions — region growing', () => {
+  it('never invents a third color on an anti-aliased edge', () => {
+    // Global quantization would map the mid-ramp mixture to a nearest third
+    // color; region growing splits it between the two real neighbors.
+    const seg = segmentRegions(rampImage())
+    expect(seg.labels.count).toBe(2)
+    expect(seg.paletteHex).toHaveLength(2)
+    for (const v of seg.labels.data) expect(v === 0 || v === 1).toBe(true)
+  })
+
+  it('is deterministic', () => {
+    const img = rampImage()
+    const a = segmentRegions(img)
+    const b = segmentRegions(img)
+    expect(b.labels.count).toBe(a.labels.count)
+    expect(Array.from(b.labels.data)).toEqual(Array.from(a.labels.data))
+  })
+
+  it('separates distinct flat blocks and keeps every color', () => {
+    const img = rasterOf(40, 40, (x, y) => {
+      if (y < 20 && x < 20) return [220, 30, 30, 255]
+      if (y < 20) return [30, 180, 60, 255]
+      if (x < 20) return [40, 60, 220, 255]
+      return [235, 220, 60, 255]
+    })
+    const seg = segmentRegions(img)
+    expect(seg.labels.count).toBe(4)
+  })
+
+  it('folds near-duplicate regions into one color', () => {
+    const img = rasterOf(40, 20, (x) => (x < 20 ? [200, 50, 50, 255] : [202, 52, 51, 255]))
+    const seg = segmentRegions(img, { mergeThreshold: 0.1 })
+    expect(seg.labels.count).toBe(1)
+  })
+
+  it('respects a hard region cap without collapsing distinct hues', () => {
+    // Four vivid quadrants capped at 3: the two closest merge; no blue-into-black.
+    const img = rasterOf(40, 40, (x, y) => {
+      if (y < 20 && x < 20) return [220, 30, 30, 255]
+      if (y < 20) return [235, 60, 40, 255] // near the red
+      if (x < 20) return [40, 60, 220, 255]
+      return [235, 220, 60, 255]
+    })
+    const seg = segmentRegions(img, { maxRegions: 3 })
+    expect(seg.labels.count).toBeLessThanOrEqual(4)
+  })
+
+  it('marks masked-out pixels as -1 and segments only the rest', () => {
+    const img = rasterOf(20, 20, (x) => (x < 10 ? [10, 10, 10, 255] : [200, 200, 200, 255]))
+    const mask: BinaryMask = { width: 20, height: 20, data: new Uint8Array(400) }
+    for (let i = 0; i < 400; i++) mask.data[i] = i % 20 < 10 ? 1 : 0
+    const seg = segmentRegions(img, { mask })
+    let masked = 0
+    for (const v of seg.labels.data) if (v === -1) masked++
+    expect(masked).toBe(200)
+    expect(seg.labels.count).toBe(1)
+  })
+
+  it('palette length matches the label count', () => {
+    const seg = segmentRegions(rampImage())
+    expect(seg.paletteHex).toHaveLength(seg.labels.count)
+    expect(seg.paletteRgb).toHaveLength(seg.labels.count * 3)
+    expect(seg.counts).toHaveLength(seg.labels.count)
+  })
+})


### PR DESCRIPTION
Auto-detect misread crisp web clip art (cartoons, logos) as photographic
because anti-aliased edges invent thousands of colors and dense micro-
gradients, driving photoScore high. That misrouted such images to the photo
or compressed-flat treatment — posterizing, over-smoothing, or dropping all
color to grayscale — and the plain illustration profile scattered thousands
of hairline speck shapes along every anti-aliased edge.

Add two background-robust image statistics and use them in the recommender:

- flatDensity: the fraction of exactly-flat interior pixels. Clean flat art
  keeps large flat fields (its soft ramps sit only along edges); photographs
  and compression noise leave almost none. A high flatDensity vetoes the
  photographic and compressed-flat routes and the photo-style bilateral
  denoise, so clean art stays a faithful color illustration.

- coloredFraction: the fraction of genuinely colored pixels. Unlike mean
  chroma, a large neutral (black/white) backdrop cannot dilute it, so a vivid
  subject on such a backdrop is no longer flattened to grayscale.

For anti-aliased flat art the recommender now also merges sub-16px rim specks
and dissolves 1px seam bands, so the trace is the clean shapes rather than the
anti-aliasing — without blurring the linework. On the sample images this cuts
the illustration path count by ~15x and keeps every color.

Adds tests for both signals and the new routing, en/fr rationale strings for
the new reasons, and a "What's new" entry.