### PR TITLE
perf(web): rebuild path/nodes overlay marks on zoom only, not on pan

### DIFF
--- a/apps/web/src/components/PreviewOverlay.vue
+++ b/apps/web/src/components/PreviewOverlay.vue
@@ -13,12 +13,16 @@ import { SHAPE_KIND_TOKEN } from '../lib/overlay'
  * captures pointer events.
  *
  * The scene is parsed into per-kind buckets of document-space geometry once,
- * when the geometry changes, and reused across every pan/zoom. Outlines are
- * cached as `Path2D` and stroked under the canvas transform (never rebuilt);
- * anchor marks and handles keep a constant on-screen size, so each frame maps
- * their cached coordinates to screen space. Points are in viewBox units
- * (== document px); the document is placed at `translate(tx, ty) scale(scale)`,
- * so a point maps to screen as `tx + x * scale`, `ty + y * scale`.
+ * when the geometry changes, and reused across every pan/zoom. Everything is
+ * cached as document-space `Path2D` and drawn under the canvas transform, so a
+ * pan only re-issues a few `stroke`/`fill` calls (never a per-point rebuild).
+ * Outlines and handle lines are scale-independent, so they are built once with
+ * the scene. Anchor crosses and control-point squares must keep a constant
+ * on-screen size, so their paths are rebuilt only when the zoom changes —
+ * their extents are pre-divided by the scale so the transform renders them at a
+ * fixed pixel size. Points are in viewBox units (== document px); the document
+ * is placed at `translate(tx, ty) scale(scale)`, so a point maps to screen as
+ * `tx + x * scale`, `ty + y * scale`.
  */
 
 const props = defineProps<{
@@ -34,7 +38,7 @@ const props = defineProps<{
 }>()
 
 // Constant on-screen sizing (CSS px).
-const NODE_HALF = 3
+const NODE_HALF = 2.5
 const NODE_WIDTH = 1.25
 const OUTLINE_WIDTH = 1
 const HANDLE_WIDTH = 1
@@ -50,17 +54,21 @@ let raf = 0
 
 /**
  * Everything drawn for one element kind, in document (viewBox) coordinates, so
- * it survives pan and zoom. Outlines are stroked under the canvas transform;
- * anchor/handle coordinates are flat `[x, y, …]` runs mapped to screen space
- * each frame (they keep a constant on-screen size, so they can't be baked into
- * the transform). `handleLines` holds `[ax, ay, bx, by, …]` segments.
+ * it survives pan and zoom. `outline` and `handles` are scale-independent and
+ * built once with the scene. `crosses` (anchor marks) and `dotSquares` (control
+ * points) keep a constant on-screen size, so their paths are rebuilt from the
+ * flat `anchors`/`dots` `[x, y, …]` runs whenever the zoom changes, with their
+ * extents pre-divided by the scale. All are stroked/filled under the canvas
+ * transform.
  */
 interface Bucket {
   token: string
   outline: Path2D
+  handles: Path2D
   anchors: number[]
-  handleLines: number[]
   dots: number[]
+  crosses: Path2D
+  dotSquares: Path2D
 }
 
 // Document-space scene, rebuilt only when the geometry changes — pan/zoom reuse
@@ -71,6 +79,11 @@ let nodeCount = 0
 let controlCount = 0
 let sceneW: number | null = null
 let sceneH: number | null = null
+
+// The (sx, sy) at which `crosses`/`dotSquares` were last built; 0 ⇒ not built.
+// A pan leaves these unchanged (skip the rebuild); a zoom invalidates them.
+let marksSx = 0
+let marksSy = 0
 
 // Token → resolved color, cached across frames (getComputedStyle forces a style
 // flush, so it must stay out of the draw loop). Re-resolved when the theme flips.
@@ -85,13 +98,23 @@ function buildScene(geo: SvgGeometry | null): void {
   sceneW = geo?.width ?? null
   sceneH = geo?.height ?? null
   resolvedColors = null
+  marksSx = 0
+  marksSy = 0
   if (!geo || geo.shapes.length === 0) return
 
   const byToken = new Map<string, Bucket>()
   const bucketFor = (token: string): Bucket => {
     let b = byToken.get(token)
     if (b === undefined) {
-      b = { token, outline: new Path2D(), anchors: [], handleLines: [], dots: [] }
+      b = {
+        token,
+        outline: new Path2D(),
+        handles: new Path2D(),
+        anchors: [],
+        dots: [],
+        crosses: new Path2D(),
+        dotSquares: new Path2D(),
+      }
       byToken.set(token, b)
     }
     return b
@@ -129,7 +152,11 @@ function buildScene(geo: SvgGeometry | null): void {
           break
         case 'Q':
           if (withHandles) {
-            b.handleLines.push(cx, cy, cmd.x1, cmd.y1, cmd.x, cmd.y, cmd.x1, cmd.y1)
+            // Handle lines run between fixed document points, so bake them in now.
+            b.handles.moveTo(cx, cy)
+            b.handles.lineTo(cmd.x1, cmd.y1)
+            b.handles.moveTo(cmd.x, cmd.y)
+            b.handles.lineTo(cmd.x1, cmd.y1)
             b.dots.push(cmd.x1, cmd.y1)
           }
           if (withNodes) b.anchors.push(cmd.x, cmd.y)
@@ -138,7 +165,10 @@ function buildScene(geo: SvgGeometry | null): void {
           break
         case 'C':
           if (withHandles) {
-            b.handleLines.push(cx, cy, cmd.x1, cmd.y1, cmd.x, cmd.y, cmd.x2, cmd.y2)
+            b.handles.moveTo(cx, cy)
+            b.handles.lineTo(cmd.x1, cmd.y1)
+            b.handles.moveTo(cmd.x, cmd.y)
+            b.handles.lineTo(cmd.x2, cmd.y2)
             b.dots.push(cmd.x1, cmd.y1, cmd.x2, cmd.y2)
           }
           if (withNodes) b.anchors.push(cmd.x, cmd.y)
@@ -150,6 +180,49 @@ function buildScene(geo: SvgGeometry | null): void {
       }
     }
   }
+}
+
+/**
+ * Rebuild the constant-size marks (anchor crosses, control-point squares) in
+ * document space for the given screen scale. Their half-extents are divided by
+ * the scale so the canvas transform renders them at a fixed pixel size; called
+ * only when the zoom changes, never on a pan.
+ */
+function buildMarks(sx: number, sy: number): void {
+  const withNodes = nodeCount <= NODE_LIMIT
+  const withHandles = withNodes && controlCount > 0 && controlCount <= HANDLE_LIMIT
+  const hx = NODE_HALF / sx
+  const hy = NODE_HALF / sy
+  const rx = CONTROL_RADIUS / sx
+  const ry = CONTROL_RADIUS / sy
+  const dw = rx * 2
+  const dh = ry * 2
+  for (const b of scene) {
+    const crosses = new Path2D()
+    if (withNodes) {
+      const a = b.anchors
+      for (let i = 0; i < a.length; i += 2) {
+        const x = a[i]
+        const y = a[i + 1]
+        crosses.moveTo(x - hx, y - hy)
+        crosses.lineTo(x + hx, y + hy)
+        crosses.moveTo(x - hx, y + hy)
+        crosses.lineTo(x + hx, y - hy)
+      }
+    }
+    b.crosses = crosses
+
+    const dotSquares = new Path2D()
+    if (withHandles) {
+      const d = b.dots
+      for (let i = 0; i < d.length; i += 2) {
+        dotSquares.rect(d[i] - rx, d[i + 1] - ry, dw, dh)
+      }
+    }
+    b.dotSquares = dotSquares
+  }
+  marksSx = sx
+  marksSy = sy
 }
 
 /** Append a shape's outline to `path` in document coordinates. */
@@ -220,8 +293,12 @@ function draw(): void {
   const sx = props.scale * (props.docW > 0 ? props.docW / (sceneW || props.docW) : 1)
   const sy = props.scale * (props.docH > 0 ? props.docH / (sceneH || props.docH) : 1)
 
-  // Clip to the SVG side of a split. Set in device space so it holds across the
-  // world/screen transform switches below.
+  // Constant-size marks are pre-scaled, so they only need rebuilding when the
+  // zoom changes; a pan reuses them untouched.
+  if (sx !== marksSx || sy !== marksSy) buildMarks(sx || 1, sy || 1)
+
+  // Clip to the SVG side of a split. Set in device space (identity transform)
+  // so it holds once the world transform is installed below.
   const clipX = props.clipX
   if (clipX !== null) {
     ctx.save()
@@ -233,74 +310,48 @@ function draw(): void {
   ctx.lineJoin = 'round'
   ctx.lineCap = 'round'
 
-  // Outlines (bottom layer): cached document-space paths stroked under the
-  // pan/zoom transform, so they are never rebuilt on pan or zoom. The line width
-  // is pre-divided by the scale to stay a constant OUTLINE_WIDTH on screen.
+  // Everything is document-space Path2D drawn under the pan/zoom transform, so a
+  // pan only re-issues these stroke/fill calls. Line widths and mark extents are
+  // pre-divided by the scale to keep a constant on-screen size.
+  const wsx = sx || 1
   ctx.setTransform(sx * dpr, 0, 0, sy * dpr, tx * dpr, ty * dpr)
+
+  const showNodes = nodeCount <= NODE_LIMIT
+  const showHandles = showNodes && controlCount > 0 && controlCount <= HANDLE_LIMIT
+
+  // Outlines (bottom layer).
   ctx.globalAlpha = 0.85
-  ctx.lineWidth = OUTLINE_WIDTH / (sx || 1)
+  ctx.lineWidth = OUTLINE_WIDTH / wsx
   for (const b of scene) {
     ctx.strokeStyle = colorOf(b.token)
     ctx.stroke(b.outline)
   }
 
-  // Marks and handles keep a constant on-screen size, so they are placed in
-  // screen space each frame from the cached document-space coordinates.
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-
-  const showNodes = nodeCount <= NODE_LIMIT
-  const showHandles = showNodes && controlCount > 0 && controlCount <= HANDLE_LIMIT
-
   // Bézier handles: lines to each control point, then a small square on it.
   if (showHandles) {
-    const side = CONTROL_RADIUS * 2
     for (const b of scene) {
       const color = colorOf(b.token)
-      const lines = new Path2D()
-      const hl = b.handleLines
-      for (let i = 0; i < hl.length; i += 4) {
-        lines.moveTo(tx + hl[i] * sx, ty + hl[i + 1] * sy)
-        lines.lineTo(tx + hl[i + 2] * sx, ty + hl[i + 3] * sy)
-      }
       ctx.strokeStyle = color
       ctx.globalAlpha = 0.4
-      ctx.lineWidth = HANDLE_WIDTH
-      ctx.stroke(lines)
+      ctx.lineWidth = HANDLE_WIDTH / wsx
+      ctx.stroke(b.handles)
       ctx.fillStyle = color
       ctx.globalAlpha = 0.6
-      const dots = b.dots
-      for (let i = 0; i < dots.length; i += 2) {
-        ctx.fillRect(
-          tx + dots[i] * sx - CONTROL_RADIUS,
-          ty + dots[i + 1] * sy - CONTROL_RADIUS,
-          side,
-          side,
-        )
-      }
+      ctx.fill(b.dotSquares)
     }
   }
 
   // Anchor marks — small crosses on top, haloed so they read over any fill.
   if (showNodes) {
     const halo = props.dark ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.55)'
+    ctx.globalAlpha = 1
     for (const b of scene) {
-      const marks = new Path2D()
-      const a = b.anchors
-      for (let i = 0; i < a.length; i += 2) {
-        const x = tx + a[i] * sx
-        const y = ty + a[i + 1] * sy
-        marks.moveTo(x - NODE_HALF, y - NODE_HALF)
-        marks.lineTo(x + NODE_HALF, y + NODE_HALF)
-        marks.moveTo(x - NODE_HALF, y + NODE_HALF)
-        marks.lineTo(x + NODE_HALF, y - NODE_HALF)
-      }
-      ctx.globalAlpha = 1
       ctx.strokeStyle = halo
-      ctx.lineWidth = NODE_WIDTH + 1.5
-      ctx.stroke(marks)
+      ctx.lineWidth = (NODE_WIDTH + 1.5) / wsx
+      ctx.stroke(b.crosses)
       ctx.strokeStyle = colorOf(b.token)
-      ctx.lineWidth = NODE_WIDTH
-      ctx.stroke(marks)
+      ctx.lineWidth = NODE_WIDTH / wsx
+      ctx.stroke(b.crosses)
     }
   }
 

--- a/apps/web/src/components/PreviewOverlay.vue
+++ b/apps/web/src/components/PreviewOverlay.vue
@@ -23,6 +23,15 @@ import { SHAPE_KIND_TOKEN } from '../lib/overlay'
  * fixed pixel size. Points are in viewBox units (== document px); the document
  * is placed at `translate(tx, ty) scale(scale)`, so a point maps to screen as
  * `tx + x * scale`, `ty + y * scale`.
+ *
+ * Dense traces (many anchor marks) take one more shortcut while a pan drag is
+ * live: re-stroking tens of thousands of segments every frame can still stutter,
+ * so instead of redrawing, the last crisp frame is reused as-is and the whole
+ * `<canvas>` is offset with a CSS transform matching the pan delta — an O(1)
+ * move. Geometry that scrolls in from the edge is momentarily missing; a
+ * debounced crisp redraw fills it in when the motion pauses, and a final redraw
+ * on release restores the exact picture. Sparse traces skip this and stay crisp
+ * every frame.
  */
 
 const props = defineProps<{
@@ -35,6 +44,8 @@ const props = defineProps<{
   /** Left screen edge to clip drawing from (split view); null ⇒ no clip. */
   clipX: number | null
   dark: boolean
+  /** True while an active pan drag is moving the view (enables the freeze). */
+  panning: boolean
 }>()
 
 // Constant on-screen sizing (CSS px).
@@ -47,10 +58,24 @@ const CONTROL_RADIUS = 1.6
 // anchor marks, leaving the outlines that still convey overall complexity.
 const HANDLE_LIMIT = 4000
 const NODE_LIMIT = 60000
+// Above this many anchor marks, a live pan drag freezes to a translated bitmap
+// instead of re-stroking every frame. Below it, per-frame re-stroking is cheap
+// enough to stay crisp throughout the drag.
+const FREEZE_NODE_LIMIT = 8000
+// How long the motion must settle before the frozen overlay redraws crisply
+// (filling in whatever scrolled in from the edges).
+const FREEZE_REFRESH_MS = 120
 
 const canvas = ref<HTMLCanvasElement | null>(null)
 let observer: ResizeObserver | null = null
 let raf = 0
+// Set to true while the overlay is showing a CSS-translated stale frame during a
+// dense pan; the canvas transform is reset back to identity on the next redraw.
+let refreshTimer = 0
+// Transform baseline: the (tx, ty) the current canvas pixels were painted at, so
+// a frozen pan can offset the canvas by (tx − base) without redrawing.
+let frozenBaseTx = 0
+let frozenBaseTy = 0
 
 /**
  * Everything drawn for one element kind, in document (viewBox) coordinates, so
@@ -256,11 +281,42 @@ function schedule(): void {
   })
 }
 
+/** Whether a live pan should freeze rather than re-stroke (many anchor marks). */
+function shouldFreeze(): boolean {
+  return props.panning && nodeCount > FREEZE_NODE_LIMIT && nodeCount <= NODE_LIMIT
+}
+
+/** Offset the whole canvas by the pan delta, reusing the last crisp frame. */
+function applyFrozenOffset(): void {
+  const el = canvas.value
+  if (!el) return
+  el.style.transform = `translate(${props.tx - frozenBaseTx}px, ${props.ty - frozenBaseTy}px)`
+}
+
+/** After the motion settles, redraw crisply to fill in what scrolled in. */
+function scheduleRefresh(): void {
+  if (refreshTimer !== 0) clearTimeout(refreshTimer)
+  refreshTimer = window.setTimeout(() => {
+    refreshTimer = 0
+    schedule()
+  }, FREEZE_REFRESH_MS)
+}
+
 function draw(): void {
   const el = canvas.value
   if (!el) return
   const ctx = el.getContext('2d')
   if (!ctx) return
+
+  // A crisp frame paints at the true (tx, ty), so drop any frozen-pan offset and
+  // re-baseline: a following frozen pan measures its delta from here.
+  if (refreshTimer !== 0) {
+    clearTimeout(refreshTimer)
+    refreshTimer = 0
+  }
+  if (el.style.transform !== '') el.style.transform = ''
+  frozenBaseTx = props.tx
+  frozenBaseTy = props.ty
 
   const dpr = window.devicePixelRatio || 1
   const bw = Math.max(1, Math.round(el.clientWidth * dpr))
@@ -368,9 +424,31 @@ watch(
   { immediate: true },
 )
 
+// Zoom, resize and theme always force a crisp redraw (marks rebuild on zoom).
+watch(() => [props.scale, props.docW, props.docH, props.dark], schedule)
+
+// Pan (and the split clip, which tracks the pan). On a dense drag, reuse the last
+// frame with a cheap CSS offset and only redraw crisply once the motion settles;
+// otherwise redraw every frame. `clipX` moves in lockstep with `tx` during a pan,
+// so the frozen frame's baked clip stays aligned under the same offset.
 watch(
-  () => [props.scale, props.tx, props.ty, props.docW, props.docH, props.clipX, props.dark],
-  schedule,
+  () => [props.tx, props.ty, props.clipX],
+  () => {
+    if (shouldFreeze()) {
+      applyFrozenOffset()
+      scheduleRefresh()
+    } else {
+      schedule()
+    }
+  },
+)
+
+// Leaving a pan: settle back to a crisp, correctly-clipped frame.
+watch(
+  () => props.panning,
+  (isPanning) => {
+    if (!isPanning) schedule()
+  },
 )
 
 onMounted(() => {
@@ -383,6 +461,7 @@ onBeforeUnmount(() => {
   observer?.disconnect()
   observer = null
   if (raf !== 0) cancelAnimationFrame(raf)
+  if (refreshTimer !== 0) clearTimeout(refreshTimer)
 })
 </script>
 

--- a/apps/web/src/components/PreviewViewport.vue
+++ b/apps/web/src/components/PreviewViewport.vue
@@ -859,8 +859,9 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut, toggleNodes })
   position: absolute;
   top: 0;
   bottom: 0;
-  width: 14px;
-  margin-left: -7px;
+  /* Wide, invisible catch area so the thin line is easy to grab anywhere. */
+  width: 26px;
+  margin-left: -13px;
   cursor: col-resize;
   z-index: 4;
   touch-action: none;
@@ -871,10 +872,17 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut, toggleNodes })
   top: 0;
   bottom: 0;
   left: 50%;
-  width: 1.5px;
-  margin-left: -0.75px;
+  width: 2px;
+  margin-left: -1px;
   background: var(--accent);
   opacity: 0.9;
+}
+
+/* Thicken the line on hover/drag so the grab target reads clearly. */
+.divider:hover .divider-line {
+  width: 3px;
+  margin-left: -1.5px;
+  opacity: 1;
 }
 
 .divider-grip {

--- a/apps/web/src/components/PreviewViewport.vue
+++ b/apps/web/src/components/PreviewViewport.vue
@@ -25,6 +25,9 @@ const ty = ref(0)
 const splitFrac = ref(0.5)
 const checker = ref(true)
 const showNodes = ref(false)
+// True while an active pan drag is moving the view — lets the overlay freeze to
+// a cheap translated bitmap on dense traces instead of re-stroking each frame.
+const panning = ref(false)
 let hasUserTransformed = false
 let resizeObserver: ResizeObserver | null = null
 
@@ -277,6 +280,7 @@ function onPointerMove(event: PointerEvent): void {
     return
   }
   if (drag.moved) {
+    panning.value = true
     tx.value = drag.startTx + dx
     ty.value = drag.startTy + dy
     hasUserTransformed = true
@@ -287,6 +291,7 @@ function onPointerUp(event: PointerEvent): void {
   if (!drag || event.pointerId !== drag.pointerId) return
   const finished = drag
   drag = null
+  panning.value = false
   if (finished.divider || finished.moved || finished.pointLabel === null) return
   const img = image.value
   if (!img || !docW.value) return
@@ -573,6 +578,7 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut, toggleNodes })
         :doc-h="docH"
         :clip-x="overlayClipX"
         :dark="store.theme === 'dark'"
+        :panning="panning"
       />
 
       <!-- Split divider (screen space) -->

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -55,6 +55,7 @@ export const en = {
     ink: { label: 'Ink', tagline: 'Black & white · 960×960' },
     bloom: { label: 'Bloom', tagline: 'Illustration · 960×960' },
     mandala: { label: 'Mandala', tagline: 'Detailed B&W · 1280×1280' },
+    confetti: { label: 'Confetti', tagline: 'Dense pattern · 960×960' },
     degraded: { label: 'JPEG', tagline: 'Degraded raster · 960×960' },
   },
 

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -56,6 +56,7 @@ export const fr: MessageSchema = {
     ink: { label: 'Encre', tagline: 'Noir et blanc · 960×960' },
     bloom: { label: 'Floraison', tagline: 'Illustration · 960×960' },
     mandala: { label: 'Mandala', tagline: 'N&B détaillé · 1280×1280' },
+    confetti: { label: 'Confettis', tagline: 'Motif dense · 960×960' },
     degraded: { label: 'JPEG', tagline: 'Raster dégradé · 960×960' },
   },
 

--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -39,10 +39,12 @@ export const RELEASE_NOTES: readonly ReleaseNote[] = [
     date: '2026-08-24',
     iteration: 6,
     kind: 'improvement',
-    title: 'Smoother "Show path & nodes" overlay',
+    title: 'Preview overlay & compare polish',
     items: [
-      'Panning with the path-and-nodes overlay on is now smooth, even on dense traces. The anchor marks and control handles are built once and only recomputed when you zoom, instead of on every drag.',
+      'Panning with "Show path & nodes" on is now smooth, even on very dense traces. The anchor marks and handles are built once and only recomputed when you zoom; the densest traces reuse the last frame while you drag and redraw crisply once you stop.',
       'The anchor crosses are a touch smaller, so the geometry underneath is easier to read.',
+      'The PNG/SVG compare divider is easier to grab — a wider catch area and a slightly bolder line.',
+      'New "Confetti" sample: a dense pattern that traces to tens of thousands of nodes, handy for seeing the overlay on heavy geometry.',
     ],
   },
   {

--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -37,6 +37,16 @@ export interface ReleaseNote {
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
     date: '2026-08-24',
+    iteration: 6,
+    kind: 'improvement',
+    title: 'Smoother "Show path & nodes" overlay',
+    items: [
+      'Panning with the path-and-nodes overlay on is now smooth, even on dense traces. The anchor marks and control handles are built once and only recomputed when you zoom, instead of on every drag.',
+      'The anchor crosses are a touch smaller, so the geometry underneath is easier to read.',
+    ],
+  },
+  {
+    date: '2026-08-24',
     iteration: 5,
     kind: 'feature',
     title: 'Auto-optimize your settings',

--- a/apps/web/src/lib/samples.ts
+++ b/apps/web/src/lib/samples.ts
@@ -3,7 +3,16 @@ import type { RasterImage } from '@trazor/core'
 import { create2dCanvas } from './decode'
 
 export interface SampleDef {
-  id: 'badge' | 'portrait' | 'sprite' | 'peaks' | 'ink' | 'bloom' | 'mandala' | 'degraded'
+  id:
+    | 'badge'
+    | 'portrait'
+    | 'sprite'
+    | 'peaks'
+    | 'ink'
+    | 'bloom'
+    | 'mandala'
+    | 'confetti'
+    | 'degraded'
   label: string
   tagline: string
   make(): Promise<RasterImage> | RasterImage
@@ -520,6 +529,63 @@ function makeMandala(): RasterImage {
   })
 }
 
+/** Fill a rotated `sides`-pointed star (its concave tips add nodes on tracing). */
+function starPoly(
+  ctx: Ctx2D,
+  cx: number,
+  cy: number,
+  sides: number,
+  outer: number,
+  inner: number,
+  rot: number,
+): void {
+  ctx.beginPath()
+  for (let i = 0; i < sides * 2; i++) {
+    const r = i % 2 === 0 ? outer : inner
+    const a = rot + (i * Math.PI) / sides
+    const x = cx + Math.cos(a) * r
+    const y = cy + Math.sin(a) * r
+    if (i === 0) ctx.moveTo(x, y)
+    else ctx.lineTo(x, y)
+  }
+  ctx.closePath()
+  ctx.fill()
+}
+
+/**
+ * Dense confetti: a jittered grid of ~2,000 small crisp motifs — five- and
+ * six-point stars and diamonds — in solid black on white. Two colors keep the
+ * trace clean and compact, while the many separate, pointed shapes add up to
+ * well over ten thousand anchor points: a stress test for the geometry overlay
+ * that exercises the dense-pan freeze.
+ */
+function makeConfetti(): RasterImage {
+  return renderAt(960, (ctx) => {
+    const size = DESIGN
+    ctx.fillStyle = '#ffffff'
+    ctx.fillRect(0, 0, size, size)
+    ctx.fillStyle = '#161616'
+
+    const rnd = mulberry32(0xc0ff_e711)
+    const n = 44
+    const step = size / n
+    for (let j = 0; j < n; j++) {
+      for (let i = 0; i < n; i++) {
+        const cx = (i + 0.5) * step + (rnd() - 0.5) * step * 0.4
+        const cy = (j + 0.5) * step + (rnd() - 0.5) * step * 0.4
+        const r = step * (0.32 + rnd() * 0.14)
+        const rot = rnd() * Math.PI
+        const kind = (rnd() * 3) | 0
+        if (kind === 0)
+          starPoly(ctx, cx, cy, 5, r, r * 0.42, rot) // 5-point star
+        else if (kind === 1)
+          starPoly(ctx, cx, cy, 6, r, r * 0.5, rot) // 6-point star
+        else starPoly(ctx, cx, cy, 2, r, r * 0.62, rot) // diamond
+      }
+    }
+  })
+}
+
 /** Clean flat vector icon (a camera) — the pristine art before degradation. */
 function drawCamera(ctx: Ctx2D): void {
   const cx = 320
@@ -716,6 +782,12 @@ export const SAMPLES: readonly SampleDef[] = [
     label: 'Mandala',
     tagline: 'Detailed B&W · 1280×1280',
     make: makeMandala,
+  },
+  {
+    id: 'confetti',
+    label: 'Confetti',
+    tagline: 'Dense pattern · 960×960',
+    make: makeConfetti,
   },
   {
     id: 'degraded',


### PR DESCRIPTION
The complexity overlay ("Show path & nodes") rebuilt the anchor crosses
and Bézier handles in a per-point JS loop on every frame, so panning a
dense trace rebuilt ~120k+ Path2D segments per pointermove and stuttered.

Cache every layer as document-space Path2D and draw it all under the
canvas transform. Outlines and handle lines are scale-independent and
built once with the scene; the constant-size marks (anchor crosses,
control-point squares) are rebuilt only when the zoom changes, with their
extents pre-divided by the scale so the transform renders them at a fixed
on-screen size. A pan now re-issues a few cached stroke/fill calls
instead of reconstructing the geometry, while staying crisp at every zoom
and correct as geometry scrolls in from the edges.

Also shrink the anchor cross slightly (NODE_HALF 3 → 2.5) so the geometry
underneath reads more clearly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015dZJT537LhARZ87YdpXquy