### PR TITLE
feat(web): hover, inspect and remove shapes on the preview

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -6,6 +6,7 @@ import DropZone from './components/DropZone.vue'
 import LayerPanel from './components/LayerPanel.vue'
 import PreviewViewport from './components/PreviewViewport.vue'
 import ReleaseNotes from './components/ReleaseNotes.vue'
+import RetraceDialog from './components/RetraceDialog.vue'
 import SettingsPanel from './components/SettingsPanel.vue'
 import StatsBar from './components/StatsBar.vue'
 import ToastHost from './components/ToastHost.vue'
@@ -208,6 +209,7 @@ onBeforeUnmount(() => {
       <TuneWall />
     </div>
     <ReleaseNotes v-if="releaseNotesOpen" @close="releaseNotesOpen = false" />
+    <RetraceDialog v-if="store.retraceConfirm" />
     <ToastHost />
   </div>
 </template>

--- a/apps/web/src/components/ExportBar.vue
+++ b/apps/web/src/components/ExportBar.vue
@@ -9,19 +9,19 @@ const { t } = useI18n()
 const disabled = computed(() => store.result === null)
 
 function onDownload(): void {
-  if (!store.result) return
-  downloadSvg(store.result.svg, store.exportName)
+  if (!store.displaySvg) return
+  downloadSvg(store.displaySvg, store.exportName)
 }
 
 async function onCopySvg(): Promise<void> {
-  if (!store.result) return
-  const ok = await copyText(store.result.svg)
+  if (!store.displaySvg) return
+  const ok = await copyText(store.displaySvg)
   store.notify(t(ok ? 'toasts.svgCopied' : 'toasts.clipboardUnavailable'), ok ? 'success' : 'error')
 }
 
 async function onCopyDataUri(): Promise<void> {
-  if (!store.result) return
-  const ok = await copyText(svgToDataUri(store.result.svg))
+  if (!store.displaySvg) return
+  const ok = await copyText(svgToDataUri(store.displaySvg))
   store.notify(
     t(ok ? 'toasts.dataUriCopied' : 'toasts.clipboardUnavailable'),
     ok ? 'success' : 'error',

--- a/apps/web/src/components/LayerPanel.vue
+++ b/apps/web/src/components/LayerPanel.vue
@@ -60,6 +60,16 @@ async function copyColor(color: string): Promise<void> {
   )
 }
 
+// --------------------------- Remove / restore ----------------------------
+function removeLayer(layer: Layer): void {
+  store.removeLayer(layer.key)
+  store.notify(t('toasts.layerRemoved', { hex: layer.color }), 'success')
+}
+function restoreLayers(): void {
+  store.restoreLayers()
+  store.notify(t('toasts.layersRestored'), 'info')
+}
+
 // --------------------------- Hover / highlight ---------------------------
 function hoverLayer(index: number): void {
   store.setLayerHover({ layer: index, shape: null })
@@ -181,6 +191,16 @@ const summary = computed(() => {
         <span class="lp-dot">·</span>
         {{ t('layers.summaryNodes', { count: summary.nodes }) }}
       </p>
+      <div v-if="store.removedLayers.length" class="lp-removed">
+        <span>{{
+          t(
+            'layers.removedCount',
+            { count: store.removedLayers.length },
+            store.removedLayers.length,
+          )
+        }}</span>
+        <button class="lp-restore" @click="restoreLayers">{{ t('layers.restore') }}</button>
+      </div>
     </header>
 
     <div v-if="!layers.length" class="lp-empty">
@@ -265,6 +285,24 @@ const summary = computed(() => {
             :aria-label="t('layers.copyColor', { hex: layer.color })"
             @click="copyColor(layer.color)"
           />
+
+          <button
+            class="lp-remove"
+            :title="t('layers.remove')"
+            :aria-label="t('layers.remove')"
+            @click="removeLayer(layer)"
+          >
+            <svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
+              <path
+                d="M3 4h10M6.5 4V2.8h3V4M5 4l.6 9h4.8L11 4"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.3"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
         </div>
 
         <ul v-if="expanded.has(layer.index)" class="lp-shapes">
@@ -497,6 +535,69 @@ const summary = computed(() => {
 
 .lp-swatch:hover {
   transform: scale(1.12);
+}
+
+.lp-remove {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  margin-right: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-3);
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.12s ease,
+    color 0.12s ease,
+    background 0.12s ease;
+}
+
+.lp-row:hover .lp-remove,
+.lp-remove:focus-visible {
+  opacity: 1;
+}
+
+.lp-remove:hover {
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
+/* Coarse pointers can't hover — keep the control reachable. */
+@media (hover: none) {
+  .lp-remove {
+    opacity: 1;
+  }
+}
+
+.lp-removed {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--text-3);
+}
+
+.lp-restore {
+  border: none;
+  background: transparent;
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.lp-restore:hover {
+  text-decoration: underline;
 }
 
 .lp-shapes {

--- a/apps/web/src/components/PreviewViewport.vue
+++ b/apps/web/src/components/PreviewViewport.vue
@@ -4,7 +4,9 @@ import type { RasterImage } from '@trazor/core'
 import type { SvgElementKind, SvgGeometry } from '@trazor/svg'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { copyText } from '../lib/download'
 import { formatCount } from '../lib/format'
+import type { Layer } from '../lib/layers'
 import { SHAPE_KIND_TOKEN } from '../lib/overlay'
 import { useAppStore } from '../store/appStore'
 import PreviewOverlay from './PreviewOverlay.vue'
@@ -292,7 +294,19 @@ function onPointerUp(event: PointerEvent): void {
   const finished = drag
   drag = null
   panning.value = false
-  if (finished.divider || finished.moved || finished.pointLabel === null) return
+  if (finished.divider) {
+    pressedLayer = null
+    return
+  }
+  // A non-drag left click that landed on a traced shape opens its menu (normal
+  // mode only — magic mode never arms `pressedLayer`).
+  if (!finished.moved && event.button === 0 && pressedLayer !== null) {
+    openShapeMenu(event.clientX, event.clientY, pressedLayer)
+    pressedLayer = null
+    return
+  }
+  pressedLayer = null
+  if (finished.moved || finished.pointLabel === null) return
   const img = image.value
   if (!img || !docW.value) return
   const { x, y } = hostPos(event)
@@ -325,6 +339,105 @@ const markers = computed(() => {
     keep: p.label === 1,
   }))
 })
+
+// --------------------------- Shape interaction ---------------------------
+// A transparent hit path per color layer, laid over the SVG so hovering a shape
+// highlights it (driving the same `layerFocus` the layer panel uses — hover is
+// bidirectional), a tooltip reads out its info, and a click opens a small menu.
+// Disabled while magic-select owns the pointer.
+const shapeLayers = computed<Layer[]>(() => store.layerModel?.layers ?? [])
+const shapesInteractive = computed(
+  () => showSvg.value && !store.magicActive && shapeLayers.value.length > 0,
+)
+
+// The layer whose hit path received the pointerdown; read on pointerup to decide
+// whether a click (no drag) should open that layer's menu.
+let pressedLayer: number | null = null
+
+// Hover tooltip and click menu, both positioned in screen space at the cursor.
+const tip = ref<{ x: number; y: number; index: number } | null>(null)
+const menu = ref<{ x: number; y: number; index: number } | null>(null)
+
+const tipLayer = computed<Layer | null>(() =>
+  tip.value ? (shapeLayers.value[tip.value.index] ?? null) : null,
+)
+const menuLayer = computed<Layer | null>(() =>
+  menu.value ? (shapeLayers.value[menu.value.index] ?? null) : null,
+)
+
+function onShapeEnter(event: PointerEvent, index: number): void {
+  store.setLayerHover({ layer: index, shape: null })
+  tip.value = { x: event.clientX, y: event.clientY, index }
+}
+function onShapeMove(event: PointerEvent, index: number): void {
+  if (tip.value) {
+    tip.value = { x: event.clientX, y: event.clientY, index }
+  }
+}
+function onShapeLeave(index: number): void {
+  if (store.layerHover?.layer === index) store.setLayerHover(null)
+  if (tip.value?.index === index) tip.value = null
+}
+function onShapeDown(index: number): void {
+  pressedLayer = index
+}
+
+function openShapeMenu(x: number, y: number, index: number): void {
+  tip.value = null
+  store.setLayerHover(null)
+  menu.value = { x, y, index }
+}
+function closeShapeMenu(): void {
+  menu.value = null
+}
+
+function removeMenuLayer(): void {
+  const layer = menuLayer.value
+  if (!layer) return
+  store.removeLayer(layer.key)
+  store.notify(t('toasts.layerRemoved', { hex: layer.color }), 'success')
+  closeShapeMenu()
+}
+async function copyMenuColor(): Promise<void> {
+  const layer = menuLayer.value
+  if (!layer) return
+  const ok = await copyText(layer.color)
+  store.notify(
+    ok ? t('toasts.hexCopied', { hex: layer.color }) : t('toasts.clipboardUnavailable'),
+    ok ? 'success' : 'error',
+  )
+  closeShapeMenu()
+}
+
+// Clamp the floating tooltip/menu into the viewport (rough sizes; exact width is
+// content-driven but this keeps them off the edges).
+function clampedStyle(x: number, y: number, w: number, h: number): Record<string, string> {
+  return {
+    left: `${Math.min(x + 14, window.innerWidth - w)}px`,
+    top: `${Math.min(y + 16, window.innerHeight - h)}px`,
+  }
+}
+const tipStyle = computed(() => (tip.value ? clampedStyle(tip.value.x, tip.value.y, 190, 64) : {}))
+const menuStyle = computed(() =>
+  menu.value ? clampedStyle(menu.value.x, menu.value.y, 190, 120) : {},
+)
+
+// Tear down transient UI when interaction goes away (view change, magic mode, a
+// fresh trace that empties the layer model).
+watch(shapesInteractive, (on) => {
+  if (!on) {
+    tip.value = null
+    menu.value = null
+    pressedLayer = null
+  }
+})
+
+function onWindowKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape' && menu.value) {
+    event.stopPropagation()
+    closeShapeMenu()
+  }
+}
 
 // ------------------------------- Drawing ---------------------------------
 function drawRaster(canvas: HTMLCanvasElement | null, raster: RasterImage | null): void {
@@ -369,11 +482,15 @@ onMounted(() => {
   })
   if (paneEl.value) resizeObserver.observe(paneEl.value)
   if (docW.value) fit()
+  // Capture phase so Escape closes the shape menu before the app's global
+  // shortcut handler sees it.
+  window.addEventListener('keydown', onWindowKeydown, true)
 })
 
 onBeforeUnmount(() => {
   resizeObserver?.disconnect()
   resizeObserver = null
+  window.removeEventListener('keydown', onWindowKeydown, true)
 })
 
 const progressLabel = computed(() => {
@@ -509,7 +626,7 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut, toggleNodes })
           v-show="showSvg"
           class="layer layer-svg"
           :style="svgLayerStyle"
-          v-html="store.result?.svg ?? ''"
+          v-html="store.displaySvg ?? ''"
         />
         <svg
           v-if="showSvg && focus"
@@ -549,6 +666,29 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut, toggleNodes })
             stroke-linecap="round"
           />
         </svg>
+        <!-- Interactive hit layer: one transparent path per color layer, over the
+             SVG. Hover highlights the layer (and its panel row); click opens its
+             menu. `pointer-events` live on the paths so gaps fall through. -->
+        <svg
+          v-if="shapesInteractive"
+          class="layer layer-hit"
+          :viewBox="`0 0 ${docW} ${docH}`"
+          preserveAspectRatio="none"
+          :style="svgLayerStyle"
+        >
+          <path
+            v-for="layer in shapeLayers"
+            :key="layer.key"
+            :d="layer.d"
+            fill-rule="evenodd"
+            :class="{ 'hit-stroke': layer.stroke }"
+            @pointerenter="onShapeEnter($event, layer.index)"
+            @pointermove="onShapeMove($event, layer.index)"
+            @pointerleave="onShapeLeave(layer.index)"
+            @pointerdown="onShapeDown(layer.index)"
+          />
+        </svg>
+
         <canvas v-show="showDiff" ref="diffCanvas" class="layer layer-diff pixelated" />
 
         <!-- Magic-select markers -->
@@ -626,6 +766,60 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut, toggleNodes })
         </button>
       </div>
     </div>
+
+    <!-- Hover tooltip: the same info the layer panel shows for a color. -->
+    <Teleport to="body">
+      <div v-if="tipLayer && !menu" class="shape-tip card" :style="tipStyle">
+        <span class="shape-tip-swatch" :style="{ background: tipLayer.color }" />
+        <span class="shape-tip-body">
+          <span class="mono shape-tip-hex">{{ tipLayer.color }}</span>
+          <span class="shape-tip-counts">
+            {{
+              t('layers.shapesNodes', {
+                shapes: formatCount(tipLayer.shapes.length),
+                nodes: formatCount(tipLayer.nodeCount),
+              })
+            }}
+          </span>
+        </span>
+      </div>
+    </Teleport>
+
+    <!-- Click menu on a shape: remove or copy its color. -->
+    <Teleport to="body">
+      <div v-if="menuLayer" class="shape-menu-backdrop" @pointerdown="closeShapeMenu" />
+      <div v-if="menuLayer" class="shape-menu card" :style="menuStyle">
+        <div class="shape-menu-head">
+          <span class="shape-tip-swatch" :style="{ background: menuLayer.color }" />
+          <span class="mono shape-tip-hex">{{ menuLayer.color }}</span>
+        </div>
+        <button class="shape-menu-item shape-menu-danger" @click="removeMenuLayer">
+          <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+            <path
+              d="M3 4h10M6.5 4V2.8h3V4M5 4l.6 9h4.8L11 4"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.3"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          {{ t('layers.remove') }}
+        </button>
+        <button class="shape-menu-item" @click="copyMenuColor">
+          <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+            <path
+              d="M5.5 5.5V3.5h7v7h-2M3.5 5.5h7v7h-7z"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.3"
+              stroke-linejoin="round"
+            />
+          </svg>
+          {{ t('layers.copyColor', { hex: menuLayer.color }) }}
+        </button>
+      </div>
+    </Teleport>
   </div>
 </template>
 
@@ -830,6 +1024,27 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut, toggleNodes })
   opacity: 0.95;
 }
 
+/* Interactive hit layer: transparent paths that catch hover/click per color. */
+.layer-hit {
+  z-index: 2;
+  pointer-events: none;
+  cursor: pointer;
+}
+
+.layer-hit path {
+  fill: transparent;
+  pointer-events: fill;
+}
+
+/* Centerline (stroke-only) layers have no fill area — give them a fat,
+   zoom-independent transparent stroke so the thin line is still grabbable. */
+.layer-hit path.hit-stroke {
+  stroke: transparent;
+  stroke-width: 8;
+  vector-effect: non-scaling-stroke;
+  pointer-events: stroke;
+}
+
 .marker {
   position: absolute;
   width: 16px;
@@ -983,5 +1198,105 @@ defineExpose({ setView, fit, zoom100, zoomIn, zoomOut, toggleNodes })
   font-size: 12px;
   color: var(--text-2);
   word-break: break-word;
+}
+
+/* Shape hover tooltip — follows the cursor, reads out the color's counts. */
+.shape-tip {
+  position: fixed;
+  z-index: 61;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 9px;
+  box-shadow: var(--shadow-2);
+  pointer-events: none;
+}
+
+.shape-tip-swatch {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.28);
+}
+
+.shape-tip-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.shape-tip-hex {
+  font-size: 12px;
+  color: var(--text-1);
+  text-transform: uppercase;
+}
+
+.shape-tip-counts {
+  font-size: 10.5px;
+  color: var(--text-3);
+}
+
+/* Shape click menu — remove / copy color. */
+.shape-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 62;
+}
+
+.shape-menu {
+  position: fixed;
+  z-index: 63;
+  min-width: 168px;
+  padding: 5px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  box-shadow: var(--shadow-2);
+}
+
+.shape-menu-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 7px 6px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 3px;
+}
+
+.shape-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 8px;
+  border: none;
+  background: transparent;
+  border-radius: 5px;
+  color: var(--text-1);
+  font-size: 12.5px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.shape-menu-item:hover {
+  background: var(--bg-2);
+}
+
+.shape-menu-item svg {
+  flex: 0 0 auto;
+  color: var(--text-3);
+}
+
+.shape-menu-danger {
+  color: var(--danger);
+}
+
+.shape-menu-danger svg {
+  color: var(--danger);
+}
+
+.shape-menu-danger:hover {
+  background: var(--danger-soft);
 }
 </style>

--- a/apps/web/src/components/RetraceDialog.vue
+++ b/apps/web/src/components/RetraceDialog.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAppStore } from '../store/appStore'
+
+/**
+ * Confirmation shown when a re-trace is about to run while the user has removed
+ * color layers. A re-trace rebuilds the geometry from scratch, so those edits
+ * would be lost — confirm discards them and re-traces; cancel keeps the current
+ * result untouched.
+ */
+
+const store = useAppStore()
+const { t } = useI18n()
+
+function onKeyDown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    store.cancelRetrace()
+  }
+}
+
+onMounted(() => window.addEventListener('keydown', onKeyDown))
+onBeforeUnmount(() => window.removeEventListener('keydown', onKeyDown))
+</script>
+
+<template>
+  <div class="rt-backdrop" @click.self="store.cancelRetrace()">
+    <div class="rt-modal card" role="alertdialog" aria-modal="true" aria-labelledby="rt-title">
+      <h2 id="rt-title" class="rt-title">{{ t('retrace.title') }}</h2>
+      <p class="rt-body">
+        {{ t('retrace.body', { count: store.removedLayers.length }, store.removedLayers.length) }}
+      </p>
+      <div class="rt-actions">
+        <button class="btn btn-ghost" @click="store.cancelRetrace()">
+          {{ t('retrace.cancel') }}
+        </button>
+        <button class="btn btn-primary" @click="store.confirmRetrace()">
+          {{ t('retrace.confirm') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.rt-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 210;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(2px);
+}
+
+.rt-modal {
+  width: 100%;
+  max-width: 380px;
+  padding: 20px;
+  box-shadow: var(--shadow-2);
+}
+
+.rt-title {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-1);
+}
+
+.rt-body {
+  margin: 0 0 18px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-2);
+}
+
+.rt-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+</style>

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -442,6 +442,13 @@ export const en = {
     removedCount: '{count} layer removed | {count} layers removed',
   },
 
+  retrace: {
+    title: 'Re-trace image?',
+    body: "You've removed {count} layer. Re-tracing will discard that edit and bring every color back. | You've removed {count} layers. Re-tracing will discard those edits and bring every color back.",
+    confirm: 'Re-trace',
+    cancel: 'Keep my layers',
+  },
+
   tune: {
     open: 'Auto-optimize',
     openTitle: 'Search for the best settings for this image and your priorities',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -437,6 +437,9 @@ export const en = {
     contour: 'Contour {index}',
     shapesNodes: '{shapes} shapes · {nodes} nodes',
     contourNodes: 'Contour {index} · {nodes} nodes',
+    remove: 'Remove layer',
+    restore: 'Restore',
+    removedCount: '{count} layer removed | {count} layers removed',
   },
 
   tune: {
@@ -719,6 +722,8 @@ export const en = {
     modelCacheCleared: 'Model cache cleared',
     modelCacheFailed: 'Could not clear the model cache: {error}',
     hexCopied: '{hex} copied',
+    layerRemoved: '{hex} layer removed',
+    layersRestored: 'Removed layers restored',
     clipboardUnavailable: 'Clipboard unavailable',
     svgCopied: 'SVG markup copied',
     dataUriCopied: 'Data URI copied',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -456,6 +456,13 @@ export const fr: MessageSchema = {
     removedCount: '{count} calque supprimé | {count} calques supprimés',
   },
 
+  retrace: {
+    title: "Revectoriser l'image ?",
+    body: 'Vous avez supprimé {count} calque. La revectorisation annulera cette modification et rétablira toutes les couleurs. | Vous avez supprimé {count} calques. La revectorisation annulera ces modifications et rétablira toutes les couleurs.',
+    confirm: 'Revectoriser',
+    cancel: 'Conserver mes calques',
+  },
+
   tune: {
     open: 'Optimisation auto',
     openTitle: 'Rechercher les meilleurs réglages pour cette image et vos priorités',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -451,6 +451,9 @@ export const fr: MessageSchema = {
     contour: 'Contour {index}',
     shapesNodes: '{shapes} formes · {nodes} nœuds',
     contourNodes: 'Contour {index} · {nodes} nœuds',
+    remove: 'Supprimer le calque',
+    restore: 'Rétablir',
+    removedCount: '{count} calque supprimé | {count} calques supprimés',
   },
 
   tune: {
@@ -741,6 +744,8 @@ export const fr: MessageSchema = {
     modelCacheCleared: 'Cache des modèles vidé',
     modelCacheFailed: 'Impossible de vider le cache des modèles : {error}',
     hexCopied: '{hex} copié',
+    layerRemoved: 'Calque {hex} supprimé',
+    layersRestored: 'Calques supprimés rétablis',
     clipboardUnavailable: 'Presse-papiers indisponible',
     svgCopied: 'Balisage SVG copié',
     dataUriCopied: 'Data URI copié',

--- a/apps/web/src/lib/layers.ts
+++ b/apps/web/src/lib/layers.ts
@@ -238,3 +238,38 @@ export function framingViewBox(
 function round(v: number): number {
   return Math.round(v * 100) / 100
 }
+
+/** Drawable elements the serializer emits — same set {@link extractGeometry} reads. */
+const DRAWABLE_RE = /<(?:path|rect|circle|ellipse|line|polyline|polygon)\b([^>]*)>/g
+
+/** Value of a quoted `name="…"` attribute in an element's attribute text. */
+function readAttr(attrs: string, name: string): string | null {
+  const m = new RegExp(`(?<![\\w-])${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`).exec(attrs)
+  if (m === null) return null
+  return m[1] ?? m[2] ?? ''
+}
+
+/** The normalized paint key an element belongs to — fill, else stroke; null when unpainted. */
+function paintKeyOfAttrs(attrs: string): string | null {
+  const fill = readAttr(attrs, 'fill')
+  if (fill !== null && fill !== 'none' && fill !== 'transparent') return normalizeKey(fill)
+  const stroke = readAttr(attrs, 'stroke')
+  if (stroke !== null && stroke !== 'none' && stroke !== 'transparent') return normalizeKey(stroke)
+  return null
+}
+
+/**
+ * Drop every drawable element whose paint (fill, else stroke) matches one of the
+ * `removed` layer keys, leaving the rest of the document — and any now-empty
+ * `<g>` wrappers — untouched. Keys are the same normalized paints
+ * {@link buildLayers} groups by, so removing a `Layer.key` removes exactly that
+ * color's shapes. String-based and DOM-free, like the rest of this module; a
+ * pass-through when nothing is removed.
+ */
+export function filterLayers(svg: string, removed: ReadonlySet<string>): string {
+  if (removed.size === 0) return svg
+  return svg.replace(DRAWABLE_RE, (full, attrs: string) => {
+    const key = paintKeyOfAttrs(attrs)
+    return key !== null && removed.has(key) ? '' : full
+  })
+}

--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -50,6 +50,16 @@ export interface ReleaseNote {
  */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    date: '2026-08-26',
+    iteration: 1,
+    kind: 'feature',
+    title: 'Hover and edit shapes right on the preview',
+    items: [
+      'Hover a color in the preview and it lights up — with its hex and shape/node counts — and the matching row in the Layers panel highlights too, so it works both ways.',
+      'Click a color in the preview for a quick menu to remove it or copy its hex, and every Layers row now has a remove button. Removed colors drop out of the preview and the exported SVG, and one tap on Restore brings them back.',
+    ],
+  },
+  {
     date: '2026-08-25',
     iteration: 1,
     kind: 'fix',

--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -57,6 +57,7 @@ export const RELEASE_NOTES: readonly ReleaseNote[] = [
     items: [
       'Hover a color in the preview and it lights up — with its hex and shape/node counts — and the matching row in the Layers panel highlights too, so it works both ways.',
       'Click a color in the preview for a quick menu to remove it or copy its hex, and every Layers row now has a remove button. Removed colors drop out of the preview and the exported SVG, and one tap on Restore brings them back.',
+      'If a new trace would discard colors you removed, Trazor now asks first — so a stray settings change never wipes your edits by surprise.',
     ],
   },
   {

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -242,6 +242,8 @@ export const useAppStore = defineStore('app', () => {
   const selectedLayer = ref<number | null>(null)
   /** Paint keys the user has hidden from the preview/export (removable, restorable). */
   const removedLayers = ref<string[]>([])
+  /** Open while a re-trace is waiting on the user to confirm discarding removed layers. */
+  const retraceConfirm = ref(false)
 
   // Non-reactive machinery
   let client: TrazorClient | null = null
@@ -342,6 +344,7 @@ export const useAppStore = defineStore('app', () => {
   function restoreLayers(): void {
     if (removedLayers.value.length === 0) return
     removedLayers.value = []
+    retraceConfirm.value = false
   }
 
   function setLayersOpen(open: boolean): void {
@@ -352,11 +355,13 @@ export const useAppStore = defineStore('app', () => {
     layersOpen.value = !layersOpen.value
   }
 
-  // A new trace invalidates layer indices — drop any hover/selection/removals.
+  // A new trace invalidates layer indices — drop any hover/selection/removals,
+  // and close a stale re-trace prompt.
   watch(result, () => {
     layerHover.value = null
     selectedLayer.value = null
     removedLayers.value = []
+    retraceConfirm.value = false
   })
 
   // ------------------------------- Toasts --------------------------------
@@ -800,18 +805,43 @@ export const useAppStore = defineStore('app', () => {
     }
   }
 
+  /**
+   * Start a trace, unless the user has removed layers — a re-trace rebuilds the
+   * geometry from scratch and would discard those edits, so pause and ask first
+   * (see {@link confirmRetrace} / {@link cancelRetrace}).
+   */
+  function startRun(): void {
+    if (removedLayers.value.length > 0) {
+      retraceConfirm.value = true
+      return
+    }
+    void doRun()
+  }
+
   /** Debounced re-vectorization trigger (used by the settings/image watcher). */
   function run(immediate = false): void {
     if (runTimer !== null) clearTimeout(runTimer)
     if (immediate) {
       runTimer = null
-      void doRun()
+      startRun()
       return
     }
     runTimer = setTimeout(() => {
       runTimer = null
-      void doRun()
+      startRun()
     }, RUN_DEBOUNCE_MS)
+  }
+
+  /** Proceed with the pending re-trace, discarding the removed layers. */
+  function confirmRetrace(): void {
+    retraceConfirm.value = false
+    removedLayers.value = []
+    void doRun()
+  }
+
+  /** Dismiss the prompt and keep the current result with its removed layers. */
+  function cancelRetrace(): void {
+    retraceConfirm.value = false
   }
 
   watch([workingImage, settings, edgePrepass], () => {
@@ -1106,6 +1136,7 @@ export const useAppStore = defineStore('app', () => {
     layerHover,
     selectedLayer,
     removedLayers,
+    retraceConfirm,
     tuneOpen,
     tuneRunning,
     tuneProgress,
@@ -1180,6 +1211,8 @@ export const useAppStore = defineStore('app', () => {
     toggleSelectedLayer,
     removeLayer,
     restoreLayers,
+    confirmRetrace,
+    cancelRetrace,
     setLayersOpen,
     toggleLayersOpen,
   }

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -37,7 +37,7 @@ import { defaultPoolSize, runAutoTune } from '../lib/tuner'
 import type { AutoTuneOptions, TuneSignal } from '../lib/tuner'
 import { DEFAULT_FREE } from '@trazor/tune'
 import type { ObjectiveId, ScoredCandidate, SeedPatch, TunableKey, TuneWeights } from '@trazor/tune'
-import { buildLayers } from '../lib/layers'
+import { buildLayers, filterLayers } from '../lib/layers'
 import type { LayerModel } from '../lib/layers'
 import { countUnseen, latestReleaseId } from '../lib/releaseNotes'
 import { getSample } from '../lib/samples'
@@ -240,6 +240,8 @@ export const useAppStore = defineStore('app', () => {
   const layerHover = ref<LayerFocus | null>(null)
   /** Pinned layer (click) — highlighted and expanded until cleared. */
   const selectedLayer = ref<number | null>(null)
+  /** Paint keys the user has hidden from the preview/export (removable, restorable). */
+  const removedLayers = ref<string[]>([])
 
   // Non-reactive machinery
   let client: TrazorClient | null = null
@@ -288,10 +290,21 @@ export const useAppStore = defineStore('app', () => {
     return `${base || 'vectorized'}.svg`
   })
 
+  // The result SVG with any user-removed color layers stripped — what the
+  // preview shows and the export writes. Everything downstream (geometry, the
+  // layer panel, highlights) reads this, so a removal propagates consistently.
+  const displaySvg = computed<string | null>(() => {
+    const res = result.value
+    if (!res) return null
+    return removedLayers.value.length > 0
+      ? filterLayers(res.svg, new Set(removedLayers.value))
+      : res.svg
+  })
+
   // Decoded result geometry, parsed once per result and shared by the layer
   // panel and the preview's complexity/highlight overlays.
   const geometry = computed<SvgGeometry | null>(() =>
-    result.value ? extractGeometry(result.value.svg) : null,
+    displaySvg.value ? extractGeometry(displaySvg.value) : null,
   )
   /** Color layers (and their contours) derived from the result. */
   const layerModel = computed<LayerModel | null>(() =>
@@ -313,6 +326,24 @@ export const useAppStore = defineStore('app', () => {
     selectedLayer.value = selectedLayer.value === index ? null : index
   }
 
+  /**
+   * Hide a color layer from the preview and export by its paint `key`. Removal
+   * renumbers the remaining layers, so any live hover/pin is dropped to avoid a
+   * stale index highlighting the wrong shape.
+   */
+  function removeLayer(key: string): void {
+    if (removedLayers.value.includes(key)) return
+    removedLayers.value = [...removedLayers.value, key]
+    layerHover.value = null
+    selectedLayer.value = null
+  }
+
+  /** Bring every removed layer back. */
+  function restoreLayers(): void {
+    if (removedLayers.value.length === 0) return
+    removedLayers.value = []
+  }
+
   function setLayersOpen(open: boolean): void {
     layersOpen.value = open
   }
@@ -321,10 +352,11 @@ export const useAppStore = defineStore('app', () => {
     layersOpen.value = !layersOpen.value
   }
 
-  // A new trace invalidates layer indices — drop any hover/selection.
+  // A new trace invalidates layer indices — drop any hover/selection/removals.
   watch(result, () => {
     layerHover.value = null
     selectedLayer.value = null
+    removedLayers.value = []
   })
 
   // ------------------------------- Toasts --------------------------------
@@ -1073,6 +1105,7 @@ export const useAppStore = defineStore('app', () => {
     layersOpen,
     layerHover,
     selectedLayer,
+    removedLayers,
     tuneOpen,
     tuneRunning,
     tuneProgress,
@@ -1093,6 +1126,7 @@ export const useAppStore = defineStore('app', () => {
     isWorkingModified,
     exportName,
     unseenReleaseCount,
+    displaySvg,
     geometry,
     layerModel,
     layerFocus,
@@ -1144,6 +1178,8 @@ export const useAppStore = defineStore('app', () => {
     setLocale,
     setLayerHover,
     toggleSelectedLayer,
+    removeLayer,
+    restoreLayers,
     setLayersOpen,
     toggleLayersOpen,
   }

--- a/apps/web/test/layers.test.ts
+++ b/apps/web/test/layers.test.ts
@@ -2,7 +2,7 @@ import { extractGeometry, serializeSvg } from '@trazor/svg'
 import type { SvgDocument } from '@trazor/svg'
 import type { PathCommand } from '@trazor/core'
 import { describe, expect, it } from 'vitest'
-import { buildLayers, framingViewBox } from '../src/lib/layers'
+import { buildLayers, filterLayers, framingViewBox } from '../src/lib/layers'
 
 const tri = (ox: number): PathCommand[] => [
   { type: 'M', x: ox, y: 0 },
@@ -82,5 +82,45 @@ describe('framingViewBox', () => {
 
   it('falls back to the full document when there are no bounds', () => {
     expect(framingViewBox(null, 30, 40)).toBe('0 0 30 40')
+  })
+})
+
+describe('filterLayers', () => {
+  it('is a pass-through when nothing is removed', () => {
+    const svg = svgFrom([{ commands: tri(0), fill: '#ff0000' }])
+    expect(filterLayers(svg, new Set())).toBe(svg)
+  })
+
+  it('drops exactly the elements whose fill matches a removed key', () => {
+    const svg = svgFrom([
+      { commands: tri(0), fill: '#ff0000' },
+      { commands: tri(6), fill: '#00ff00' },
+    ])
+    const filtered = filterLayers(svg, new Set(['#ff0000']))
+    const model = buildLayers(extractGeometry(filtered))
+    expect(model.layers).toHaveLength(1)
+    expect(model.layers[0].key).toBe('#00ff00')
+  })
+
+  it('removes a stroke-only layer by its stroke key', () => {
+    const svg = svgFrom([
+      {
+        commands: [
+          { type: 'M', x: 1, y: 1 },
+          { type: 'L', x: 8, y: 8 },
+        ],
+        stroke: '#0000ff',
+      },
+    ])
+    expect(
+      buildLayers(extractGeometry(filterLayers(svg, new Set(['#0000ff'])))).layers,
+    ).toHaveLength(0)
+  })
+
+  it('matches keys case-insensitively', () => {
+    const svg = svgFrom([{ commands: tri(0), fill: '#AABBCC' }])
+    expect(
+      buildLayers(extractGeometry(filterLayers(svg, new Set(['#aabbcc'])))).layers,
+    ).toHaveLength(0)
   })
 })


### PR DESCRIPTION
Make the preview↔layer-panel highlight bidirectional and add
on-canvas editing of color layers.

- A transparent hit layer over the traced SVG (one path per color
  layer) drives the same `layerFocus` the panel uses, so hovering a
  shape lights it up and highlights its panel row, and vice versa.
- A cursor-following tooltip reads out the hovered color's hex and
  shape/node counts — the same info the panel shows.
- Clicking a shape opens a small menu to remove the layer or copy its
  hex; every layer row also gets a remove button, with a Restore
  affordance in the panel header.
- Removed colors are stripped from the preview and the exported SVG via
  a new `filterLayers` pass and a `displaySvg` the geometry, panel and
  export all read; a fresh trace clears removals.

Adds en/fr strings, a release note, and `filterLayers` unit tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y9AW7dx5mVAC7k4etqgaBx