### PR TITLE
feat(web): add Buy Me a Coffee links and an About page

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
+import AboutDialog from './components/AboutDialog.vue'
 import AppHeader from './components/AppHeader.vue'
 import DropZone from './components/DropZone.vue'
 import LayerPanel from './components/LayerPanel.vue'
@@ -48,8 +49,9 @@ function isTypingTarget(target: EventTarget | null): boolean {
 }
 
 function onKeyDown(event: KeyboardEvent): void {
-  // The release-notes overlay owns the keyboard while it is open (it handles Escape itself).
-  if (releaseNotesOpen.value) return
+  // The release-notes and about overlays own the keyboard while open (each
+  // handles Escape itself).
+  if (releaseNotesOpen.value || store.aboutOpen) return
 
   // The auto-optimize overlay owns the keyboard while open: Escape closes it,
   // and its own inputs handle the rest.
@@ -209,6 +211,7 @@ onBeforeUnmount(() => {
       <TuneWall />
     </div>
     <ReleaseNotes v-if="releaseNotesOpen" @close="releaseNotesOpen = false" />
+    <AboutDialog v-if="store.aboutOpen" />
     <RetraceDialog v-if="store.retraceConfirm" />
     <ToastHost />
   </div>

--- a/apps/web/src/components/AboutDialog.vue
+++ b/apps/web/src/components/AboutDialog.vue
@@ -1,0 +1,350 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAppStore } from '../store/appStore'
+import BuyMeCoffee from './BuyMeCoffee.vue'
+
+const store = useAppStore()
+const { t, tm, rt } = useI18n()
+
+function close(): void {
+  store.closeAbout()
+}
+
+function onKeyDown(event: KeyboardEvent): void {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    close()
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', onKeyDown)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown)
+})
+</script>
+
+<template>
+  <div class="ab-backdrop" @click.self="close">
+    <div class="ab-modal card" role="dialog" aria-modal="true" aria-labelledby="ab-title">
+      <header class="ab-head">
+        <div class="ab-head-title">
+          <svg class="ab-glyph" viewBox="0 0 32 32" width="20" height="20" aria-hidden="true">
+            <path
+              d="M7 24C12 8 20 8 25 24"
+              fill="none"
+              stroke="var(--accent)"
+              stroke-width="2.5"
+              stroke-linecap="round"
+            />
+            <path d="M7 24 12 13M25 24 20 13" stroke="var(--text-3)" stroke-width="1.4" />
+            <circle cx="12" cy="13" r="1.8" fill="var(--text-2)" />
+            <circle cx="20" cy="13" r="1.8" fill="var(--text-2)" />
+            <rect x="4.8" y="21.8" width="4.4" height="4.4" rx="1" fill="var(--text-1)" />
+            <rect x="22.8" y="21.8" width="4.4" height="4.4" rx="1" fill="var(--text-1)" />
+          </svg>
+          <h2 id="ab-title" class="ab-title">{{ t('about.title') }}</h2>
+        </div>
+        <button
+          class="btn btn-ghost btn-icon"
+          type="button"
+          :aria-label="t('about.close')"
+          @click="close"
+        >
+          <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+            <path
+              d="M4 4l8 8M12 4l-8 8"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+            />
+          </svg>
+        </button>
+      </header>
+
+      <div class="ab-scroll">
+        <!-- Intro -->
+        <section class="ab-hero">
+          <p class="ab-lede">{{ t('about.intro') }}</p>
+          <div class="ab-tags">
+            <span class="chip chip--accent">{{ t('about.privacyTag') }}</span>
+            <span class="chip chip--success">{{ t('about.openSourceTag') }}</span>
+          </div>
+        </section>
+
+        <!-- How it works -->
+        <section class="ab-section">
+          <h3 class="ab-section-title">{{ t('about.howTitle') }}</h3>
+          <ol class="ab-steps">
+            <li v-for="(step, i) in tm('about.howSteps')" :key="i">{{ rt(step) }}</li>
+          </ol>
+        </section>
+
+        <!-- What makes it different -->
+        <section class="ab-section">
+          <h3 class="ab-section-title">{{ t('about.featuresTitle') }}</h3>
+          <ul class="ab-features">
+            <li v-for="(feature, i) in tm('about.features')" :key="i">
+              <svg class="ab-check" viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+                <path
+                  d="M3 8.5l3 3 7-7.5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+              <span>{{ rt(feature) }}</span>
+            </li>
+          </ul>
+        </section>
+
+        <!-- The maker -->
+        <section class="ab-section ab-maker">
+          <h3 class="ab-section-title">{{ t('about.makerTitle') }}</h3>
+          <p class="ab-maker-body">{{ t('about.makerBody') }}</p>
+          <div class="ab-actions">
+            <a
+              class="btn"
+              href="https://github.com/PhenX/Trazor"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <svg
+                viewBox="0 0 16 16"
+                width="14"
+                height="14"
+                aria-hidden="true"
+                fill="currentColor"
+              >
+                <path
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.42 7.42 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
+                />
+              </svg>
+              {{ t('about.viewSource') }}
+            </a>
+            <BuyMeCoffee variant="button" />
+          </div>
+        </section>
+      </div>
+
+      <footer class="ab-foot">
+        <span class="muted">{{ t('about.thanks') }}</span>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ab-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: color-mix(in srgb, var(--bg-0) 62%, transparent);
+  backdrop-filter: blur(2px);
+  animation: ab-fade 0.14s ease;
+}
+
+.ab-modal {
+  display: flex;
+  flex-direction: column;
+  width: min(560px, 100%);
+  max-height: min(720px, calc(100vh - 48px));
+  box-shadow: var(--shadow-2);
+  animation: ab-rise 0.16s ease;
+}
+
+.ab-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px 12px 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.ab-head-title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.ab-glyph {
+  flex: 0 0 auto;
+}
+
+.ab-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 650;
+  color: var(--text-1);
+}
+
+.ab-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 18px 20px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+/* Hero */
+.ab-lede {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-1);
+}
+
+.ab-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.ab-section-title {
+  margin: 0 0 10px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+/* How it works */
+.ab-steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: step;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ab-steps li {
+  counter-increment: step;
+  position: relative;
+  padding-left: 34px;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text-2);
+}
+
+.ab-steps li::before {
+  content: counter(step);
+  position: absolute;
+  left: 0;
+  top: -1px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 11.5px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Features */
+.ab-features {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ab-features li {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text-2);
+}
+
+.ab-check {
+  flex: 0 0 auto;
+  margin-top: 2px;
+  color: var(--success);
+}
+
+/* Maker */
+.ab-maker {
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-m);
+  background: var(--bg-2);
+}
+
+.ab-maker-body {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--text-2);
+}
+
+.ab-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.ab-foot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 11px 16px;
+  border-top: 1px solid var(--border);
+  font-size: 11.5px;
+}
+
+@keyframes ab-fade {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes ab-rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+
+@media (max-width: 560px) {
+  .ab-backdrop {
+    padding: 0;
+    align-items: stretch;
+  }
+
+  .ab-modal {
+    width: 100%;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+
+  .ab-scroll {
+    padding: 16px 16px 8px;
+  }
+}
+</style>

--- a/apps/web/src/components/AppHeader.vue
+++ b/apps/web/src/components/AppHeader.vue
@@ -130,6 +130,24 @@ function onLocaleChange(event: Event): void {
       </button>
       <button
         class="btn btn-ghost btn-icon"
+        :title="t('about.openTitle')"
+        :aria-label="t('about.open')"
+        @click="store.openAbout()"
+      >
+        <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+          <circle cx="8" cy="8" r="6.4" fill="none" stroke="currentColor" stroke-width="1.4" />
+          <path
+            d="M8 7.2v4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+          <circle cx="8" cy="4.9" r="0.95" fill="currentColor" />
+        </svg>
+      </button>
+      <button
+        class="btn btn-ghost btn-icon"
         :title="store.theme === 'dark' ? t('header.toLight') : t('header.toDark')"
         :aria-label="store.theme === 'dark' ? t('header.toLight') : t('header.toDark')"
         @click="store.toggleTheme()"

--- a/apps/web/src/components/BuyMeCoffee.vue
+++ b/apps/web/src/components/BuyMeCoffee.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+// The maker's Buy Me a Coffee page. A single external link, opened in a new tab.
+const COFFEE_URL = 'https://buymeacoffee.com/phenxdesign'
+
+// `button` is a compact pill (settings footer, dialogs); `banner` is a wide,
+// full-width strip that also carries a short pitch (top of the landing screen).
+withDefaults(defineProps<{ variant?: 'button' | 'banner' }>(), { variant: 'button' })
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <a
+    class="bmc"
+    :class="`bmc--${variant}`"
+    :href="COFFEE_URL"
+    target="_blank"
+    rel="noopener noreferrer"
+    :title="t('support.coffeeTitle')"
+  >
+    <span v-if="variant === 'banner'" class="bmc-pitch">{{ t('support.pitch') }}</span>
+    <span class="bmc-cta">
+      <svg class="bmc-cup" viewBox="0 0 24 24" width="17" height="17" aria-hidden="true">
+        <path
+          d="M3.5 8.5h13v4.5a4.5 4.5 0 0 1-4.5 4.5h-4a4.5 4.5 0 0 1-4.5-4.5V8.5Z"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.7"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M16.5 9.5h1.8a2.6 2.6 0 0 1 0 5.2h-1.3"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.7"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M6.5 2.5c-.7.9-.7 1.8 0 2.7M10 2c-.7.9-.7 1.8 0 2.7M13.5 2.5c-.7.9-.7 1.8 0 2.7"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+        />
+      </svg>
+      <span class="bmc-label">{{ t('support.coffee') }}</span>
+    </span>
+  </a>
+</template>
+
+<style scoped>
+/* Buy Me a Coffee brand yellow with near-black ink — a deliberately fixed brand
+   color (not a theme token) so the button reads the same in light and dark. */
+.bmc {
+  --bmc-yellow: #ffdd00;
+  --bmc-ink: #1a1a1a;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.bmc-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  height: 34px;
+  padding: 0 15px;
+  border-radius: 999px;
+  background: var(--bmc-yellow);
+  color: var(--bmc-ink);
+  font-size: 13px;
+  font-weight: 650;
+  white-space: nowrap;
+  box-shadow: var(--shadow-1);
+  transition:
+    filter 0.12s ease,
+    transform 0.12s ease;
+}
+
+.bmc:hover .bmc-cta {
+  filter: brightness(1.05);
+}
+
+.bmc:active .bmc-cta {
+  transform: translateY(0.5px);
+}
+
+.bmc:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 999px;
+}
+
+.bmc-cup {
+  flex: 0 0 auto;
+}
+
+/* Banner: a full-width strip pairing a short pitch with the button. */
+.bmc--banner {
+  width: 100%;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-m);
+  background: linear-gradient(
+    100deg,
+    color-mix(in srgb, var(--bmc-yellow) 14%, var(--bg-1)),
+    var(--bg-1)
+  );
+}
+
+.bmc-pitch {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text-2);
+  line-height: 1.4;
+}
+
+@media (max-width: 480px) {
+  .bmc--banner {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+    gap: 10px;
+  }
+
+  .bmc--banner .bmc-cta {
+    width: 100%;
+  }
+}
+</style>

--- a/apps/web/src/components/DropZone.vue
+++ b/apps/web/src/components/DropZone.vue
@@ -5,6 +5,7 @@ import { useI18n } from 'vue-i18n'
 import { acceptAttr } from '../lib/decode'
 import { SAMPLES } from '../lib/samples'
 import { useAppStore } from '../store/appStore'
+import BuyMeCoffee from './BuyMeCoffee.vue'
 
 const store = useAppStore()
 const { t } = useI18n()
@@ -177,6 +178,9 @@ defineExpose({ openPicker })
     <!-- Empty state -->
     <div v-if="!store.hasImage" class="empty">
       <div class="empty-inner">
+        <!-- Support banner sits at the very top of the landing screen. -->
+        <BuyMeCoffee variant="banner" />
+
         <button class="target" type="button" @click="openPicker">
           <svg viewBox="0 0 48 48" width="40" height="40" aria-hidden="true">
             <path
@@ -225,6 +229,14 @@ defineExpose({ openPicker })
             </button>
           </div>
         </div>
+
+        <footer class="empty-foot">
+          <button class="foot-link" type="button" @click="store.openAbout()">
+            {{ t('support.about') }}
+          </button>
+          <span class="foot-dot" aria-hidden="true">·</span>
+          <span class="foot-made">{{ t('support.madeBy') }}</span>
+        </footer>
       </div>
     </div>
 
@@ -326,6 +338,34 @@ defineExpose({ openPicker })
   align-items: center;
   gap: 12px;
   width: 100%;
+}
+
+/* Landing footer: About + attribution. */
+.empty-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11.5px;
+  color: var(--text-3);
+}
+
+.foot-link {
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-2);
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: color 0.12s ease;
+}
+
+.foot-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.foot-dot {
+  color: var(--text-3);
 }
 
 .samples-title {

--- a/apps/web/src/components/SettingsPanel.vue
+++ b/apps/web/src/components/SettingsPanel.vue
@@ -5,6 +5,7 @@ import type { PaletteSuggestion } from '@trazor/assist'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '../store/appStore'
+import BuyMeCoffee from './BuyMeCoffee.vue'
 import ColorRow from './controls/ColorRow.vue'
 import ControlRow from './controls/ControlRow.vue'
 import SelectRow from './controls/SelectRow.vue'
@@ -745,6 +746,14 @@ function isActiveSuggestion(sug: PaletteSuggestion): boolean {
           @update:model-value="set('detectIslands', $event)"
         />
       </section>
+
+      <!-- Support & about: credit the maker without cluttering the controls. -->
+      <footer class="panel-foot">
+        <BuyMeCoffee variant="button" />
+        <button class="link-btn" type="button" @click="store.openAbout()">
+          {{ t('support.about') }}
+        </button>
+      </footer>
     </div>
   </aside>
 </template>
@@ -1146,5 +1155,31 @@ function isActiveSuggestion(sug: PaletteSuggestion): boolean {
 
 .unit-seg {
   width: 110px;
+}
+
+/* Support & about footer, pinned to the end of the scrolling panel. */
+.panel-foot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+
+.link-btn {
+  padding: 2px 4px;
+  border: none;
+  background: transparent;
+  color: var(--text-3);
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: color 0.12s ease;
+}
+
+.link-btn:hover {
+  color: var(--accent);
+  text-decoration: underline;
 }
 </style>

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -36,6 +36,44 @@ export const en = {
     github: 'View source on GitHub',
   },
 
+  support: {
+    coffee: 'Buy me a coffee',
+    coffeeTitle: 'Support Trazor on Buy Me a Coffee',
+    pitch: 'Enjoying Trazor? It’s free and open source.',
+    madeBy: 'Made with care by PhenX',
+    about: 'About Trazor',
+  },
+
+  about: {
+    title: 'About Trazor',
+    open: 'About',
+    openTitle: 'About Trazor and its maker',
+    close: 'Close about',
+    intro:
+      'Trazor turns any raster image — a photo, logo, sketch or screenshot — into clean, editable, cuttable SVG. The whole thing runs in your browser: images are decoded, quantized and traced on your own device, and nothing is ever uploaded.',
+    privacyTag: '100% in your browser',
+    openSourceTag: 'Free & open source',
+    howTitle: 'How it works',
+    howSteps: [
+      'Drop, paste or browse for an image — or start from one of the built-in samples.',
+      'Trazor decodes it and runs the tracer in a background worker: it reduces the image to a palette, grows flat color regions, and fits smooth Bézier curves along every edge.',
+      'Shape the result with target profiles — illustration, logo, vinyl cut, pen plotter and more — and live settings, or let Auto-optimize search for the best combination.',
+      'Copy or download the finished SVG. No account, no upload, no server — it all stays on your machine.',
+    ],
+    featuresTitle: 'What makes it different',
+    features: [
+      'Private by design — nothing leaves your device, so it works offline and your artwork stays yours.',
+      'A real tracing engine — a Potrace-class curve tracer with seam-free cutout layers, centerline tracing and data-derived palettes.',
+      'Built for makers — profiles tuned for screen printing, vinyl cutting, laser engraving, pen plotting and stencils.',
+      'Optional on-device ML — background removal and click-to-segment run locally, and the studio stays fully usable without them.',
+    ],
+    makerTitle: 'About the maker',
+    makerBody:
+      'Trazor is designed and built by PhenX — an independent developer and designer. It’s free to use and open source. If it saved you time, or you’d simply like to support its development, a coffee goes a long way.',
+    viewSource: 'View source on GitHub',
+    thanks: 'Thank you for using Trazor.',
+  },
+
   dropzone: {
     title: 'Drop an image, paste, or browse',
     formats: 'PNG · JPEG · WebP · GIF · BMP · AVIF · SVG — processed locally, nothing is uploaded',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -37,6 +37,44 @@ export const fr: MessageSchema = {
     github: 'Voir le code source sur GitHub',
   },
 
+  support: {
+    coffee: 'Offrez-moi un café',
+    coffeeTitle: 'Soutenir Trazor sur Buy Me a Coffee',
+    pitch: 'Trazor vous plaît ? C’est gratuit et open source.',
+    madeBy: 'Créé avec soin par PhenX',
+    about: 'À propos de Trazor',
+  },
+
+  about: {
+    title: 'À propos de Trazor',
+    open: 'À propos',
+    openTitle: 'À propos de Trazor et de son créateur',
+    close: 'Fermer À propos',
+    intro:
+      'Trazor transforme n’importe quelle image raster — photo, logo, croquis ou capture d’écran — en SVG net, éditable et découpable. Tout se passe dans votre navigateur : les images sont décodées, quantifiées et vectorisées sur votre appareil, et rien n’est jamais envoyé.',
+    privacyTag: '100 % dans votre navigateur',
+    openSourceTag: 'Gratuit et open source',
+    howTitle: 'Comment ça marche',
+    howSteps: [
+      'Déposez, collez ou parcourez pour choisir une image — ou partez d’un des exemples intégrés.',
+      'Trazor la décode et lance le vectoriseur dans un worker d’arrière-plan : il réduit l’image à une palette, fait croître des régions de couleur plates et ajuste des courbes de Bézier lisses le long de chaque bord.',
+      'Affinez le résultat avec les profils cibles — illustration, logo, découpe vinyle, traceur à plume et plus — et les réglages en direct, ou laissez l’optimisation auto trouver la meilleure combinaison.',
+      'Copiez ou téléchargez le SVG final. Pas de compte, pas d’envoi, pas de serveur — tout reste sur votre machine.',
+    ],
+    featuresTitle: 'Ce qui le distingue',
+    features: [
+      'Privé par conception — rien ne quitte votre appareil, donc ça fonctionne hors ligne et vos créations restent les vôtres.',
+      'Un vrai moteur de vectorisation — un traceur de courbes de classe Potrace avec calques en découpe sans jointure, tracé médian et palettes dérivées des données.',
+      'Pensé pour les créateurs — des profils réglés pour la sérigraphie, la découpe vinyle, la gravure laser, le traçage à la plume et les pochoirs.',
+      'ML local optionnel — la suppression du fond et la sélection par clic s’exécutent localement, et le studio reste pleinement utilisable sans eux.',
+    ],
+    makerTitle: 'À propos du créateur',
+    makerBody:
+      'Trazor est conçu et développé par PhenX — développeur et designer indépendant. Il est gratuit et open source. S’il vous a fait gagner du temps, ou si vous souhaitez simplement soutenir son développement, un café fait toute la différence.',
+    viewSource: 'Voir le code source sur GitHub',
+    thanks: 'Merci d’utiliser Trazor.',
+  },
+
   dropzone: {
     title: 'Déposez une image, collez ou parcourez',
     formats: 'PNG · JPEG · WebP · GIF · BMP · AVIF · SVG — traité localement, rien n’est envoyé',

--- a/apps/web/src/lib/releaseNotes.ts
+++ b/apps/web/src/lib/releaseNotes.ts
@@ -52,6 +52,16 @@ export interface ReleaseNote {
  */
 export const RELEASE_NOTES: readonly ReleaseNote[] = [
   {
+    date: '2026-08-30',
+    iteration: 1,
+    kind: 'feature',
+    title: 'About page and a way to support Trazor',
+    items: [
+      'A new About page explains what Trazor is, how it traces your images entirely in your browser, and who makes it — open it from the info button in the header or the link on the landing screen.',
+      'If Trazor is useful to you, there’s now a “Buy me a coffee” link at the top of the landing screen and at the bottom of the settings panel to support its development. It stays free and open source, and nothing about how it works changes.',
+    ],
+  },
+  {
     date: '2026-08-26',
     iteration: 3,
     kind: 'improvement',

--- a/apps/web/src/store/appStore.ts
+++ b/apps/web/src/store/appStore.ts
@@ -237,6 +237,8 @@ export const useAppStore = defineStore('app', () => {
   const lastSeenRelease = ref<string | null>(persisted.lastSeenRelease ?? null)
   /** Active UI language. Persisted once chosen; auto-detected on the first visit. */
   const locale = ref<LocaleCode>(persisted.locale ?? pickInitialLocale())
+  /** Whether the About overlay is open (project & maker info). Not persisted. */
+  const aboutOpen = ref(false)
 
   // ---------------------------- Layer panel ------------------------------
   // The panel opens on the right on desktop and starts closed on mobile (a
@@ -1105,6 +1107,15 @@ export const useAppStore = defineStore('app', () => {
     lastSeenRelease.value = latestReleaseId()
   }
 
+  // ------------------------------- About ---------------------------------
+  function openAbout(): void {
+    aboutOpen.value = true
+  }
+
+  function closeAbout(): void {
+    aboutOpen.value = false
+  }
+
   // ------------------------------- Theme ---------------------------------
   function toggleTheme(): void {
     theme.value = theme.value === 'dark' ? 'light' : 'dark'
@@ -1183,6 +1194,7 @@ export const useAppStore = defineStore('app', () => {
     autoOnLoad,
     lastSeenRelease,
     locale,
+    aboutOpen,
     layersOpen,
     layerHover,
     selectedLayer,
@@ -1245,6 +1257,8 @@ export const useAppStore = defineStore('app', () => {
     undoMagicPoint,
     applyMagicSelect,
     markReleasesSeen,
+    openAbout,
+    closeAbout,
     openTune,
     closeTune,
     startTune,


### PR DESCRIPTION
Credit the maker and give people a way to support the project:

- A "Buy me a coffee" banner at the top of the landing screen and a
  compact button at the bottom of the settings panel, plus one in the
  About page — all a single reusable BuyMeCoffee component pointing at
  buymeacoffee.com/phenxdesign.
- A new About page (modal) covering what Trazor is, how it works, what
  sets it apart, and the maker, with GitHub + coffee links. Opened from
  a new header info button, the landing footer, or the settings footer.
- English and French strings for both, kept in parity, and a release
  note for the What's new panel.

Responsive across desktop and mobile, theme-aware in light and dark.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GwRGWGeLvHKboW2o3E72ti