### PR TITLE
Fix middle artifacts on diverging (red→white→blue) gradients

### DIFF
--- a/packages/raster/src/quantize.ts
+++ b/packages/raster/src/quantize.ts
@@ -56,6 +56,76 @@ export interface QuantizeResult {
 /** Oklab distance below which `autoK` merges two centroids. */
 const MERGE_DIST = 0.03
 
+// ---- hue-flip guard (Oklab k-means labeling) ----
+// A diverging ramp (red→white→blue) crosses through neutral, where k-means
+// allocates one near-neutral cluster whose centroid keeps a small residual hue.
+// Because every near-neutral color sits close together in Oklab, that one
+// centroid becomes the nearest for near-neutral pixels of BOTH hues around the
+// crossover — so bluish-white pixels get labeled with a pinkish-white centroid,
+// painting an off-hue band across the opposite side. The guard re-labels such a
+// pixel to the nearest centroid that is instead neutral or hue-aligned, when one
+// is a comparably close match. It fires only for a pixel with a clear hue whose
+// nearest centroid is chromatic and points >45° away, so flat art (each region
+// near its own on-hue centroid) is untouched.
+/** Min squared chroma for a pixel's hue to be trusted (below ⇒ effectively neutral, left alone). */
+const HUE_GUARD_MIN_CHROMA2 = 0.018 * 0.018
+/** A centroid below this squared chroma is neutral: never a mismatch, always an acceptable target. */
+const HUE_GUARD_NEUTRAL_CHROMA2 = 0.012 * 0.012
+/** cos²(45°): hue vectors within 45° count as aligned. */
+const HUE_GUARD_MIN_COS2 = 0.5
+/** Max squared Oklab distance (ΔE 0.09) an alternative centroid may lie at to be taken. */
+const HUE_GUARD_MAX_D2 = 0.09 * 0.09
+
+/**
+ * If the nearest centroid mismatches a chromatic pixel's hue (>45°), return the
+ * nearest neutral-or-hue-aligned centroid within {@link HUE_GUARD_MAX_D2}; else
+ * return `best` unchanged. `cent` is the interleaved Oklab centroid buffer;
+ * `(la, aa, ba)` is the pixel's Oklab. A pure function of the pixel color and
+ * the centroids, so the per-color memo in {@link assignNearest} stays valid.
+ */
+function hueGuardLabel(
+  la: number,
+  aa: number,
+  ba: number,
+  best: number,
+  cent: Float32Array,
+  m: number,
+): number {
+  const pc2 = aa * aa + ba * ba
+  if (pc2 < HUE_GUARD_MIN_CHROMA2) return best // pixel effectively neutral
+  const bA = cent[best * 3 + 1]
+  const bB = cent[best * 3 + 2]
+  const bc2 = bA * bA + bB * bB
+  if (bc2 < HUE_GUARD_NEUTRAL_CHROMA2) return best // nearest centroid is neutral: no hue clash
+  const dotB = aa * bA + ba * bB
+  // Hue-aligned (angle ≤ 45°) ⇒ keep it.
+  if (dotB > 0 && dotB * dotB >= HUE_GUARD_MIN_COS2 * pc2 * bc2) return best
+  // Mismatch: re-pick the nearest neutral-or-aligned centroid within the cap.
+  let alt = -1
+  let altD2 = HUE_GUARD_MAX_D2
+  for (let c = 0, cc = 0; c < m; c++, cc += 3) {
+    if (c === best) continue
+    const cA = cent[cc + 1]
+    const cB = cent[cc + 2]
+    const cch2 = cA * cA + cB * cB
+    let ok = cch2 < HUE_GUARD_NEUTRAL_CHROMA2
+    if (!ok) {
+      const dot = aa * cA + ba * cB
+      ok = dot > 0 && dot * dot >= HUE_GUARD_MIN_COS2 * pc2 * cch2
+    }
+    if (!ok) continue
+    const dL = la - cent[cc]
+    const dA = aa - cA
+    const dB = ba - cB
+    const d2 = dL * dL + dA * dA + dB * dB
+    if (d2 < altD2) {
+      altD2 = d2
+      alt = c
+    }
+  }
+  return alt >= 0 ? alt : best
+}
+
 /**
  * Label every in-mask pixel with its nearest centroid; returns per-label pixel
  * counts. When `rgbSums` is given (length m*3) it accumulates the summed RGB
@@ -71,6 +141,7 @@ function assignNearest(
   mask: Uint8Array | null,
   n: number,
   rgbSums: Float64Array | null,
+  hueGuard: boolean,
 ): Uint32Array {
   const counts = new Uint32Array(m)
   // Memoize the nearest centroid per distinct RGB color: the label a color maps
@@ -102,6 +173,7 @@ function assignNearest(
             best = c
           }
         }
+        if (hueGuard) best = hueGuardLabel(x, y, z, best, cent, m)
         memo.set(key, best)
       }
       labelData[i] = best
@@ -200,7 +272,9 @@ export function quantize(image: RasterImage, opts: QuantizeOptions): QuantizeRes
         }
       }
       const feat = useOklab ? toOklabBuffer(image) : null
-      const counts = assignNearest(labelData, cent, m, data, feat, mask, n, null)
+      // Fixed palette is an explicit, exact "nearest of these colors" contract —
+      // no hue guard (it would silently override the user's chosen mapping).
+      const counts = assignNearest(labelData, cent, m, data, feat, mask, n, null, false)
       return {
         labels: { width, height, data: labelData, count: m },
         paletteHex,
@@ -450,7 +524,10 @@ export function quantize(image: RasterImage, opts: QuantizeOptions): QuantizeRes
   // Final pass: label every in-mask pixel by nearest centroid, accumulating
   // exact per-cluster RGB sums for the output palette.
   const rgbSums = new Float64Array(k * 3)
-  let fullCounts = assignNearest(labelData, cent, k, data, feat, mask, n, rgbSums)
+  // Hue guard on for the clustering path (Oklab only; no-op when feat is null):
+  // stops a hue-biased near-neutral centroid from claiming opposite-hue pixels
+  // across a diverging ramp's crossover.
+  let fullCounts = assignNearest(labelData, cent, k, data, feat, mask, n, rgbSums, useOklab)
 
   // Drop centroids that won zero pixels so the palette only contains used colors.
   let m = 0

--- a/packages/raster/test/quantize.test.ts
+++ b/packages/raster/test/quantize.test.ts
@@ -245,6 +245,39 @@ describe('quantize — k-means path', () => {
     expect(mismatches).toBe(0)
   })
 
+  it('does not label opposite-hue pixels across a diverging ramp (hue-flip guard)', () => {
+    // A red→white→blue horizontal ramp crosses through neutral in the middle.
+    // k-means allocates one near-neutral cluster with a small residual (pink) hue;
+    // in Oklab every near-neutral color is close, so that centroid would otherwise
+    // become the nearest for bluish-white pixels too, painting a pink band on the
+    // blue side. The guard re-labels those to a neutral/hue-aligned centroid.
+    const red = [220, 30, 40]
+    const white = [255, 255, 255]
+    const blue = [40, 60, 210]
+    const lerp = (a: number[], b: number[], t: number, i: number): number =>
+      a[i] + (b[i] - a[i]) * t
+    const img = rasterOf(240, 40, (x) => {
+      const t = x / 239
+      const c =
+        t < 0.5
+          ? [0, 1, 2].map((i) => lerp(red, white, t / 0.5, i))
+          : [0, 1, 2].map((i) => lerp(white, blue, (t - 0.5) / 0.5, i))
+      return [c[0], c[1], c[2], 255] as Rgba
+    })
+    const res = quantize(img, { ...baseOpts, k: 16, seed: 0x02f6e2b1 })
+    const pal = [...res.paletteRgb]
+    let bluishLabeledPink = 0
+    for (let i = 0; i < 240 * 40; i++) {
+      const p = i * 4
+      // A source pixel that is clearly blue (blue channel well above red)...
+      if (img.data[p + 2] <= img.data[p] + 15) continue
+      const l = res.labels.data[i]
+      // ...must not be labeled with a clearly pink/warm palette color.
+      if (pal[l * 3] > pal[l * 3 + 2] + 8) bluishLabeledPink++
+    }
+    expect(bluishLabeledPink).toBe(0)
+  })
+
   it('autoK merges centroids closer than 0.03 in Oklab', () => {
     // Six distinct colors (> k) forming two tight groups.
     const shades = [0x10, 0x12, 0x14, 0xec, 0xee, 0xf0]

--- a/packages/svg/src/primitive.ts
+++ b/packages/svg/src/primitive.ts
@@ -429,6 +429,34 @@ function detectRegularPolygon(start: Pt, ops: PathCommand[], precision: number):
   if (rMax < 3) return null
   const tol = Math.min(4, Math.max(0.8, rMax * 0.045))
 
+  // A genuine regular figure spans the same bounding box as the outline it was
+  // fit to. Reject a candidate whose extent diverges — the polar corner search
+  // can otherwise fold a thin, elongated shape into a self-intersecting star
+  // (a "bowtie") that still threads the edge-distance test.
+  const bx0 = Math.min(...pts.map((p) => p.x))
+  const bx1 = Math.max(...pts.map((p) => p.x))
+  const by0 = Math.min(...pts.map((p) => p.y))
+  const by1 = Math.max(...pts.map((p) => p.y))
+  const bboxMatches = (poly: Pt[]): boolean => {
+    let x0 = Infinity
+    let x1 = -Infinity
+    let y0 = Infinity
+    let y1 = -Infinity
+    for (const p of poly) {
+      if (p.x < x0) x0 = p.x
+      if (p.x > x1) x1 = p.x
+      if (p.y < y0) y0 = p.y
+      if (p.y > y1) y1 = p.y
+    }
+    const m = 2 * tol
+    return (
+      Math.abs(x0 - bx0) <= m &&
+      Math.abs(x1 - bx1) <= m &&
+      Math.abs(y0 - by0) <= m &&
+      Math.abs(y1 - by1) <= m
+    )
+  }
+
   // Phase from the farthest sample (a corner).
   let iMax = 0
   for (let i = 1; i < rad.length; i++) if (rad[i] > rad[iMax]) iMax = i
@@ -467,7 +495,7 @@ function detectRegularPolygon(start: Pt, ops: PathCommand[], precision: number):
       const edgeAng = Math.atan2(Math.abs(poly[1].y - poly[0].y), Math.abs(poly[1].x - poly[0].x))
       if (edgeAng < Math.PI / 12 || edgeAng > Math.PI / 2 - Math.PI / 12) continue
     }
-    if (outlineFitsEdges(pts, cx, cy, poly, vertexAngles, tol, step * 0.18)) {
+    if (bboxMatches(poly) && outlineFitsEdges(pts, cx, cy, poly, vertexAngles, tol, step * 0.18)) {
       return round({ kind: 'polygon', points: poly }, precision)
     }
   }
@@ -504,7 +532,7 @@ function detectRegularPolygon(start: Pt, ops: PathCommand[], precision: number):
         y: cy + (i % 2 === 0 ? Ro : Ri) * Math.sin(a),
       })
     }
-    if (outlineFitsEdges(pts, cx, cy, poly, vertexAngles, tol, step * 0.09)) {
+    if (bboxMatches(poly) && outlineFitsEdges(pts, cx, cy, poly, vertexAngles, tol, step * 0.09)) {
       return round({ kind: 'polygon', points: poly }, precision)
     }
   }

--- a/packages/svg/test/primitive.test.ts
+++ b/packages/svg/test/primitive.test.ts
@@ -300,6 +300,27 @@ describe('detectPrimitive — regular polygons and stars (gated)', () => {
     expect(detectPrimitive(quad, 2, true)?.kind === 'polygon').toBe(false)
   })
 
+  it('does not fit a self-intersecting star to a thin rectangle stripe', () => {
+    // As the tracer emits a stripe: it starts mid-edge and drops a midpoint anchor
+    // on every straight edge, so `detectRect` (which wants exactly four anchors)
+    // passes it to the polygon fit. The polar corner search would otherwise fold
+    // this elongated shape into a bowtie star spanning far outside its own box —
+    // the bounding-box guard rejects any such degenerate fit.
+    const stripe: PathCommand[] = [
+      { type: 'M', x: 16, y: 100 },
+      { type: 'L', x: 16, y: 0 },
+      { type: 'L', x: 19, y: 0 },
+      { type: 'L', x: 22, y: 0 },
+      { type: 'L', x: 22, y: 100 },
+      { type: 'L', x: 22, y: 200 },
+      { type: 'L', x: 19, y: 200 },
+      { type: 'L', x: 16, y: 200 },
+      { type: 'L', x: 16, y: 100 },
+      { type: 'Z' },
+    ]
+    expect(detectPrimitive(stripe, 2, true)?.kind === 'polygon').toBe(false)
+  })
+
   it('emits <polygon> and is deterministic', () => {
     const cmds = regularPolygonPath(50, 50, 30, 6, 10)
     const a = serializeSvg(primitiveDoc(cmds), {


### PR DESCRIPTION
Two independent defects made a symmetric red→white→blue gradient render a
visible seam right at its centre, even with gradient detection off.

1. Off-hue band (quantizer). A diverging ramp crosses through neutral, where
   k-means allocates a single near-neutral cluster whose centroid keeps a small
   residual hue. Because every near-neutral colour sits close together in Oklab,
   that one centroid becomes the nearest for near-neutral pixels of BOTH hues
   around the crossover, so bluish-white pixels get labelled with a pinkish-white
   centroid — a pink band on the blue side. Add a hue-flip guard to the Oklab
   k-means labeling: when the nearest centroid's hue points >45° away from a
   chromatic pixel, re-pick the nearest neutral-or-hue-aligned centroid within a
   close ΔE cap. It fires only near a hue crossover, so flat art (each region
   near its own on-hue centroid) is untouched; the fixed-palette path keeps its
   exact "nearest of these colours" contract.

2. Bowtie polygon (SVG optimizer). The tracer starts each loop mid-edge and drops
   a midpoint anchor on every straight edge, so a plain rectangle stripe reaches
   detectRegularPolygon with extra collinear anchors; its polar corner search
   then folds the thin shape into a self-intersecting star spanning far outside
   its own box, painting a horizontal "lens" across the middle under stacked +
   optimize. Reject any regular-polygon/star fit whose bounding box does not match
   the traced outline's.

Both are covered by unit tests reproducing the failing case.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018dht34RKv8GDGUgqQXouEK