### PR TITLE
feat(engine): stream stacked trace snapshots for the timeline

### DIFF
--- a/packages/engine/src/native.ts
+++ b/packages/engine/src/native.ts
@@ -96,6 +96,13 @@ const COHERENCE_ROUNDS = 4
 const EDGE_PROTECT_THRESHOLD = 0.5
 
 /**
+ * Most intermediate trace snapshots to stream while stacked layers accumulate, so
+ * the studio timeline can replay the shapes building up with real per-batch
+ * timing. Throttles the emit so a many-layer image does not flood the stream.
+ */
+const TRACE_SNAPSHOTS = 10
+
+/**
  * L1 RGB gradient (0..765) at or above which a pixel is treated as an
  * anti-aliased boundary and kept out of the color-clustering training sample,
  * so rim mixtures cannot claim a palette entry.
@@ -1034,6 +1041,21 @@ async function colorPipeline(
     // Progress splits over the base layers plus the island layers on top.
     const totalLayers = order.length + islands.length
     let done = 0
+    // Stream a snapshot of the shapes as they accumulate (throttled), so the
+    // timeline can replay the geometry building up. `shapes` is in push order, so
+    // its running length is all the studio needs to redraw the state at each stop.
+    const traceStride = Math.max(1, Math.ceil(totalLayers / TRACE_SNAPSHOTS))
+    const emitTraceSnapshot = (): void =>
+      run.emitStep(() => ({
+        code: 'trace',
+        label: `Trace layer ${done}/${totalLayers}`,
+        metrics: {
+          shapes: shapes.length,
+          nodes: totalNodes(shapes),
+          layer: done,
+          layersTotal: totalLayers,
+        },
+      }))
     for (let i = 0; i < order.length; i++) {
       const label = order[i]
       // Seed the flood from this layer's own pixels, then grow through the
@@ -1081,6 +1103,7 @@ async function colorPipeline(
       for (let k = offset[label]; k < offset[label + 1]; k++) union[bucket[k]] = 0
       done++
       run.progress(done / totalLayers)
+      if (run.tracing && done < totalLayers && done % traceStride === 0) emitTraceSnapshot()
       // Sequential on purpose: yields the worker event loop between layers so
       // cancel messages interleave with the computation.
       // oxlint-disable-next-line no-await-in-loop
@@ -1127,6 +1150,7 @@ async function colorPipeline(
         }
         done++
         run.progress(done / totalLayers)
+        if (run.tracing && done < totalLayers && done % traceStride === 0) emitTraceSnapshot()
         // oxlint-disable-next-line no-await-in-loop
         await run.tick()
       }

--- a/packages/engine/test/trace.test.ts
+++ b/packages/engine/test/trace.test.ts
@@ -105,6 +105,22 @@ describe('engine tracer', () => {
     expect(seg?.metrics?.colors).toBeGreaterThan(1)
   })
 
+  it('streams stacked trace snapshots with a non-decreasing shape count', async () => {
+    const steps = await trace(
+      swatches(),
+      normalizeSettings({ mode: 'color', layering: 'stacked', paletteSize: 6 }),
+    )
+    const traceSteps = steps.filter((s) => s.code === 'trace')
+    // Intermediate snapshots as the shapes build up, plus the final summary.
+    expect(traceSteps.length).toBeGreaterThan(1)
+    const counts = traceSteps.map((s) => (s.metrics?.shapes as number) ?? 0)
+    for (let i = 1; i < counts.length; i++) {
+      expect(counts[i]).toBeGreaterThanOrEqual(counts[i - 1])
+    }
+    // The final summary counts every shape the run produced.
+    expect(counts[counts.length - 1]).toBeGreaterThan(0)
+  })
+
   it('bw traces a threshold mask; centerline adds a skeleton', async () => {
     const bw = await trace(ring(), normalizeSettings({ mode: 'bw' }))
     const thr = bw.find((s) => s.code === 'threshold')


### PR DESCRIPTION
## Summary

The trace stage emitted a single `TraceStep`, so the studio's timeline inspector could neither show the geometry accumulating nor time the layering. This streams throttled trace snapshots as the stacked shapes build up, each with real per-batch timing.

## Details

- `packages/engine/src/native.ts`: in the stacked color pipeline, emit a trace snapshot at up to `TRACE_SNAPSHOTS` (10) checkpoints across the base + island layers. Each snapshot carries the running `shapes`/`nodes` counts and its emit window tiles the real per-batch layering time.
- Because `shapes` is in push order, its running length is all a consumer needs to redraw the state at each stop — **no partial SVG crosses the worker boundary**.
- Guarded by `run.tracing` and side-effect-free (no shape mutation), so an untraced run stays byte-identical and its timings are unchanged. The final "Trace & fit" summary step is unchanged.
- Cutout / B&W / centerline trace in one upfront call, so per-batch timing there wouldn't be meaningful — they keep their single trace step.

## Tests

- New: asserts stacked color streams more than one `trace` step with a non-decreasing `shapes` count.
- The existing side-effect-free test (traced SVG == untraced SVG) still passes for color, cutout, bw, and centerline.

`npm run typecheck`, `lint`, and the engine test suite are green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5hswnuAHbo4R1P4ArFEXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5hswnuAHbo4R1P4ArFEXS)_