### PR TITLE
Refactor: extract utilities, improve linting, and normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Normalize all text files to LF in the repository and on checkout, on every
+# platform. Without this, a contributor whose Git has core.autocrlf=true rewrites
+# line endings on checkout/commit, so files flip between LF and CRLF between
+# machines. Matches .editorconfig and .oxfmtrc.json (both end_of_line = lf).
+* text=auto eol=lf
+
+# Binary assets — Git must never apply text or EOL normalization to these.
+*.png binary

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -15,5 +15,25 @@
     "unicorn/no-new-array": "off",
     "import/no-cycle": "error"
   },
+  "overrides": [
+    {
+      "files": ["**/test/**", "**/*.test.ts"],
+      "rules": {
+        "unicorn/consistent-function-scoping": "off",
+        "unicorn/no-array-sort": "off",
+        "oxc/no-map-spread": "off",
+        "no-await-in-loop": "off",
+        "promise/always-return": "off"
+      }
+    },
+    {
+      "files": ["scripts/**", "docs/demos/**"],
+      "rules": {
+        "unicorn/consistent-function-scoping": "off",
+        "unicorn/no-array-sort": "off",
+        "no-await-in-loop": "off"
+      }
+    }
+  ],
   "ignorePatterns": ["**/dist/**", "**/node_modules/**", "**/generated/**", "**/*.d.ts"]
 }

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -64,6 +64,11 @@ export const i18n = createI18n({
   locale: pickInitialLocale(),
   fallbackLocale: DEFAULT_LOCALE,
   messages: { en, fr },
+  // Some hints name SVG elements literally (`<title>`, `<g>`); intlify's
+  // HTML-in-message guard flags those. Every message renders as text — a
+  // `:title` tooltip or `{{ t(...) }}` interpolation — and never through
+  // `v-html` (only the traced SVG output is), so the angle brackets are inert.
+  warnHtmlMessage: false,
 })
 
 /** Translate with the shared instance from non-component modules (e.g. the store). */

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -155,6 +155,14 @@ function mlPhaseInfo(p: MlProgress): { progress: number | null; phase: string } 
   return { progress: null, phase: t('ml.phaseRunning') }
 }
 
+/** Drop `mode` from a settings patch: the search never changes mode — that is
+ * the user's call — so seeds don't either. */
+function stripMode(patch: Partial<VectorizeSettings>): Partial<VectorizeSettings> {
+  const copy = { ...patch }
+  delete copy.mode
+  return copy
+}
+
 export const useAppStore = defineStore('app', () => {
   const persisted = loadPersisted()
 
@@ -654,13 +662,6 @@ export const useAppStore = defineStore('app', () => {
     return keys
   }
 
-  function stripMode(patch: Partial<VectorizeSettings>): Partial<VectorizeSettings> {
-    const copy = { ...patch }
-    // The search never changes mode — that is the user's call — so seeds don't either.
-    delete copy.mode
-    return copy
-  }
-
   /** Round-0 seed points: the assist recommendation and same-mode target profiles. */
   function tuneSeeds(image: RasterImage): SeedPatch[] {
     const seeds: SeedPatch[] = []
@@ -716,7 +717,7 @@ export const useAppStore = defineStore('app', () => {
       },
     }
     try {
-      const result = await runAutoTune(
+      const tuneResult = await runAutoTune(
         image,
         settings.value,
         opts,
@@ -724,9 +725,9 @@ export const useAppStore = defineStore('app', () => {
         signal,
       )
       if (tuneSignal !== signal) return
-      tuneResults.value = result.results
-      tuneBest.value = result.best
-      tuneFront.value = result.front
+      tuneResults.value = tuneResult.results
+      tuneBest.value = tuneResult.best
+      tuneFront.value = tuneResult.front
     } catch (e) {
       if (tuneSignal === signal && !signal.cancelled) tuneError.value = errorMessage(e)
     } finally {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit -p tsconfig.packages.json && npm run typecheck -w apps/web",
-    "lint": "oxlint .",
+    "lint": "oxlint --deny-warnings .",
     "lint:fix": "oxlint . --fix",
     "fmt": "oxfmt .",
     "fmt:check": "oxfmt . --check",

--- a/packages/engine/src/native.ts
+++ b/packages/engine/src/native.ts
@@ -910,7 +910,7 @@ async function colorPipeline(
         }
         for (const p of c.pixels) arr.push(p)
       }
-      const islandColors = [...byColor.keys()].sort((a, b) => a - b)
+      const islandColors = [...byColor.keys()].toSorted((a, b) => a - b)
       const islandMask: BinaryMask = {
         width: labels.width,
         height: labels.height,

--- a/packages/raster/src/resize.ts
+++ b/packages/raster/src/resize.ts
@@ -15,6 +15,11 @@ interface BoxTaps {
   stride: number
 }
 
+/** Clamp `v` to the inclusive range [0, hi]. */
+function clampTo(v: number, hi: number): number {
+  return v < 0 ? 0 : v > hi ? hi : v
+}
+
 /** Per-destination-pixel source coverage weights along one axis. */
 function buildBoxTaps(src: number, dst: number): BoxTaps {
   const scale = src / dst
@@ -140,14 +145,13 @@ export function resizeGray(image: GrayImage, width: number, height: number): Gra
   const out = new Float32Array(width * height)
   const sx = w / width
   const sy = h / height
-  const last = (v: number, hi: number): number => (v < 0 ? 0 : v > hi ? hi : v)
   for (let y = 0; y < height; y++) {
-    const fy = last((y + 0.5) * sy - 0.5, h - 1)
+    const fy = clampTo((y + 0.5) * sy - 0.5, h - 1)
     const y0 = Math.floor(fy)
     const y1 = Math.min(h - 1, y0 + 1)
     const wy = fy - y0
     for (let x = 0; x < width; x++) {
-      const fx = last((x + 0.5) * sx - 0.5, w - 1)
+      const fx = clampTo((x + 0.5) * sx - 0.5, w - 1)
       const x0 = Math.floor(fx)
       const x1 = Math.min(w - 1, x0 + 1)
       const wx = fx - x0

--- a/packages/raster/src/segment.ts
+++ b/packages/raster/src/segment.ts
@@ -370,6 +370,9 @@ function floodRegions(
   for (let p = 0; p < n; p++) {
     if (region[p] >= 0) enqueueNeighbors(p, region[p])
   }
+  // `hs` (heap size) is mutated by pop()/push() below; the linter cannot see
+  // through those closures.
+  // eslint-disable-next-line no-unmodified-loop-condition
   while (hs > 0) {
     const p = hp[0]
     const r = hr[0]
@@ -485,7 +488,7 @@ function mergeRegions(
     // Candidates ordered by ΔE, then region ids, for a deterministic sequence.
     const cand = edges
       .map(([a, b]): [number, number, number] => [a, b, meanDelta(a, b)])
-      .sort((p, q) => p[2] - q[2] || p[0] - q[0] || p[1] - q[1])
+      .toSorted((p, q) => p[2] - q[2] || p[0] - q[0] || p[1] - q[1])
     let merged = false
     for (const [a, b, d] of cand) {
       const ra = find(a)

--- a/packages/svg/src/fit.ts
+++ b/packages/svg/src/fit.ts
@@ -84,7 +84,7 @@ function jacobiEigenSymmetric(
 ): { values: number[]; vectors: number[][] } {
   const a = input.map((row) => [...row])
   const v: number[][] = Array.from({ length: n }, (_, i) =>
-    Array.from({ length: n }, (_, j) => (i === j ? 1 : 0)),
+    Array.from({ length: n }, (__, j) => (i === j ? 1 : 0)),
   )
   for (let sweep = 0; sweep < 100; sweep++) {
     let off = 0


### PR DESCRIPTION
This PR consolidates utility functions, strengthens linting rules, and establishes consistent line ending conventions across the codebase.

**Key changes:**

- **Extract utility functions to module scope**: Moved `stripMode()` from inside the store to module level in `appStore.ts`, and extracted `clampTo()` as a reusable utility in `resize.ts` to improve code organization and testability.

- **Strengthen linting configuration**: Added `.oxlintrc.json` overrides to relax rules in test files and scripts (e.g., `unicorn/consistent-function-scoping`, `no-await-in-loop`) where they're less applicable, while enabling `--deny-warnings` in the lint script to catch all issues.

- **Normalize line endings**: Added `.gitattributes` to enforce LF line endings across all platforms, preventing CRLF/LF inconsistencies between contributors.

- **Use modern array methods**: Replaced `.sort()` with `.toSorted()` in `segment.ts` and `native.ts` to use immutable array methods and align with linter preferences.

- **Fix variable shadowing**: Renamed unused parameter `_` to `__` in `fit.ts` to clarify intent and satisfy linting rules.

- **Improve i18n configuration**: Disabled `warnHtmlMessage` in i18n setup with a comment explaining that SVG element names in messages are inert text, not HTML.

- **Rename loop variable for clarity**: Changed `result` to `tuneResult` in `appStore.ts` to avoid shadowing and improve readability.

- **Add linter directive**: Added `eslint-disable-next-line` comment in `segment.ts` to document why the loop condition check is necessary despite linter concerns.

No functional changes to user-facing behavior; this is purely a code quality and maintainability improvement.

https://claude.ai/code/session_011tyQUQUFnDFt4adPcT6zvr