### PR TITLE
feat(eval): A/B verdict harness + representative-corpus evaluation rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,29 @@ Do not put a model identifier anywhere in a commit message, PR title/body, or co
   circles stay near their radius, cutout regions share exact boundary anchors, output is deterministic, warnings fire.
 - Every algorithm change ships with a test that would have caught the bug it fixes.
 
+### Evaluating quality changes
+
+A change to color, palette, segmentation or the tracer is only "better" if it is **measured** better on
+**representative** images — actual illustrations, logos and photos, not clean synthetic shapes.
+
+- **Never judge a quality change on a synthetic or one-off image.** The built-in `npm run eval:corpus` set is a signal
+  generator (clean procedural shapes) and a single hand-picked image proves nothing — both routinely show a "win" that
+  vanishes on real art. Measure on the **representative corpus**: `scripts/eval/corpus-vtracer` (`npm run eval:samples`)
+  or any folder of real PNG/JPEG images passed with `--data`.
+- **Use `npm run eval:ab` for the verdict.** It traces the corpus through the engine on your working tree and on HEAD
+  and prints **PASS / MIXED / FAIL** (`scripts/eval/README.md`). A change ships only on **PASS**; a **MIXED** is a real
+  trade-off to weigh out loud with the user, and a **FAIL** does not ship. Don't hand-compare two runs by eye.
+- **Read the whole metric panel, not the mean.** Whole-image mean ΔE dilutes local damage; a change can lower the mean
+  while raising **spurious hue** (a saturated color invented at a seam). `eval:ab` judges on ΔE _and_ spurious hue for
+  exactly this reason — a better mean bought with worse spurious hue is not an improvement.
+- **Gate at the routing you actually changed.** A palette (quantize) change shows nothing on images the recommender
+  routes to region growing, and vice-versa; force the path (`--set segmentation=quantize`) or sweep a setting
+  (`--sweep segmentation=quantize,regions`, or `--sweep 6,8,12` for `paletteSize`) so the change is exercised where it
+  lives. `eval:ab` prints a per-image breakdown and a verdict per swept value — don't hand-diff two runs.
+- **Don't write throwaway eval code.** The per-image deltas and the parameter sweep are built into `eval:ab`; a quick
+  "does this function do X?" check belongs in a unit test, not a scratch script. When prototyping a new tunable you'll
+  want to sweep, thread it through `VectorizeSettings` so `--sweep` reaches it.
+
 ### Working with the user's requests
 
 - **Capture conventions.** When asked to apply a change across many files ("always do X"), add the resulting rule to

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eval:corpus": "node scripts/eval/make-corpus.mjs",
     "eval:samples": "node scripts/eval/fetch-vtracer-samples.mjs",
     "eval:tracers": "tsx scripts/eval/tracer-compare.ts",
+    "eval:ab": "node scripts/eval/ab.mjs",
     "check": "npm run lint && npm run fmt:check && npm run typecheck && npm run test"
   },
   "devDependencies": {

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -131,6 +131,47 @@ for every image instead.
 | `--montage` | off                      | also write `index.html`: source \| Trazor \| VTracer                 |
 | `--json`    | —                        | also write the report as JSON                                        |
 
+## A/B verdict — `eval:ab`
+
+`tracer-compare` measures one build; **`eval:ab` decides whether a change is an improvement.** It traces the same
+corpus through the engine twice — once on your **working tree**, once on **HEAD** (your edits stashed away) — and prints
+an explicit **PASS / MIXED / FAIL** so a quality change never ships on a diluted whole-image mean while a localized
+metric regresses. It is the guardrail for any color / palette / segmentation change ([`../../AGENTS.md`](../../AGENTS.md)
+→ _Evaluating quality changes_).
+
+```sh
+# make your edit, then:
+npm run eval:ab                                   # auto settings over corpus-vtracer
+npm run eval:ab -- --sweep 6,8,12                 # sweep paletteSize (shorthand)
+npm run eval:ab -- --sweep segmentation=quantize,regions   # sweep any setting, verdict per value
+npm run eval:ab -- --set segmentation=quantize    # force the quantize path (palette changes)
+npm run eval:ab -- --data <dir> --profile illustration
+```
+
+The verdict prints **per image** (biggest ΔE move first, so a lone regression stands out), then per
+family, then overall — no hand-diffing two runs to find which image moved. `--sweep <key>=<v1,v2,…>`
+re-runs the whole A/B at each value of any setting and prints one verdict per value; a bare `--sweep
+6,8,12` is shorthand for `paletteSize`. To sweep a tunable that is a code constant rather than a
+setting, either thread it through `VectorizeSettings` while prototyping (then `--sweep` reaches it) or
+edit the constant and re-run `eval:ab` once per value.
+
+It requires uncommitted changes (the candidate) to compare against HEAD (the baseline); because the packages export TS
+source with no build step, stashing the source and re-running is a true baseline. The verdict rests on the two metrics
+that matter most — **mean ΔE and spurious-hue** — judged per family and overall:
+
+- **PASS** — a primary metric improved and **no** family regressed. Ships.
+- **FAIL** — a primary metric (ΔE or spurious hue) regressed overall, or on two-plus families. Does **not** ship.
+- **MIXED** — a genuine trade-off (some families win, some lose). A human weighs it.
+
+`ab-report.ts` is the pure verdict engine (unit-tested in `ab-report.test.ts`) and also runs standalone on any two
+`--json` reports, however they were produced — the way to A/B two commits rather than working-tree-vs-HEAD:
+
+```sh
+git checkout main    && npm run eval:tracers -- --data scripts/eval/corpus-vtracer --json base.json
+git checkout mybranch && npm run eval:tracers -- --data scripts/eval/corpus-vtracer --json cand.json
+tsx scripts/eval/ab-report.ts base.json cand.json
+```
+
 ## The corpus
 
 `make-corpus.mjs` (`npm run eval:corpus`) writes a small, deterministic, **browser-free** image set spanning the families

--- a/scripts/eval/ab-report.test.ts
+++ b/scripts/eval/ab-report.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { type TrazorMetrics, compareReports, overallVerdict, renderReport } from './ab-report'
+
+/** Build a one-row report at a given metric level (fields not set default sane). */
+function report(rows: Array<{ family: string; image: string } & Partial<TrazorMetrics>>) {
+  return {
+    rows: rows.map((r) => ({
+      family: r.family,
+      image: r.image,
+      trazor: {
+        dE: r.dE ?? 0.02,
+        edgeDE: r.edgeDE ?? 0.03,
+        p95: r.p95 ?? 0.04,
+        spurious: r.spurious ?? 0.015,
+        nodes: r.nodes ?? 1000,
+        bytes: r.bytes ?? 10000,
+      },
+    })),
+  }
+}
+
+describe('A/B verdict', () => {
+  it('PASSes a clean win — both primaries improve, none regress', () => {
+    const base = report([{ family: 'illustration', image: 'a.png', dE: 0.02, spurious: 0.015 }])
+    const cand = report([{ family: 'illustration', image: 'a.png', dE: 0.017, spurious: 0.012 }])
+    expect(compareReports(base, cand).verdict).toBe('PASS')
+  })
+
+  it('FAILs a better mean bought with worse spurious hue (the trap this guards)', () => {
+    // Whole-image ΔE drops, but the change invents a hue at a seam — the exact
+    // case a mean-only glance would wave through.
+    const base = report([{ family: 'illustration', image: 'a.png', dE: 0.021, spurious: 0.012 }])
+    const cand = report([{ family: 'illustration', image: 'a.png', dE: 0.019, spurious: 0.016 }])
+    expect(compareReports(base, cand).verdict).toBe('FAIL')
+  })
+
+  it('FAILs when the overall mean ΔE regresses', () => {
+    const base = report([{ family: 'illustration', image: 'a.png', dE: 0.02, spurious: 0.015 }])
+    const cand = report([{ family: 'illustration', image: 'a.png', dE: 0.024, spurious: 0.015 }])
+    expect(compareReports(base, cand).verdict).toBe('FAIL')
+  })
+
+  it('FAILs when two or more families regress a primary metric', () => {
+    const base = report([
+      { family: 'illustration', image: 'a.png', dE: 0.02 },
+      { family: 'photo', image: 'b.png', spurious: 0.015 },
+    ])
+    const cand = report([
+      { family: 'illustration', image: 'a.png', dE: 0.025 },
+      { family: 'photo', image: 'b.png', spurious: 0.02 },
+    ])
+    expect(compareReports(base, cand).verdict).toBe('FAIL')
+  })
+
+  it('holds sub-noise wobble as unchanged → not a false win or loss', () => {
+    const base = report([{ family: 'illustration', image: 'a.png', dE: 0.02, spurious: 0.015 }])
+    const cand = report([
+      { family: 'illustration', image: 'a.png', dE: 0.020_05, spurious: 0.015_1 },
+    ])
+    const res = compareReports(base, cand)
+    expect(res.overall.metrics.dE.dir).toBe('held')
+    expect(res.overall.metrics.spurious.dir).toBe('held')
+    // Nothing moved → not a PASS (no improvement) and not a FAIL (no regression).
+    expect(res.verdict).toBe('MIXED')
+  })
+
+  it('matches rows by image name and ignores unpaired rows', () => {
+    const base = report([
+      { family: 'illustration', image: 'a.png', dE: 0.02 },
+      { family: 'illustration', image: 'only-in-base.png', dE: 0.01 },
+    ])
+    const cand = report([
+      { family: 'illustration', image: 'a.png', dE: 0.017 },
+      { family: 'illustration', image: 'only-in-cand.png', dE: 0.5 },
+    ])
+    const res = compareReports(base, cand)
+    expect(res.overall.n).toBe(1)
+    expect(res.perImage.map((p) => p.image)).toEqual(['a.png'])
+    expect(res.verdict).toBe('PASS')
+  })
+
+  it('renders a per-image section, biggest ΔE mover first', () => {
+    const base = report([
+      { family: 'illustration', image: 'small-move.png', dE: 0.02 },
+      { family: 'illustration', image: 'big-move.png', dE: 0.06 },
+    ])
+    const cand = report([
+      { family: 'illustration', image: 'small-move.png', dE: 0.019 },
+      { family: 'illustration', image: 'big-move.png', dE: 0.02 },
+    ])
+    const out = renderReport(compareReports(base, cand))
+    expect(out).toContain('per image')
+    expect(out).toContain('VERDICT:')
+    // The larger ΔE swing (big-move) is listed before the smaller one.
+    expect(out.indexOf('big-move.png')).toBeLessThan(out.indexOf('small-move.png'))
+  })
+
+  it('overallVerdict: a per-family win with no regression PASSes even if overall holds', () => {
+    const overall = {
+      name: 'overall',
+      n: 2,
+      metrics: {
+        dE: { base: 0.02, cand: 0.0199, dir: 'held' as const },
+        spurious: { base: 0.015, cand: 0.015, dir: 'held' as const },
+        edgeDE: { base: 0.03, cand: 0.03, dir: 'held' as const },
+        p95: { base: 0.04, cand: 0.04, dir: 'held' as const },
+        nodes: { base: 1000, cand: 1000, dir: 'held' as const },
+      },
+    }
+    const fam = {
+      name: 'regions',
+      n: 1,
+      metrics: {
+        dE: { base: 0.04, cand: 0.03, dir: 'better' as const },
+        spurious: { base: 0.02, cand: 0.018, dir: 'better' as const },
+        edgeDE: { base: 0.03, cand: 0.03, dir: 'held' as const },
+        p95: { base: 0.04, cand: 0.04, dir: 'held' as const },
+        nodes: { base: 1000, cand: 1000, dir: 'held' as const },
+      },
+    }
+    expect(overallVerdict(overall, [fam])).toBe('PASS')
+  })
+})

--- a/scripts/eval/ab-report.ts
+++ b/scripts/eval/ab-report.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env tsx
+/**
+ * A/B verdict over two `tracer-compare` JSON reports (baseline vs candidate).
+ *
+ * The point is to turn "eyeball two runs" into an explicit **PASS / MIXED /
+ * FAIL** so a quality change can't ship on a diluted whole-image mean while a
+ * localized metric regresses. It diffs every fidelity metric the harness
+ * records — mean ΔE, the banding-aware edge ΔE, the p95 tail, and the
+ * spurious-hue score — per image, per family, and overall, and judges the run
+ * on the two that matter most: **mean ΔE and spurious-hue**. A change that
+ * lowers the mean but raises spurious hue (a saturated color invented at a
+ * seam) is not an improvement, and this catches exactly that.
+ *
+ * Deterministic and pure: it only reads the two JSON blobs. Used both as the
+ * verdict step of `npm run eval:ab` and directly (`tsx ab-report.ts a.json
+ * b.json`) to compare any two reports, however they were produced.
+ */
+import { readFileSync } from 'node:fs'
+
+/** One tracer's metrics for one image, as written by `tracer-compare.ts`. */
+export interface TrazorMetrics {
+  dE: number
+  edgeDE: number
+  p95: number
+  spurious: number
+  nodes: number
+  bytes: number
+  ms?: number
+}
+
+interface Row {
+  family: string
+  image: string
+  trazor: TrazorMetrics
+}
+
+/** The metrics compared, in report order. `primary` ones decide the verdict. */
+const METRICS = [
+  { key: 'dE', label: 'ΔE', primary: true },
+  { key: 'spurious', label: 'spurious', primary: true },
+  { key: 'edgeDE', label: 'band', primary: false },
+  { key: 'p95', label: 'p95', primary: false },
+  { key: 'nodes', label: 'nodes', primary: false },
+] as const
+type MetricKey = (typeof METRICS)[number]['key']
+
+/**
+ * A metric only counts as changed when it moves by more than `REL` (relative)
+ * *and* `absFloor` (absolute) — so sub-noise wobble on already-tiny values
+ * (a 0.0001 ΔE drift) reads as "held", not a win or a loss.
+ */
+const REL = 0.02
+const ABS_FLOOR: Record<MetricKey, number> = {
+  dE: 0.0005,
+  spurious: 0.0005,
+  edgeDE: 0.0005,
+  p95: 0.001,
+  nodes: 20,
+}
+
+export type Direction = 'better' | 'worse' | 'held'
+export type Verdict = 'PASS' | 'MIXED' | 'FAIL'
+
+function direction(key: MetricKey, base: number, cand: number): Direction {
+  const abs = cand - base
+  if (Math.abs(abs) < ABS_FLOOR[key]) return 'held'
+  if (base !== 0 && Math.abs(abs / base) < REL) return 'held'
+  // Every metric here is lower-is-better.
+  return abs < 0 ? 'better' : 'worse'
+}
+
+/** Mean of `key` over a set of rows. */
+function mean(rows: Row[], key: MetricKey): number {
+  if (rows.length === 0) return 0
+  let s = 0
+  for (const r of rows) s += r.trazor[key]
+  return s / rows.length
+}
+
+export interface GroupVerdict {
+  name: string
+  n: number
+  metrics: Record<MetricKey, { base: number; cand: number; dir: Direction }>
+}
+
+function groupVerdict(name: string, base: Row[], cand: Row[]): GroupVerdict {
+  const metrics = {} as GroupVerdict['metrics']
+  for (const { key } of METRICS) {
+    const b = mean(base, key)
+    const c = mean(cand, key)
+    metrics[key] = { base: b, cand: c, dir: direction(key, b, c) }
+  }
+  return { name, n: cand.length, metrics }
+}
+
+/**
+ * Overall verdict from the family + overall groups. A change **FAILs** when it
+ * regresses a primary metric (ΔE or spurious hue) on the overall aggregate, or
+ * on two or more families — the ship-blocking cases. It **PASSes** only when a
+ * primary metric improves overall and none regresses anywhere. Everything in
+ * between is **MIXED** — a real trade a human has to weigh.
+ */
+export function overallVerdict(overall: GroupVerdict, families: GroupVerdict[]): Verdict {
+  const primaries = METRICS.filter((m) => m.primary).map((m) => m.key)
+  let overallWorse = false
+  let overallBetter = false
+  for (const k of primaries) {
+    if (overall.metrics[k].dir === 'worse') overallWorse = true
+    if (overall.metrics[k].dir === 'better') overallBetter = true
+  }
+  let familiesRegressed = 0
+  let familyBetter = false
+  for (const f of families) {
+    let worse = false
+    for (const k of primaries) {
+      if (f.metrics[k].dir === 'worse') worse = true
+      if (f.metrics[k].dir === 'better') familyBetter = true
+    }
+    if (worse) familiesRegressed++
+  }
+  if (overallWorse || familiesRegressed >= 2) return 'FAIL'
+  if (overallBetter && familiesRegressed === 0) return 'PASS'
+  if (familyBetter && familiesRegressed === 0 && !overallWorse) return 'PASS'
+  return 'MIXED'
+}
+
+export interface AbResult {
+  overall: GroupVerdict
+  families: GroupVerdict[]
+  perImage: Array<{ image: string; family: string; base: TrazorMetrics; cand: TrazorMetrics }>
+  verdict: Verdict
+}
+
+/** Compare two parsed reports. Rows are matched by image name. */
+export function compareReports(base: { rows: Row[] }, cand: { rows: Row[] }): AbResult {
+  const baseBy = new Map(base.rows.map((r) => [r.image, r]))
+  const paired = cand.rows.filter((r) => baseBy.has(r.image))
+  const baseRows = paired.map((r) => baseBy.get(r.image) as Row)
+
+  const families = [...new Set(paired.map((r) => r.family))].sort()
+  const familyVerdicts = families.map((fam) =>
+    groupVerdict(
+      fam,
+      baseRows.filter((r) => r.family === fam),
+      paired.filter((r) => r.family === fam),
+    ),
+  )
+  const overall = groupVerdict('overall', baseRows, paired)
+  const perImage = paired.map((r) => ({
+    image: r.image,
+    family: r.family,
+    base: (baseBy.get(r.image) as Row).trazor,
+    cand: r.trazor,
+  }))
+  return {
+    overall,
+    families: familyVerdicts,
+    perImage,
+    verdict: overallVerdict(overall, familyVerdicts),
+  }
+}
+
+// ---- CLI rendering ----
+
+const MARK: Record<Direction, string> = { better: '✓', worse: '✗', held: '·' }
+
+function pct(base: number, cand: number): string {
+  if (base === 0) return '  —  '
+  const d = ((cand - base) / base) * 100
+  return (d >= 0 ? '+' : '') + d.toFixed(1) + '%'
+}
+
+function fmt(v: number, key: MetricKey): string {
+  return key === 'nodes' ? String(Math.round(v)) : v.toFixed(4)
+}
+
+function renderGroup(g: GroupVerdict): string {
+  const parts = METRICS.map(({ key, label }) => {
+    const m = g.metrics[key]
+    return `${label} ${MARK[m.dir]} ${fmt(m.base, key)}→${fmt(m.cand, key)} ${pct(m.base, m.cand)}`
+  })
+  return `  ${g.name.padEnd(13)} (${g.n})  ` + parts.join('   ')
+}
+
+/** Per-image lines, biggest ΔE move first, so a lone regression stands out. */
+function renderPerImage(res: AbResult): string[] {
+  const rows = [...res.perImage].sort(
+    (a, b) => Math.abs(b.cand.dE - b.base.dE) - Math.abs(a.cand.dE - a.base.dE),
+  )
+  const cell = (key: MetricKey, base: number, cand: number, label: string): string =>
+    `${label} ${MARK[direction(key, base, cand)]} ${fmt(base, key)}→${fmt(cand, key)} ${pct(base, cand)}`
+  return rows.map((r) => {
+    const name = `${r.family}/${r.image}`
+    const head = (name.length > 34 ? name.slice(0, 33) + '…' : name).padEnd(35)
+    return (
+      `  ${head} ` +
+      [
+        cell('dE', r.base.dE, r.cand.dE, 'ΔE'),
+        cell('spurious', r.base.spurious, r.cand.spurious, 'spur'),
+        cell('nodes', r.base.nodes, r.cand.nodes, 'nodes'),
+      ].join('   ')
+    )
+  })
+}
+
+export function renderReport(res: AbResult): string {
+  const lines: string[] = []
+  lines.push('\n  per image (largest ΔE move first):\n')
+  for (const l of renderPerImage(res)) lines.push(l)
+  lines.push('')
+  lines.push('  per family (baseline → candidate):\n')
+  for (const f of res.families) lines.push(renderGroup(f))
+  lines.push('')
+  lines.push(renderGroup(res.overall))
+  lines.push('')
+  const banner =
+    res.verdict === 'PASS'
+      ? '✓ PASS — ships: a primary metric improved with no family regression'
+      : res.verdict === 'FAIL'
+        ? '✗ FAIL — do not ship: a primary metric (ΔE / spurious hue) regressed'
+        : '~ MIXED — a real trade-off; needs a human call'
+  lines.push(`  VERDICT: ${res.verdict}   ${banner}`)
+  lines.push('')
+  lines.push(
+    '  primary metrics: ΔE (mean fidelity) · spurious (invented hue at seams). lower is better.',
+  )
+  return lines.join('\n')
+}
+
+function main(): void {
+  const [baseP, candP] = process.argv.slice(2)
+  if (!baseP || !candP) {
+    console.error('usage: tsx ab-report.ts <baseline.json> <candidate.json>')
+    process.exit(2)
+  }
+  const base = JSON.parse(readFileSync(baseP, 'utf8'))
+  const cand = JSON.parse(readFileSync(candP, 'utf8'))
+  const res = compareReports(base, cand)
+  console.log(renderReport(res))
+  // Non-zero exit on FAIL so it can gate a script / CI step.
+  if (res.verdict === 'FAIL') process.exit(1)
+}
+
+// Run as CLI only when invoked directly (not when imported by a test).
+if (import.meta.url === `file://${process.argv[1]}`) main()

--- a/scripts/eval/ab.mjs
+++ b/scripts/eval/ab.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * One-command A/B: trace the representative corpus through the engine on your
+ * **working tree** and on **HEAD**, then print a PASS / MIXED / FAIL verdict.
+ *
+ * This is the guardrail for any color / palette / segmentation change. It runs
+ * `tracer-compare` twice over the same real-image corpus — once with your
+ * uncommitted edits, once with them stashed away — and hands both reports to
+ * `ab-report` for the verdict. Because the packages export TS source (no build
+ * step), stashing the source and re-running is a true baseline.
+ *
+ * Usage:
+ *   npm run eval:ab                                  # auto settings over corpus-vtracer
+ *   npm run eval:ab -- --set segmentation=quantize --set paletteSize=12
+ *   npm run eval:ab -- --sweep 6,8,12                # sweep paletteSize (shorthand)
+ *   npm run eval:ab -- --sweep segmentation=quantize,regions   # sweep any setting
+ *   npm run eval:ab -- --data <dir> --profile illustration
+ *
+ * `--sweep <key>=<v1,v2,...>` re-runs the whole A/B at each value of any Trazor
+ * setting and prints a verdict per value; a bare `--sweep <n1,n2,...>` is
+ * shorthand for `paletteSize` (which also pins `autoPaletteSize=false` so the
+ * forced size sticks). Any other flag (`--data`, `--profile`, `--set`,
+ * `--max-dim`, `--limit`) passes straight through to `tracer-compare`. Requires
+ * uncommitted changes to compare against HEAD; to compare two commits, run
+ * `tracer-compare --json` on each and diff with `tsx scripts/eval/ab-report.ts`.
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = process.cwd()
+const OUT = join(ROOT, 'eval-artifacts', 'ab')
+const DEFAULT_DATA = 'scripts/eval/corpus-vtracer'
+
+function sh(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { stdio: 'pipe', encoding: 'utf8', ...opts })
+}
+
+function hasLocalChanges() {
+  const unstaged = sh('git', ['diff', '--name-only'])
+  const staged = sh('git', ['diff', '--cached', '--name-only'])
+  return (unstaged + staged).trim().length > 0
+}
+
+/**
+ * `--sweep 6,8,12` → sweep paletteSize; `--sweep key=a,b` → sweep any setting.
+ * Returns `{ key, values }`; `key === null` means a single auto run.
+ */
+function parseSweep(spec) {
+  const eq = spec.indexOf('=')
+  if (eq < 0) return { key: 'paletteSize', values: spec.split(',').map((s) => s.trim()) }
+  return {
+    key: spec.slice(0, eq),
+    values: spec
+      .slice(eq + 1)
+      .split(',')
+      .map((s) => s.trim()),
+  }
+}
+
+/** Split argv into sweep control vs pass-through flags for tracer-compare. */
+function parseArgs(argv) {
+  const passthrough = []
+  let sweep = { key: null, values: [null] }
+  let data = DEFAULT_DATA
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--sweep') {
+      sweep = parseSweep(argv[++i])
+    } else if (a === '--data') {
+      data = argv[++i]
+    } else {
+      passthrough.push(a)
+      // flags that take a value: keep the value with them
+      if (['--profile', '--set', '--max-dim', '--limit', '--out'].includes(a)) {
+        passthrough.push(argv[++i])
+      }
+    }
+  }
+  return { passthrough, sweep, data }
+}
+
+/** A filesystem-safe tag for one sweep value. */
+function tagOf(key, value) {
+  if (value == null) return 'auto'
+  return `${key}=${value}`.replace(/[^\w.=-]/g, '_')
+}
+
+/** One tracer-compare run → JSON report at `outPath`, forcing `key=value` if set. */
+function runCompare(data, passthrough, key, value, outPath) {
+  const args = ['scripts/eval/tracer-compare.ts', '--data', data, '--json', outPath, ...passthrough]
+  if (key != null && value != null) {
+    args.push('--set', `${key}=${value}`)
+    // A forced palette size only sticks with autoPaletteSize off.
+    if (key === 'paletteSize') args.push('--set', 'autoPaletteSize=false')
+  }
+  sh('npx', ['tsx', ...args], { stdio: 'inherit' })
+}
+
+function main() {
+  const { passthrough, sweep, data } = parseArgs(process.argv.slice(2))
+
+  if (!existsSync(data)) {
+    console.error(`\n  corpus not found: ${data}`)
+    console.error('  fetch the representative corpus first:  npm run eval:samples')
+    console.error('  (or pass --data <dir> pointing at real PNG/JPEG images).\n')
+    process.exit(2)
+  }
+  if (!hasLocalChanges()) {
+    console.error('\n  no uncommitted changes — nothing to compare against HEAD.')
+    console.error('  make your edit first, then re-run. To compare two commits, run')
+    console.error('  tracer-compare --json on each and diff with scripts/eval/ab-report.ts.\n')
+    process.exit(2)
+  }
+
+  mkdirSync(OUT, { recursive: true })
+  const { key, values } = sweep
+
+  // Candidate (working tree) first, so a crash never leaves the tree stashed.
+  console.log('\n=== candidate (working tree) ===')
+  for (const v of values)
+    runCompare(data, passthrough, key, v, join(OUT, `cand-${tagOf(key, v)}.json`))
+
+  console.log('\n=== baseline (HEAD) ===')
+  sh('git', ['stash', 'push', '-m', 'eval:ab baseline'], { stdio: 'inherit' })
+  let stashed = true
+  try {
+    for (const v of values)
+      runCompare(data, passthrough, key, v, join(OUT, `base-${tagOf(key, v)}.json`))
+  } finally {
+    if (stashed) {
+      sh('git', ['stash', 'pop'], { stdio: 'inherit' })
+      stashed = false
+    }
+  }
+
+  // Verdict per swept value. Overall exit is FAIL if any value fails.
+  let anyFail = false
+  for (const v of values) {
+    const tag = tagOf(key, v)
+    console.log(`\n=== verdict (${tag}) ===`)
+    try {
+      sh(
+        'npx',
+        [
+          'tsx',
+          'scripts/eval/ab-report.ts',
+          join(OUT, `base-${tag}.json`),
+          join(OUT, `cand-${tag}.json`),
+        ],
+        { stdio: 'inherit' },
+      )
+    } catch {
+      anyFail = true // ab-report exits non-zero on FAIL
+    }
+  }
+  process.exit(anyFail ? 1 : 0)
+}
+
+main()

--- a/scripts/eval/tracer-compare.ts
+++ b/scripts/eval/tracer-compare.ts
@@ -293,7 +293,7 @@ function printTable(rows: Row[], hasV: boolean): void {
         'ms T',
         'ms V',
       ]
-    : ['family', 'image', 'ΔE T', 'nodes T', 'bytes T', 'ms T']
+    : ['family', 'image', 'ΔE T', 'spurious T', 'nodes T', 'bytes T', 'ms T']
   const body: string[][] = []
   for (const r of rows) {
     const t = r.trazor
@@ -318,6 +318,7 @@ function printTable(rows: Row[], hasV: boolean): void {
         r.family,
         r.name,
         fmt(t.dE),
+        fmt(t.spurious),
         String(Math.round(t.nodes)),
         String(t.bytes),
         String(Math.round(t.ms)),
@@ -348,8 +349,12 @@ function printFamilySummary(rows: Row[], hasV: boolean): void {
           `   spurious T ${fmt(t.spurious)} V ${fmt(v.spurious)}   nodes T/V ${nodeRatio}× KB T/V ${byteRatio}×`,
       )
     } else {
+      // Show band + spurious + p95 alongside the mean: a change can lower the
+      // whole-image ΔE while inventing a hue at a seam (spurious up) — the mean
+      // alone would hide that, so never print it alone.
       console.log(
-        `  ${fam.padEnd(12)} ΔE  T ${fmt(t.dE)}   nodes ${Math.round(t.nodes)}   ms ${Math.round(t.ms)}`,
+        `  ${fam.padEnd(12)} ΔE ${fmt(t.dE)}   band ${fmt(t.edgeDE)}   spurious ${fmt(t.spurious)}` +
+          `   p95 ${fmt(t.p95)}   nodes ${Math.round(t.nodes)}`,
       )
     }
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['packages/*/test/**/*.test.ts'],
+    include: ['packages/*/test/**/*.test.ts', 'scripts/**/*.test.ts'],
     environment: 'node',
     testTimeout: 30000,
   },


### PR DESCRIPTION
## Problem

Judging a color / palette / segmentation change by eye is unreliable. A change can lower the whole-image mean ΔE while a localized metric — a saturated hue invented at a seam (spurious hue) — regresses; and the built-in synthetic corpus or a single hand-picked image routinely shows a "win" that vanishes on real art. (Concretely, this cycle a chroma-weighted quantization idea looked strong on one synthetic image and was refuted the moment it ran through the real tracer on the representative corpus.)

## What

A reusable A/B harness that turns "eyeball two runs" into an explicit **PASS / MIXED / FAIL** over the representative corpus, plus a codified rule to always use it.

- **`npm run eval:ab`** — traces the corpus through `@trazor/engine` on your **working tree** vs **HEAD** (edits stashed; packages export TS source with no build step, so the stash is a true baseline) and prints the verdict. `--sweep <key>=<v1,v2,…>` re-runs the whole A/B at each value of any setting; a bare `--sweep 6,8,12` is `paletteSize` shorthand.
- **`scripts/eval/ab-report.ts`** — pure, unit-tested verdict engine. Judges on the two metrics that matter most, **mean ΔE and spurious-hue**, per image / family / overall — a better mean bought with worse spurious hue is a **FAIL**, not a win. Prints a per-image breakdown (biggest ΔE move first) so a lone regression stands out without hand-diffing. Runs standalone on any two `--json` reports.
- **`tracer-compare`** Trazor-only output now always prints band / spurious / p95 next to the mean, so a single run can't hide a spurious regression.
- **`AGENTS.md` → "Evaluating quality changes"** — measure on the representative corpus (real illustrations / photos), never synthetic or one-off images; ship only on a PASS; don't write throwaway eval code (per-image deltas and sweeps are built in; a behavioral check belongs in a unit test). `scripts/eval/README.md` documents the workflow.

## Tests & docs

- `scripts/eval/ab-report.test.ts` — verdict logic, including the "better mean, worse spurious → FAIL" trap and the per-image ordering. `vitest.config.ts` now also globs `scripts/**/*.test.ts`.
- `npm run check` green — lint · fmt · typecheck · tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Auqwc6WZeeN2jHjVFjXqT

---
_Generated by [Claude Code](https://claude.ai/code/session_018Auqwc6WZeeN2jHjVFjXqT)_