### PR TITLE
Organize ML tools and clarify palette settings UI

### DIFF
--- a/apps/web/src/components/MlTools.vue
+++ b/apps/web/src/components/MlTools.vue
@@ -79,190 +79,226 @@ onMounted(() => {
     </header>
 
     <div class="ml-body">
-      <div class="tool">
-        <button
-          class="btn tool-btn"
-          :disabled="
-            !store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy || cleanupBusy
-          "
-          :title="mlReady ? t('ml.removeBgTitle') : backendBadge.title"
-          @click="store.removeBackground()"
-        >
-          <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
-            <path
-              d="M2.5 13.5 8 2.5l5.5 11"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-            <path d="M4.5 10.5h7" stroke="currentColor" stroke-width="1.5" stroke-dasharray="2 2" />
-          </svg>
-          {{ removeBusy ? t('ml.removeBgBusy') : t('ml.removeBg') }}
-        </button>
-        <div
-          v-if="removeBusy"
-          class="progress"
-          role="progressbar"
-          :aria-label="store.mlState.removeBg.phase"
-        >
-          <div
-            class="progress-fill"
-            :class="{ indeterminate: store.mlState.removeBg.progress === null }"
-            :style="
-              store.mlState.removeBg.progress !== null
-                ? { width: `${store.mlState.removeBg.progress * 100}%` }
-                : {}
-            "
-          />
-        </div>
-        <p v-if="removeBusy" class="phase">{{ store.mlState.removeBg.phase }}</p>
-      </div>
-
-      <div class="tool">
-        <button
-          class="btn tool-btn"
-          :disabled="
-            !store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy || cleanupBusy
-          "
-          :title="mlReady ? t('ml.cleanupTitle') : backendBadge.title"
-          @click="store.cleanUp()"
-        >
-          <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
-            <path
-              d="M9.5 2.5 11 5.5 14 7l-3 1.5L9.5 11.5 8 8.5 5 7l3-1.5z"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.3"
-              stroke-linejoin="round"
-            />
-            <path
-              d="M3.5 10.5 4.4 12.3 6 13l-1.6.8L3.5 15.5 2.7 13.8 1 13l1.7-.7z"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.1"
-              stroke-linejoin="round"
-              opacity="0.7"
-            />
-          </svg>
-          {{ cleanupBusy ? t('ml.cleanupBusy') : t('ml.cleanup') }}
-        </button>
-        <div
-          v-if="cleanupBusy"
-          class="progress"
-          role="progressbar"
-          :aria-label="store.mlState.cleanup.phase"
-        >
-          <div
-            class="progress-fill"
-            :class="{ indeterminate: store.mlState.cleanup.progress === null }"
-            :style="
-              store.mlState.cleanup.progress !== null
-                ? { width: `${store.mlState.cleanup.progress * 100}%` }
-                : {}
-            "
-          />
-        </div>
-        <p v-if="cleanupBusy" class="phase">{{ store.mlState.cleanup.phase }}</p>
-        <p v-else class="phase instructions">{{ t('ml.cleanupNote') }}</p>
-      </div>
-
-      <div class="tool">
-        <button
-          class="btn tool-btn"
-          :class="{ 'is-active': store.magicActive }"
-          :disabled="
-            !store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy || cleanupBusy
-          "
-          :title="mlReady ? t('ml.magicTitle') : backendBadge.title"
-          :aria-pressed="store.magicActive"
-          @click="store.toggleMagicSelect()"
-        >
-          <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
-            <path
-              d="m9.5 2 .8 2 2 .8-2 .8-.8 2-.8-2-2-.8 2-.8ZM3.5 8l.6 1.4L5.5 10l-1.4.6L3.5 12l-.6-1.4L1.5 10l1.4-.6ZM11 10.5l.5 1 1 .5-1 .5-.5 1-.5-1-1-.5 1-.5Z"
-              fill="currentColor"
-            />
-          </svg>
-          {{ store.magicActive ? t('ml.magicActive') : t('ml.magic') }}
-        </button>
-        <div
-          v-if="magicBusy"
-          class="progress"
-          role="progressbar"
-          :aria-label="store.mlState.magic.phase"
-        >
-          <div
-            class="progress-fill"
-            :class="{ indeterminate: store.mlState.magic.progress === null }"
-            :style="
-              store.mlState.magic.progress !== null
-                ? { width: `${store.mlState.magic.progress * 100}%` }
-                : {}
-            "
-          />
-        </div>
-        <p v-if="magicBusy" class="phase">{{ store.mlState.magic.phase }}</p>
-        <p v-else-if="store.magicActive" class="phase instructions">
-          {{ t('ml.magicHint') }} · <kbd>Enter</kbd> {{ t('common.apply') }} · <kbd>Esc</kbd>
-          {{ t('common.cancel') }}
+      <!-- One-shot edits: rewrite the working image once; undo with Restore. -->
+      <div class="ml-group">
+        <p class="ml-group-head">
+          <span class="ml-group-title">{{ t('ml.groupEdits') }}</span>
+          <span class="ml-group-hint">{{ t('ml.groupEditsHint') }}</span>
         </p>
+
+        <div class="tool">
+          <button
+            class="btn tool-btn"
+            :disabled="
+              !store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy || cleanupBusy
+            "
+            :title="mlReady ? t('ml.removeBgTitle') : backendBadge.title"
+            @click="store.removeBackground()"
+          >
+            <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+              <path
+                d="M2.5 13.5 8 2.5l5.5 11"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M4.5 10.5h7"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-dasharray="2 2"
+              />
+            </svg>
+            {{ removeBusy ? t('ml.removeBgBusy') : t('ml.removeBg') }}
+          </button>
+          <div
+            v-if="removeBusy"
+            class="progress"
+            role="progressbar"
+            :aria-label="store.mlState.removeBg.phase"
+          >
+            <div
+              class="progress-fill"
+              :class="{ indeterminate: store.mlState.removeBg.progress === null }"
+              :style="
+                store.mlState.removeBg.progress !== null
+                  ? { width: `${store.mlState.removeBg.progress * 100}%` }
+                  : {}
+              "
+            />
+          </div>
+          <p v-if="removeBusy" class="phase phase-row">
+            <span>{{ store.mlState.removeBg.phase }}</span>
+            <button class="btn-cancel" @click="store.cancelMlTool('removeBg')">
+              {{ t('ml.cancel') }}
+            </button>
+          </p>
+        </div>
+
+        <div class="tool">
+          <button
+            class="btn tool-btn"
+            :disabled="
+              !store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy || cleanupBusy
+            "
+            :title="mlReady ? t('ml.cleanupTitle') : backendBadge.title"
+            @click="store.cleanUp()"
+          >
+            <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+              <path
+                d="M9.5 2.5 11 5.5 14 7l-3 1.5L9.5 11.5 8 8.5 5 7l3-1.5z"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.3"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M3.5 10.5 4.4 12.3 6 13l-1.6.8L3.5 15.5 2.7 13.8 1 13l1.7-.7z"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.1"
+                stroke-linejoin="round"
+                opacity="0.7"
+              />
+            </svg>
+            {{ cleanupBusy ? t('ml.cleanupBusy') : t('ml.cleanup') }}
+          </button>
+          <div
+            v-if="cleanupBusy"
+            class="progress"
+            role="progressbar"
+            :aria-label="store.mlState.cleanup.phase"
+          >
+            <div
+              class="progress-fill"
+              :class="{ indeterminate: store.mlState.cleanup.progress === null }"
+              :style="
+                store.mlState.cleanup.progress !== null
+                  ? { width: `${store.mlState.cleanup.progress * 100}%` }
+                  : {}
+              "
+            />
+          </div>
+          <p v-if="cleanupBusy" class="phase phase-row">
+            <span>{{ store.mlState.cleanup.phase }}</span>
+            <button class="btn-cancel" @click="store.cancelMlTool('cleanup')">
+              {{ t('ml.cancel') }}
+            </button>
+          </p>
+          <p v-else class="phase instructions">{{ t('ml.cleanupNote') }}</p>
+        </div>
+
+        <div class="tool">
+          <button
+            class="btn tool-btn"
+            :class="{ 'is-active': store.magicActive }"
+            :disabled="
+              !store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy || cleanupBusy
+            "
+            :title="mlReady ? t('ml.magicTitle') : backendBadge.title"
+            :aria-pressed="store.magicActive"
+            @click="store.toggleMagicSelect()"
+          >
+            <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+              <path
+                d="m9.5 2 .8 2 2 .8-2 .8-.8 2-.8-2-2-.8 2-.8ZM3.5 8l.6 1.4L5.5 10l-1.4.6L3.5 12l-.6-1.4L1.5 10l1.4-.6ZM11 10.5l.5 1 1 .5-1 .5-.5 1-.5-1-1-.5 1-.5Z"
+                fill="currentColor"
+              />
+            </svg>
+            {{ store.magicActive ? t('ml.magicActive') : t('ml.magic') }}
+          </button>
+          <div
+            v-if="magicBusy"
+            class="progress"
+            role="progressbar"
+            :aria-label="store.mlState.magic.phase"
+          >
+            <div
+              class="progress-fill"
+              :class="{ indeterminate: store.mlState.magic.progress === null }"
+              :style="
+                store.mlState.magic.progress !== null
+                  ? { width: `${store.mlState.magic.progress * 100}%` }
+                  : {}
+              "
+            />
+          </div>
+          <p v-if="magicBusy" class="phase phase-row">
+            <span>{{ store.mlState.magic.phase }}</span>
+            <button class="btn-cancel" @click="store.cancelMlTool('magic')">
+              {{ t('ml.cancel') }}
+            </button>
+          </p>
+          <p v-else-if="store.magicActive" class="phase instructions">
+            {{ t('ml.magicHint') }} · <kbd>Enter</kbd> {{ t('common.apply') }} · <kbd>Esc</kbd>
+            {{ t('common.cancel') }}
+          </p>
+        </div>
       </div>
 
-      <div class="tool">
-        <button
-          class="btn tool-btn"
-          :class="{ 'is-active': store.edgePrepass }"
-          :disabled="
-            !store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy || cleanupBusy
-          "
-          :title="mlReady ? t('ml.edgeTitle') : backendBadge.title"
-          :aria-pressed="store.edgePrepass"
-          @click="store.setEdgePrepass(!store.edgePrepass)"
-        >
-          <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
-            <rect
-              x="2.5"
-              y="2.5"
-              width="11"
-              height="11"
-              rx="2"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.3"
-              stroke-dasharray="2 1.6"
-              opacity="0.5"
-            />
-            <path
-              d="M2.5 10.5 6 7l3 2.5L13.5 5"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.6"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-          {{ store.edgePrepass ? t('ml.edgeActive') : t('ml.edge') }}
-        </button>
-        <div
-          v-if="edgeBusy"
-          class="progress"
-          role="progressbar"
-          :aria-label="store.mlState.edge.phase"
-        >
-          <div
-            class="progress-fill"
-            :class="{ indeterminate: store.mlState.edge.progress === null }"
-            :style="
-              store.mlState.edge.progress !== null
-                ? { width: `${store.mlState.edge.progress * 100}%` }
-                : {}
+      <!-- Per-trace steps: re-run automatically on every trace (toggles). -->
+      <div class="ml-group">
+        <p class="ml-group-head">
+          <span class="ml-group-title">{{ t('ml.groupSteps') }}</span>
+          <span class="ml-group-hint">{{ t('ml.groupStepsHint') }}</span>
+        </p>
+
+        <div class="tool">
+          <button
+            class="btn tool-btn"
+            :class="{ 'is-active': store.edgePrepass }"
+            :disabled="
+              !store.hasImage || !mlReady || removeBusy || magicBusy || edgeBusy || cleanupBusy
             "
-          />
+            :title="mlReady ? t('ml.edgeTitle') : backendBadge.title"
+            :aria-pressed="store.edgePrepass"
+            @click="store.setEdgePrepass(!store.edgePrepass)"
+          >
+            <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+              <rect
+                x="2.5"
+                y="2.5"
+                width="11"
+                height="11"
+                rx="2"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.3"
+                stroke-dasharray="2 1.6"
+                opacity="0.5"
+              />
+              <path
+                d="M2.5 10.5 6 7l3 2.5L13.5 5"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            {{ store.edgePrepass ? t('ml.edgeActive') : t('ml.edge') }}
+          </button>
+          <div
+            v-if="edgeBusy"
+            class="progress"
+            role="progressbar"
+            :aria-label="store.mlState.edge.phase"
+          >
+            <div
+              class="progress-fill"
+              :class="{ indeterminate: store.mlState.edge.progress === null }"
+              :style="
+                store.mlState.edge.progress !== null
+                  ? { width: `${store.mlState.edge.progress * 100}%` }
+                  : {}
+              "
+            />
+          </div>
+          <p v-if="edgeBusy" class="phase">{{ store.mlState.edge.phase }}</p>
+          <p v-else-if="store.edgePrepass" class="phase instructions">{{ t('ml.edgeNote') }}</p>
         </div>
-        <p v-if="edgeBusy" class="phase">{{ store.mlState.edge.phase }}</p>
-        <p v-else-if="store.edgePrepass" class="phase instructions">{{ t('ml.edgeNote') }}</p>
       </div>
 
       <div class="ml-foot">
@@ -325,13 +361,66 @@ onMounted(() => {
 .ml-body {
   display: flex;
   flex-direction: column;
+  gap: 10px;
+}
+
+.ml-group {
+  display: flex;
+  flex-direction: column;
   gap: 8px;
+}
+
+.ml-group-head {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  margin: 0;
+}
+
+.ml-group-title {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-2);
+}
+
+.ml-group-hint {
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--text-3);
 }
 
 .tool {
   display: flex;
   flex-direction: column;
   gap: 5px;
+}
+
+.phase-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.btn-cancel {
+  flex: none;
+  padding: 1px 7px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-s);
+  background: transparent;
+  color: var(--text-2);
+  font-size: 10.5px;
+  cursor: pointer;
+  transition:
+    border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.btn-cancel:hover {
+  border-color: var(--danger);
+  color: var(--danger);
 }
 
 .tool-btn {

--- a/apps/web/src/components/SettingsPanel.vue
+++ b/apps/web/src/components/SettingsPanel.vue
@@ -36,6 +36,12 @@ const MODES: ReadonlyArray<{ value: VectorizeMode }> = [
 
 const fixedPalette = computed(() => s.value.palette)
 
+// Actual number of colors the last trace produced — shown against the requested
+// budget so "up to 32" never reads as "32 colors" when the image needs fewer.
+const resultColorCount = computed(() =>
+  fixedPalette.value === null ? (store.result?.palette.length ?? null) : null,
+)
+
 function isActiveSuggestion(sug: PaletteSuggestion): boolean {
   const p = fixedPalette.value
   return p !== null && p.length === sug.colors.length && p.join(',') === sug.colors.join(',')
@@ -256,7 +262,12 @@ function isActiveSuggestion(sug: PaletteSuggestion): boolean {
           >
             <span class="pal-label">{{ t('palettes.automatic') }}</span>
             <span class="pal-meta">{{
-              t('palettes.automaticMeta', { count: s.paletteSize })
+              resultColorCount !== null
+                ? t('palettes.automaticMetaResult', {
+                    count: resultColorCount,
+                    max: s.paletteSize,
+                  })
+                : t('palettes.automaticMeta', { count: s.paletteSize })
             }}</span>
           </button>
           <button
@@ -321,7 +332,15 @@ function isActiveSuggestion(sug: PaletteSuggestion): boolean {
           </button>
         </div>
 
-        <template v-if="fixedPalette === null">
+        <!-- Clustering controls belong to the Automatic palette. With a fixed
+             palette the engine maps every pixel to the chosen colors, so these
+             don't apply — the section stays but explains itself rather than
+             silently emptying. -->
+        <h3 class="sub-title">{{ t('settings.autoPaletteGroup') }}</h3>
+        <p v-if="fixedPalette !== null" class="mode-note">
+          {{ t('settings.fixedPaletteNote') }}
+        </p>
+        <template v-else>
           <SelectRow
             :label="t('settings.segmentation.label')"
             :model-value="s.segmentation"
@@ -349,28 +368,53 @@ function isActiveSuggestion(sug: PaletteSuggestion): boolean {
             :hint="t('settings.autoReduce.hint')"
             @update:model-value="set('autoPaletteSize', $event)"
           />
-          <SliderRow
-            :label="t('settings.quality.label')"
-            :model-value="s.quantizeQuality"
-            :min="1"
-            :max="10"
-            :default-value="D.quantizeQuality"
-            :hint="t('settings.quality.hint')"
-            @update:model-value="set('quantizeQuality', $event)"
-          />
-          <SelectRow
-            :label="t('settings.colorSpace.label')"
-            :model-value="s.colorSpace"
-            :options="[
-              { value: 'oklab', label: t('settings.colorSpace.oklab') },
-              { value: 'rgb', label: t('settings.colorSpace.rgb') },
-            ]"
-            :default-value="D.colorSpace"
-            :hint="t('settings.colorSpace.hint')"
-            @update:model-value="set('colorSpace', $event)"
-          />
+          <details class="advanced">
+            <summary>{{ t('panel.advanced') }}</summary>
+            <SliderRow
+              :label="t('settings.quality.label')"
+              :model-value="s.quantizeQuality"
+              :min="1"
+              :max="10"
+              :default-value="D.quantizeQuality"
+              :hint="t('settings.quality.hint')"
+              @update:model-value="set('quantizeQuality', $event)"
+            />
+            <SelectRow
+              :label="t('settings.colorSpace.label')"
+              :model-value="s.colorSpace"
+              :options="[
+                { value: 'oklab', label: t('settings.colorSpace.oklab') },
+                { value: 'rgb', label: t('settings.colorSpace.rgb') },
+              ]"
+              :default-value="D.colorSpace"
+              :hint="t('settings.colorSpace.hint')"
+              @update:model-value="set('colorSpace', $event)"
+            />
+            <SliderRow
+              :label="t('settings.dissolveBands.label')"
+              :model-value="s.dissolveBands"
+              :min="0"
+              :max="4"
+              :default-value="D.dissolveBands"
+              :zero-label="t('settings.dissolveBands.zero')"
+              :hint="t('settings.dissolveBands.hint')"
+              @update:model-value="set('dissolveBands', $event)"
+            />
+            <SliderRow
+              :label="t('settings.colorCoherence.label')"
+              :model-value="s.colorCoherence"
+              :min="0"
+              :max="1"
+              :step="0.05"
+              :default-value="D.colorCoherence"
+              :zero-label="t('settings.colorCoherence.zero')"
+              :hint="t('settings.colorCoherence.hint')"
+              @update:model-value="set('colorCoherence', $event)"
+            />
+          </details>
         </template>
 
+        <h3 class="sub-title">{{ t('settings.layersGroup') }}</h3>
         <ControlRow :label="t('settings.layering.label')" :hint="t('settings.layering.hint')">
           <div class="radio-cards">
             <button
@@ -756,6 +800,14 @@ function isActiveSuggestion(sug: PaletteSuggestion): boolean {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-3);
+}
+
+.sub-title {
+  margin: 8px 0 2px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--text-2);
 }
 
 .mode-note {

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -122,6 +122,10 @@ export const en = {
       label: 'Alpha cutoff',
       hint: 'Alpha below this counts as empty',
     },
+    autoPaletteGroup: 'Automatic palette',
+    fixedPaletteNote:
+      'Fixed palette — pixels map to the colors above, so the clustering options (segmentation, color budget, quality) don’t apply. Switch to Automatic to change them.',
+    layersGroup: 'Layers & regions',
     segmentation: {
       label: 'Segmentation',
       hint: 'How pixels become flat regions. Region growing keeps anti-aliased edges of flat art clean; global palette suits photos and gradients',
@@ -129,12 +133,22 @@ export const en = {
       regions: 'Region growing',
     },
     colors: {
-      label: 'Colors',
-      hint: 'Number of output colors',
+      label: 'Max colors',
+      hint: 'Upper limit on output colors. The trace can use fewer — simple images and Auto reduce lower it; check the palette source for the count actually used.',
     },
     autoReduce: {
       label: 'Auto reduce',
       hint: 'Merge near-duplicate colors so simple art gets fewer layers',
+    },
+    dissolveBands: {
+      label: 'Dissolve bands',
+      hint: 'Rounds of cleanup that dissolve a hairline strip of a wrong color (an anti-aliased or JPEG rim) into the region it borders. 0 is off.',
+      zero: 'off',
+    },
+    colorCoherence: {
+      label: 'Color coherence',
+      hint: 'Re-assign pixels by balancing palette distance against agreement with neighbors, so a rim mixture joins a real region instead of a wrong-colored band. 0 is off.',
+      zero: 'off',
     },
     quality: {
       label: 'Quality',
@@ -309,7 +323,8 @@ export const en = {
   palettes: {
     automatic: 'Automatic',
     automaticTitle: 'Extract the palette from the image with k-means',
-    automaticMeta: 'k-means · {count} colors',
+    automaticMeta: 'k-means · up to {count} colors',
+    automaticMetaResult: 'k-means · {count} of {max} colors',
     updating: 'updating suggestions for this image…',
     addColor: 'Add a color',
     backToAuto: '× back to automatic',
@@ -335,6 +350,11 @@ export const en = {
 
   ml: {
     title: 'Local ML tools',
+    groupEdits: 'One-shot edits',
+    groupEditsHint: 'Rewrite the image once, before tracing. Undo with Restore original.',
+    groupSteps: 'Applied every trace',
+    groupStepsHint: 'Toggles that re-run automatically on each trace.',
+    cancel: 'Cancel',
     backendDetecting: 'detecting…',
     backendDetectingTitle: 'Probing WebGPU / WASM support',
     backendIdle: 'idle',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -123,6 +123,10 @@ export const fr: MessageSchema = {
       label: 'Seuil alpha',
       hint: 'Un alpha inférieur est considéré comme vide',
     },
+    autoPaletteGroup: 'Palette automatique',
+    fixedPaletteNote:
+      'Palette fixe — les pixels sont mappés sur les couleurs ci-dessus, donc les options de clustering (segmentation, budget de couleurs, qualité) ne s’appliquent pas. Repassez en Automatique pour les modifier.',
+    layersGroup: 'Calques et régions',
     segmentation: {
       label: 'Segmentation',
       hint: 'Comment les pixels deviennent des régions plates. La croissance de régions garde nets les bords anticrénelés des dessins plats ; la palette globale convient aux photos et dégradés',
@@ -130,12 +134,22 @@ export const fr: MessageSchema = {
       regions: 'Croissance de régions',
     },
     colors: {
-      label: 'Couleurs',
-      hint: 'Nombre de couleurs en sortie',
+      label: 'Couleurs max',
+      hint: 'Limite haute du nombre de couleurs en sortie. La vectorisation peut en utiliser moins — les images simples et la réduction auto l’abaissent ; le nombre réellement utilisé est indiqué dans la source de palette.',
     },
     autoReduce: {
       label: 'Réduction auto',
       hint: 'Fusionne les couleurs quasi identiques pour réduire les calques d’un dessin simple',
+    },
+    dissolveBands: {
+      label: 'Dissoudre les bandes',
+      hint: 'Passes de nettoyage qui dissolvent une fine bande d’une couleur erronée (un liseré anticrénelé ou JPEG) dans la région voisine. 0 = désactivé.',
+      zero: 'désactivé',
+    },
+    colorCoherence: {
+      label: 'Cohérence des couleurs',
+      hint: 'Réaffecte les pixels en équilibrant la distance de palette et l’accord avec les voisins, pour qu’un mélange de bord rejoigne une vraie région au lieu de créer une bande mal colorée. 0 = désactivé.',
+      zero: 'désactivé',
     },
     quality: {
       label: 'Qualité',
@@ -310,7 +324,8 @@ export const fr: MessageSchema = {
   palettes: {
     automatic: 'Automatique',
     automaticTitle: 'Extraire la palette de l’image avec k-means',
-    automaticMeta: 'k-means · {count} couleurs',
+    automaticMeta: 'k-means · jusqu’à {count} couleurs',
+    automaticMetaResult: 'k-means · {count} sur {max} couleurs',
     updating: 'mise à jour des suggestions pour cette image…',
     addColor: 'Ajouter une couleur',
     backToAuto: '× revenir à automatique',
@@ -348,6 +363,12 @@ export const fr: MessageSchema = {
 
   ml: {
     title: 'Outils ML locaux',
+    groupEdits: 'Modifications ponctuelles',
+    groupEditsHint:
+      'Réécrivent l’image une fois, avant la vectorisation. Annulez avec Restaurer l’original.',
+    groupSteps: 'Appliqués à chaque vectorisation',
+    groupStepsHint: 'Options réexécutées automatiquement à chaque vectorisation.',
+    cancel: 'Annuler',
     backendDetecting: 'détection…',
     backendDetectingTitle: 'Test de la prise en charge WebGPU / WASM',
     backendIdle: 'inactif',

--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -53,6 +53,18 @@ export interface ReleaseNote {
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
     date: '2026-08-26',
+    iteration: 3,
+    kind: 'improvement',
+    title: 'Clearer settings and ML tools',
+    items: [
+      'The Automatic palette now shows how many colors the trace actually used, not just the limit — so "up to 32" no longer reads as 32 when the image needs fewer.',
+      'The palette controls no longer vanish when you pick a fixed palette: the clustering options are grouped under "Automatic palette" and, when a fixed palette is active, a short note explains why they don’t apply instead of leaving a gap.',
+      'The local ML tools are split into one-shot edits (remove background, clean up, magic select — they rewrite the image once) and steps applied on every trace (the edge pre-pass), and a running ML tool can now be cancelled.',
+      'Two color-cleanup options that had no control — dissolve bands and color coherence — are now reachable under the Automatic palette’s Advanced section.',
+    ],
+  },
+  {
+    date: '2026-08-26',
     iteration: 2,
     kind: 'feature',
     beta: true,

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -256,6 +256,15 @@ export const useAppStore = defineStore('app', () => {
   let runCounter = 0
   let runTimer: ReturnType<typeof setTimeout> | null = null
   let toastCounter = 0
+  // One-shot ML tools can be cancelled mid-run: each run captures a token, the
+  // Cancel action flips it, and the run checks it after every await so a
+  // superseded result is discarded and its late progress updates are ignored.
+  type MlOneShot = 'removeBg' | 'cleanup' | 'magic'
+  const mlTokens: Record<MlOneShot, { cancelled: boolean } | null> = {
+    removeBg: null,
+    cleanup: null,
+    magic: null,
+  }
   // ML instances are heavyweight; keep them outside reactivity.
   let remover: import('@trazor/ml').BackgroundRemover | null = null
   let segmenter: import('@trazor/ml').MagicSegmenter | null = null
@@ -910,27 +919,50 @@ export const useAppStore = defineStore('app', () => {
     autoOnLoad.value = on
   }
 
+  /**
+   * Cancel a running one-shot ML tool. onnxruntime inference cannot be
+   * interrupted mid-op, so this flips the run's token: the UI returns to idle at
+   * once, the model keeps computing in the background, and its result (and any
+   * late progress) is discarded instead of applied.
+   */
+  function cancelMlTool(tool: MlOneShot): void {
+    const token = mlTokens[tool]
+    if (!token) return
+    token.cancelled = true
+    mlTokens[tool] = null
+    mlState[tool] = { busy: false, progress: null, phase: '' }
+    if (tool === 'magic') cancelMagicSelect()
+  }
+
   async function removeBackground(): Promise<void> {
     const image = workingImage.value
     if (!image || mlState.removeBg.busy) return
+    const token = { cancelled: false }
+    mlTokens.removeBg = token
     mlState.removeBg = { busy: true, progress: null, phase: t('ml.phasePreparing') }
     const onProgress = (p: MlProgress): void => {
+      if (token.cancelled) return
       const info = mlPhaseInfo(p)
       mlState.removeBg = { busy: true, progress: info.progress, phase: info.phase }
     }
     try {
       const ml = await import('@trazor/ml')
+      if (token.cancelled) return
       remover ??= await ml.BackgroundRemover.create(onProgress)
+      if (token.cancelled) return
       const out = await remover.run(image, { onProgress })
-      // Only apply if the user hasn't swapped images mid-run.
-      if (workingImage.value === image) {
+      // Only apply if the run wasn't cancelled and the image hasn't been swapped.
+      if (!token.cancelled && workingImage.value === image) {
         workingImage.value = out.image
         notify(t('toasts.bgRemoved'), 'success')
       }
     } catch (e) {
-      notify(t('toasts.bgRemovedFailed', { error: errorMessage(e) }), 'error')
+      if (!token.cancelled) notify(t('toasts.bgRemovedFailed', { error: errorMessage(e) }), 'error')
     } finally {
-      mlState.removeBg = { busy: false, progress: null, phase: '' }
+      if (mlTokens.removeBg === token) {
+        mlTokens.removeBg = null
+        mlState.removeBg = { busy: false, progress: null, phase: '' }
+      }
     }
   }
 
@@ -944,28 +976,36 @@ export const useAppStore = defineStore('app', () => {
   async function cleanUp(): Promise<void> {
     const image = workingImage.value
     if (!image || mlState.cleanup.busy) return
+    const token = { cancelled: false }
+    mlTokens.cleanup = token
     mlState.cleanup = { busy: true, progress: null, phase: t('ml.phasePreparing') }
     const onProgress = (p: MlProgress): void => {
+      if (token.cancelled) return
       const info = mlPhaseInfo(p)
       mlState.cleanup = { busy: true, progress: info.progress, phase: info.phase }
     }
     try {
       const ml = await import('@trazor/ml')
+      if (token.cancelled) return
       ml.overrideModelUrl(
         'cleanup',
         new URL(`${import.meta.env.BASE_URL}models/cleanup.onnx`, location.origin).href,
       )
       cleanupModel ??= await ml.CleanupEnhancer.create({ onProgress })
+      if (token.cancelled) return
       const out = await cleanupModel.run(image, { onProgress })
-      // Only apply if the user hasn't swapped images mid-run.
-      if (workingImage.value === image) {
+      // Only apply if the run wasn't cancelled and the image hasn't been swapped.
+      if (!token.cancelled && workingImage.value === image) {
         workingImage.value = out.image
         notify(t('toasts.cleanedUp'), 'success')
       }
     } catch (e) {
-      notify(t('toasts.cleanupFailed', { error: errorMessage(e) }), 'error')
+      if (!token.cancelled) notify(t('toasts.cleanupFailed', { error: errorMessage(e) }), 'error')
     } finally {
-      mlState.cleanup = { busy: false, progress: null, phase: '' }
+      if (mlTokens.cleanup === token) {
+        mlTokens.cleanup = null
+        mlState.cleanup = { busy: false, progress: null, phase: '' }
+      }
     }
   }
 
@@ -1011,19 +1051,26 @@ export const useAppStore = defineStore('app', () => {
       cancelMagicSelect()
       return
     }
+    const token = { cancelled: false }
+    mlTokens.magic = token
     mlState.magic = { busy: true, progress: null, phase: t('ml.phasePreparing') }
     const onProgress = (p: MlProgress): void => {
+      if (token.cancelled) return
       const info = mlPhaseInfo(p)
       mlState.magic = { busy: true, progress: info.progress, phase: info.phase }
     }
     try {
       const ml = await import('@trazor/ml')
+      if (token.cancelled) return
       segmenter ??= await ml.MagicSegmenter.create(onProgress)
+      if (token.cancelled) return
       if (segmenterImage !== image) {
         await segmenter.setImage(image, onProgress)
         segmenterImage = image
       }
+      if (token.cancelled) return
       const { mask } = await segmenter.segment(magicPoints.value)
+      if (token.cancelled) return
       // Apply: zero out alpha outside the mask, keep the canvas size (no crop).
       // settings.background stays as-is: 'auto' detects the new alpha and
       // behaves like 'transparent' per the flattenImage contract.
@@ -1039,9 +1086,12 @@ export const useAppStore = defineStore('app', () => {
       }
       cancelMagicSelect()
     } catch (e) {
-      notify(t('toasts.magicFailed', { error: errorMessage(e) }), 'error')
+      if (!token.cancelled) notify(t('toasts.magicFailed', { error: errorMessage(e) }), 'error')
     } finally {
-      mlState.magic = { busy: false, progress: null, phase: '' }
+      if (mlTokens.magic === token) {
+        mlTokens.magic = null
+        mlState.magic = { busy: false, progress: null, phase: '' }
+      }
     }
   }
 
@@ -1186,6 +1236,7 @@ export const useAppStore = defineStore('app', () => {
     setAutoOnLoad,
     removeBackground,
     cleanUp,
+    cancelMlTool,
     restoreOriginal,
     toggleMagicSelect,
     cancelMagicSelect,


### PR DESCRIPTION
Reorganize the ML tools interface and improve clarity of palette-related settings to better guide users through the available options.

## Summary

This change improves the UX of the ML tools panel and settings by:
1. Grouping ML tools into logical categories with explanatory headers
2. Adding cancel buttons to long-running ML operations
3. Clarifying palette settings with better labeling and conditional UI
4. Showing actual color counts in automatic palette mode instead of just the limit

## Key Changes

**ML Tools Panel (`MlTools.vue`)**
- Split tools into two groups: "One-shot edits" (remove background, cleanup, magic select) and "Per-trace steps" (edge detection)
- Added group headers with descriptive titles and hints explaining the difference
- Added cancel buttons to progress displays for removeBg, cleanup, and magic tools
- Improved phase display layout with `phase-row` class for better alignment
- Added new `.btn-cancel` styling for cancel buttons

**Settings Panel (`SettingsPanel.vue`)**
- Added `resultColorCount` computed property to show actual colors used vs. the limit
- Updated automatic palette label from "Colors" to "Max colors" with clarified hint text
- Added conditional display showing "X of Y colors" when a trace has been run
- Grouped clustering controls under "Automatic palette" section header
- Added explanatory note when fixed palette is active, explaining why clustering options don't apply
- Moved advanced options (quality, color space, dissolve bands, color coherence) into a collapsible `<details>` element
- Added "Layers & regions" section header for layering controls

**Store (`appStore.ts`)**
- Implemented cancellation token system for one-shot ML tools (removeBg, cleanup, magic)
- Added `cancelMlTool()` function to flip cancellation tokens and reset UI state
- Updated removeBackground, cleanUp, and applyMagicSelect to check tokens after async operations
- Ensures cancelled runs don't apply results or show error toasts

**Internationalization**
- Added new translation keys for group headers and hints in both English and French
- Updated palette-related labels and hints for clarity
- Added translations for new advanced options (dissolve bands, color coherence)

## Implementation Details

- Cancellation uses a token object pattern: each run captures a token, cancellation flips its `cancelled` flag, and the run checks it after every `await` to discard superseded results
- The UI returns to idle immediately on cancel while the model continues computing in the background
- Settings now use semantic grouping with `<h3 class="sub-title">` headers to organize related controls
- Advanced options are hidden by default in a `<details>` disclosure to reduce cognitive load

https://claude.ai/code/session_01MqGMa5W8VZGQBp2FgL6452