### PR TITLE
fix(engine): drop redundant far underlay from stacked cut layers

### DIFF
--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -50,6 +50,15 @@ export interface ReleaseNote {
  */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    date: '2026-08-25',
+    iteration: 1,
+    kind: 'fix',
+    title: 'Cleaner stacked cut layers',
+    items: [
+      'In stacked color mode, a lower sheet no longer carries hidden patches for far-away parts of the picture it never touches. Each sheet now extends only under the colors next to it, so a layer holds just the pieces you actually weed and stack — not stray islands buried under other sheets. The traced picture looks identical; only the cut sheets get simpler.',
+    ],
+  },
+  {
     date: '2026-08-24',
     iteration: 7,
     kind: 'improvement',

--- a/packages/engine/src/native.ts
+++ b/packages/engine/src/native.ts
@@ -672,10 +672,12 @@ async function colorPipeline(
     }
     run.progress(1)
   } else {
-    // Stacked: each layer covers itself plus all layers above, so lower shapes
-    // extend underneath and edges cannot crack. The most connective color — the
-    // one whose regions have the largest total perimeter, i.e. that borders the
-    // most other regions — is pinned to the bottom as the full-silhouette base,
+    // Stacked: each layer covers itself plus the sheets above that its own
+    // color actually reaches, so lower shapes extend underneath their neighbours
+    // and edges cannot crack — without dragging in far regions already covered
+    // by their own sheets (see the per-layer flood below). The most connective
+    // color — the one whose regions have the largest total perimeter, i.e. that
+    // borders the most other regions — is pinned to the bottom as the base,
     // so it reads as the outline/backdrop showing between the colors stacked on
     // top: the standard layered-vinyl build (a cartoon's black outline, a flat
     // design's background). A thin outline threading between regions outscores a
@@ -739,32 +741,84 @@ async function colorPipeline(
       if (l >= 0) bucket[cursor[l]++] = p
     }
 
-    const layerMask: BinaryMask = {
+    const unionMask: BinaryMask = {
       width: labels.width,
       height: labels.height,
       data: new Uint8Array(nPix),
     }
-    const data = layerMask.data
-    // Layer 0 is every labeled pixel (all layers stacked); higher layers peel off.
-    for (let p = 0; p < nPix; p++) data[p] = stackData[p] >= 0 ? 1 : 0
+    const union = unionMask.data
+    // Layer 0's union is every labeled pixel (all layers stacked); higher layers
+    // peel off. The union is only the running membership test for the flood
+    // below — it is never traced directly.
+    for (let p = 0; p < nPix; p++) union[p] = stackData[p] >= 0 ? 1 : 0
+
+    // A lower layer extends under the sheets above it so their shared edges
+    // cannot crack — but only where its own color actually reaches. The raw
+    // union also drags in far regions that sit entirely above this layer and
+    // are already fully covered by their own sheets: redundant underlay this
+    // layer's color never touches, so it backs none of this layer's seams and
+    // only adds area to weed. Keep just the union components the layer's own
+    // color reaches — flood 4-connected from its pixels through the union — so
+    // those disconnected islands drop out of the cut. The region directly below
+    // a dropped island still backs it, so no seam is lost; and the base, whose
+    // color threads the whole silhouette, still floods to one full solid.
+    const cutMask: BinaryMask = {
+      width: labels.width,
+      height: labels.height,
+      data: new Uint8Array(nPix),
+    }
+    const cut = cutMask.data
+    const flood = new Int32Array(nPix)
+    const w = labels.width
 
     // Progress splits over the base layers plus the island layers on top.
     const totalLayers = order.length + islands.length
     let done = 0
     for (let i = 0; i < order.length; i++) {
-      const traced = traceMask(layerMask, {
+      const label = order[i]
+      // Seed the flood from this layer's own pixels, then grow through the
+      // union; `cut` ends up as exactly the union components its color reaches.
+      cut.fill(0)
+      let sp = 0
+      for (let k = offset[label]; k < offset[label + 1]; k++) {
+        const p = bucket[k]
+        if (cut[p] === 0) {
+          cut[p] = 1
+          flood[sp++] = p
+        }
+      }
+      while (sp > 0) {
+        const p = flood[--sp]
+        const x = p - ((p / w) | 0) * w
+        if (x > 0 && union[p - 1] === 1 && cut[p - 1] === 0) {
+          cut[p - 1] = 1
+          flood[sp++] = p - 1
+        }
+        if (x < w - 1 && union[p + 1] === 1 && cut[p + 1] === 0) {
+          cut[p + 1] = 1
+          flood[sp++] = p + 1
+        }
+        if (p >= w && union[p - w] === 1 && cut[p - w] === 0) {
+          cut[p - w] = 1
+          flood[sp++] = p - w
+        }
+        if (p < nPix - w && union[p + w] === 1 && cut[p + w] === 0) {
+          cut[p + w] = 1
+          flood[sp++] = p + w
+        }
+      }
+      const traced = traceMask(cutMask, {
         ...curveOpts,
         turnPolicy: settings.turnPolicy,
         minArea: traceMinArea,
       })
-      const fill = paletteHex[order[i]]
+      const fill = paletteHex[label]
       if (traced.length > 0 && !usedPalette.includes(fill)) usedPalette.push(fill)
       for (const shape of traced) {
         shapes.push({ commands: shape.commands, fill, fillRule: 'evenodd', layerId: i })
       }
-      // Remove this layer's own pixels so the next mask is the layers below it.
-      const label = order[i]
-      for (let k = offset[label]; k < offset[label + 1]; k++) data[bucket[k]] = 0
+      // Remove this layer's own pixels so the next union is the layers below it.
+      for (let k = offset[label]; k < offset[label + 1]; k++) union[bucket[k]] = 0
       done++
       run.progress(done / totalLayers)
       // Sequential on purpose: yields the worker event loop between layers so

--- a/packages/engine/test/pipeline.test.ts
+++ b/packages/engine/test/pipeline.test.ts
@@ -596,6 +596,62 @@ describe('stacked islands on top', () => {
   })
 })
 
+/**
+ * Two objects that share no color and no border, on a transparent field: a
+ * gray-ringed red disk on the left and a lone green square on the right, with
+ * unlabeled space between them. Nothing connects the two, so no single color
+ * legitimately backs both — the base's gray must not extend a phantom sheet
+ * under the square, the way "peaks" once buried a sun-disc underlay beneath the
+ * water at the far side of the picture.
+ */
+function twoObjects(): RasterImage {
+  const img = createRaster(80, 40) // transparent background (alpha 0)
+  const disk = (cx: number, cy: number, r: number, rgb: [number, number, number]): void => {
+    for (let y = 0; y < 40; y++) {
+      for (let x = 0; x < 80; x++) {
+        if (Math.hypot(x + 0.5 - cx, y + 0.5 - cy) <= r) setPixel(img, x, y, ...rgb)
+      }
+    }
+  }
+  disk(20, 20, 15, [140, 140, 140]) // gray ring — most bordering, becomes the base
+  disk(20, 20, 11, [200, 40, 40]) // red field enclosed by the gray
+  for (let y = 10; y < 30; y++) {
+    for (let x = 52; x < 72; x++) setPixel(img, x, y, 40, 160, 60) // lone green square
+  }
+  return img
+}
+
+describe('stacked drops redundant underlay', () => {
+  it('does not back a disconnected, fully-covered region the layer never touches', async () => {
+    const s = settings({
+      mode: 'color',
+      layering: 'stacked',
+      groupByColor: true,
+      optimizeSvg: false,
+      palette: ['#8c8c8c', '#c82828', '#28a03c'],
+    })
+    const res = await vectorize(twoObjects(), s)
+    const groups = [
+      ...res.svg.matchAll(/<g id="layer-\d+"><title>(#[0-9a-f]{6})<\/title>(.*?)<\/g>/gs),
+    ]
+    const layers = groups.map((g) => ({ color: g[1], subpaths: (g[2].match(/M/g) ?? []).length }))
+    // Three colors, three layers.
+    expect(layers.length).toBe(3)
+    // The gray ring is the most-bordering color, so it is painted first as the
+    // base — but only under the left object it actually threads. Its cut is one
+    // solid disk, not a disk plus a phantom square backing the far green.
+    expect(layers[0].color).toBe('#8c8c8c')
+    expect(layers[0].subpaths).toBe(1)
+    // Every layer is exactly its own connected blob: no layer drags in the other
+    // object as buried, seam-useless underlay. Full underlay would give five.
+    const totalSubpaths = layers.reduce((n, l) => n + l.subpaths, 0)
+    expect(totalSubpaths).toBe(3)
+    // Every color still renders, and the result is deterministic.
+    for (const hex of s.palette as string[]) expect(res.svg).toContain(hex)
+    expect((await vectorize(twoObjects(), s)).svg).toBe(res.svg)
+  })
+})
+
 describe('stage cache (E3)', () => {
   // A colorful scene so the palette/segment stages do real work worth caching.
   function scene(): RasterImage {


### PR DESCRIPTION
In stacked color mode each lower layer was traced from the full union of
every sheet above it. That dragged in far regions the layer's own color
never touches and that are already fully covered by their own sheets —
redundant underlay (e.g. the "peaks" sample buried a sun-disc patch under
the water at the far side). It backs no seam of the layer and only adds
area to weed.

Build each layer's cut mask by flooding 4-connected from the layer's own
pixels through the running union, keeping only the components its color
reaches. The neighbour underlay that prevents seam cracking is connected,
so it stays; the region directly below a dropped island still backs it, so
no seam is lost; and the base, whose color threads the whole silhouette,
still floods to one full solid. Rendered pixels are unchanged — only the
cut sheets get simpler.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BumVXbvwp7L72rLDYP8HaU