### PR TITLE
Adaptive fidelity floor and geometric scoring for tune search

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -774,7 +774,11 @@ each suggested palette + a Latin-hypercube fill), then adaptive coordinate
 descent over the incumbent — probe one parameter at a time, expand the step on
 success and shrink on failure, with a palette swap, recombination, and (on
 stagnation) a seeded restart. Descent order is seeded from per-parameter
-sensitivity measured across the seed round.
+sensitivity measured across the seed round. Candidates far below the best
+fidelity the pool proved attainable are barred from winning (`fidelityFloor`,
+applied retroactively as the floor rises); while everything is barred (a high
+explicit `minFidelity`), descent climbs fidelity toward the admissible region
+instead of going blind below it.
 
 ```ts
 // score.ts — objectives mapped to 0..1 utilities.
@@ -783,6 +787,7 @@ export const OBJECTIVE_IDS: readonly ObjectiveId[]
 export type TuneWeights = Record<ObjectiveId, number> // 0 = don't care; normalized internally
 export interface CandidateMetrics {
   meanDeltaE: number // mean Oklab ΔE of the rendered SVG vs the source
+  p95DeltaE?: number // 95th-percentile Oklab ΔE over the same sampled pixels; absent ⇒ mean-only fidelity
   nodeCount: number
   pathCount: number
   byteLength: number
@@ -790,12 +795,21 @@ export interface CandidateMetrics {
   warnings: readonly VectorizeWarning[]
   durationMs: number
 }
-export function fidelityUtility(meanDeltaE: number): number // clamp(1 − 4·ΔE, 0, 1)
+// clamp(1 − 4·ΔE, 0, 1); with a p95 the judged ΔE is 0.65·mean + 0.35·p95, so
+// damage confined to a small region (which a whole-image mean dilutes) counts.
+export function fidelityUtility(meanDeltaE: number, p95DeltaE?: number): number
+// Max fidelity-utility drop below a pool's best before a candidate is barred from winning.
+export const FIDELITY_DROP: number
+// The pool's fidelity floor: max(minFidelity, bestFidelity − FIDELITY_DROP). Never
+// rejects the pool's best-fidelity candidate.
+export function fidelityFloor(bestFidelity: number, minFidelity?: number): number
 export function cleanlinessUtility(warnings: readonly VectorizeWarning[]): number
 export function isEmptyResult(metrics: CandidateMetrics): boolean
 export function utilitiesOf(m: CandidateMetrics, baseline: CandidateMetrics): Record<ObjectiveId, number>
-// The weight-normalized sum of the utilities. Fidelity is absolute; the
-// "fewer is better" axes anchor at 0.5 for the baseline candidate.
+// The weighted geometric mean of the utilities (weighted product model), so the
+// axes don't compensate: a candidate near zero on any weighted objective scores
+// near zero overall. Fidelity is absolute; the "fewer is better" axes anchor at
+// 0.5 for the baseline candidate.
 export function scoreCandidate(
   metrics: CandidateMetrics,
   baseline: CandidateMetrics,
@@ -840,7 +854,10 @@ export interface ScoredCandidate extends TuneCandidate {
   metrics: CandidateMetrics
   utilities: Record<ObjectiveId, number>
   score: number
-  rejected?: 'empty' | 'fidelity-floor'
+  // Barred from winning: empty output, under the explicit minFidelity, or under
+  // the adaptive floor trailing the pool's best fidelity (fidelityFloor).
+  // Retroactive: a later, higher-fidelity discovery re-marks earlier candidates.
+  rejected?: 'empty' | 'fidelity-floor' | 'fidelity-drop'
   svg?: string // the traced SVG, carried through for the results wall (opaque to the search)
 }
 export interface CandidateResult { id: number; metrics: CandidateMetrics; svg?: string }

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -108,6 +108,11 @@ where it is used. Keep this file up to date when adding or changing algorithms.
   Computer Code”, _Technometrics_ 21(2), 1979.** Latin-hypercube sampling used
   to seed the search’s first round so the free parameters are exercised at
   spread-out levels (`packages/tune/src/search.ts`).
+- **P. W. Bridgman, _Dimensional Analysis_, Yale University Press, 1922 (the
+  weighted product model; see also E. Triantaphyllou, _Multi-Criteria Decision
+  Making Methods: A Comparative Study_, Kluwer, 2000, ch. 2).** The candidate
+  score is the weighted geometric mean of the objective utilities, so no axis
+  can compensate for a collapse on another (`packages/tune/src/score.ts`).
 
 ## Local ML models (packages/ml)
 

--- a/packages/tune/src/index.ts
+++ b/packages/tune/src/index.ts
@@ -10,7 +10,9 @@ export {
 export type { ParamSpec, TunableKey } from './params'
 export {
   OBJECTIVE_IDS,
+  FIDELITY_DROP,
   fidelityUtility,
+  fidelityFloor,
   cleanlinessUtility,
   isEmptyResult,
   utilitiesOf,

--- a/packages/tune/src/score.ts
+++ b/packages/tune/src/score.ts
@@ -19,6 +19,11 @@ export type TuneWeights = Record<ObjectiveId, number>
 export interface CandidateMetrics {
   /** Mean Oklab ΔE between the rendered SVG and the source (lower is better). */
   meanDeltaE: number
+  /**
+   * 95th-percentile Oklab ΔE over the same sampled pixels (lower is better).
+   * Optional: when absent, fidelity is judged on the mean alone.
+   */
+  p95DeltaE?: number
   nodeCount: number
   pathCount: number
   byteLength: number
@@ -36,9 +41,43 @@ const WARNING_PENALTY: Partial<Record<WarningCode, number>> = {
   'centerline-input': 0.1,
 }
 
-/** Fidelity: the app's own score, 1 − 4·ΔE clamped — an absolute anchor, not relative to the baseline. */
-export function fidelityUtility(meanDeltaE: number): number {
-  return clamp(1 - 4 * meanDeltaE, 0, 1)
+/** Share of the 95th-percentile ΔE in the judged error (the rest is the mean). */
+const P95_BLEND = 0.35
+
+/**
+ * Max fidelity-utility drop below the pool's best before a candidate is barred
+ * from winning (see {@link fidelityFloor}).
+ */
+export const FIDELITY_DROP = 0.2
+
+/** Utilities enter the geometric score no lower than this, so ranking among poor candidates stays informative. */
+const UTILITY_FLOOR = 1e-4
+
+/**
+ * Fidelity: 1 − 4·ΔE clamped to 0..1 — an absolute anchor, not relative to the
+ * baseline. When the caller measured a 95th-percentile ΔE, the judged error
+ * blends it with the mean (65/35): a whole-image mean dilutes damage confined
+ * to a small region (a lost subject on a matching background), while the high
+ * percentile keeps that damage visible to the score.
+ */
+export function fidelityUtility(meanDeltaE: number, p95DeltaE?: number): number {
+  const deltaE =
+    p95DeltaE === undefined
+      ? meanDeltaE
+      : (1 - P95_BLEND) * meanDeltaE + P95_BLEND * Math.max(meanDeltaE, p95DeltaE)
+  return clamp(1 - 4 * deltaE, 0, 1)
+}
+
+/**
+ * The fidelity floor for a candidate pool: the caller's explicit floor, raised
+ * to within {@link FIDELITY_DROP} of the best fidelity any candidate in the
+ * pool achieved. Candidates below it must not win — whatever their other
+ * utilities, a "best choice" visibly worse than what the search proved
+ * attainable is a bad recommendation. Never rejects the pool's best-fidelity
+ * candidate, so at least one candidate always survives the adaptive part.
+ */
+export function fidelityFloor(bestFidelity: number, minFidelity?: number): number {
+  return Math.max(minFidelity ?? 0, bestFidelity - FIDELITY_DROP)
 }
 
 /**
@@ -81,7 +120,7 @@ export function utilitiesOf(
   baseline: CandidateMetrics,
 ): Record<ObjectiveId, number> {
   return {
-    fidelity: fidelityUtility(metrics.meanDeltaE),
+    fidelity: fidelityUtility(metrics.meanDeltaE, metrics.p95DeltaE),
     simplicity: fewerIsBetter(metrics.nodeCount, baseline.nodeCount),
     fileSize: fewerIsBetter(metrics.byteLength, baseline.byteLength),
     colorEconomy: fewerIsBetter(metrics.colorCount, baseline.colorCount, 1),
@@ -90,8 +129,13 @@ export function utilitiesOf(
 }
 
 /**
- * Score a candidate: the weight-normalized sum of its objective utilities. The
- * baseline anchors the "fewer is better" axes; weights need not sum to anything.
+ * Score a candidate: the weighted geometric mean of its objective utilities
+ * (weighted product model; zero-weight axes are ignored, weights need not sum
+ * to anything). Geometric rather than arithmetic so the axes don't compensate:
+ * near-perfect simplicity/file-size — which a degenerate few-blob trace gets
+ * for free — cannot buy off a collapsed fidelity, and a candidate near zero on
+ * any weighted objective scores near zero overall. The baseline anchors the
+ * "fewer is better" axes.
  */
 export function scoreCandidate(
   metrics: CandidateMetrics,
@@ -99,12 +143,13 @@ export function scoreCandidate(
   weights: TuneWeights,
 ): { score: number; utilities: Record<ObjectiveId, number> } {
   const utilities = utilitiesOf(metrics, baseline)
-  let weighted = 0
+  let logSum = 0
   let total = 0
   for (const id of OBJECTIVE_IDS) {
     const w = Math.max(0, weights[id] ?? 0)
-    weighted += w * utilities[id]
+    if (w === 0) continue
+    logSum += w * Math.log(Math.max(utilities[id], UTILITY_FLOOR))
     total += w
   }
-  return { score: total > 0 ? weighted / total : 0, utilities }
+  return { score: total > 0 ? Math.exp(logSum / total) : 0, utilities }
 }

--- a/packages/tune/src/search.ts
+++ b/packages/tune/src/search.ts
@@ -9,7 +9,7 @@ import {
   TUNABLE_PARAMS,
 } from './params'
 import type { ParamSpec, TunableKey } from './params'
-import { fidelityUtility, isEmptyResult, scoreCandidate } from './score'
+import { fidelityFloor, isEmptyResult, scoreCandidate } from './score'
 import type { CandidateMetrics, ObjectiveId, TuneWeights } from './score'
 
 export type CandidateOrigin =
@@ -36,8 +36,14 @@ export interface ScoredCandidate extends TuneCandidate {
   metrics: CandidateMetrics
   utilities: Record<ObjectiveId, number>
   score: number
-  /** Set when the candidate is excluded from winning (empty output or below the fidelity floor). */
-  rejected?: 'empty' | 'fidelity-floor'
+  /**
+   * Set when the candidate is excluded from winning: empty output, below the
+   * caller's explicit fidelity floor, or below the adaptive floor that trails
+   * the pool's best fidelity (see `fidelityFloor`). The adaptive verdict is
+   * retroactive — a later, higher-fidelity discovery raises the floor for
+   * every earlier candidate too.
+   */
+  rejected?: 'empty' | 'fidelity-floor' | 'fidelity-drop'
   /** The traced SVG, carried through for the results view (opaque to the search). */
   svg?: string
 }
@@ -138,8 +144,8 @@ export class TuneSearch {
   private readonly ledger: ScoredCandidate[] = []
   /** Emitted-but-unreported candidates from the last `nextRound()`. */
   private pending = new Map<number, TuneCandidate>()
-  /** Incumbent score when the pending round was proposed (gain attribution). */
-  private pendingBaseScore = 0
+  /** Incumbent standing when the pending round was proposed (gain attribution). */
+  private pendingBase = { score: 0, fidelity: 0, winnable: false }
 
   private baselineMetrics: CandidateMetrics | null = null
   private incumbent: ScoredCandidate | null = null
@@ -185,7 +191,13 @@ export class TuneSearch {
     }
     const batch = this.phase === 'seed' ? this.seedRound() : this.descendRound()
     this.pending = new Map(batch.map((c) => [c.id, c]))
-    this.pendingBaseScore = this.incumbent?.score ?? 0
+    this.pendingBase = this.incumbent
+      ? {
+          score: this.incumbent.score,
+          fidelity: this.incumbent.utilities.fidelity,
+          winnable: !this.incumbent.rejected,
+        }
+      : { score: 0, fidelity: 0, winnable: false }
     return batch
   }
 
@@ -207,33 +219,50 @@ export class TuneSearch {
     const anchor = this.baselineMetrics
     if (!anchor) return
 
-    const probedImproved = new Map<TunableKey, boolean>()
-    const probedSeen = new Set<TunableKey>()
-    let roundBest: ScoredCandidate | null = null
-
+    const roundScored: ScoredCandidate[] = []
     for (const r of results) {
       const candidate = this.pending.get(r.id)
       if (!candidate) continue
       const scored = this.scoreOne(candidate, r.metrics, anchor)
       if (r.svg !== undefined) scored.svg = r.svg
       this.record(scored)
+      roundScored.push(scored)
+    }
 
-      if (candidate.origin === 'step' && candidate.tweaked) {
-        probedSeen.add(candidate.tweaked)
-        const improved = !scored.rejected && scored.score > this.pendingBaseScore + 1e-9
-        if (improved) probedImproved.set(candidate.tweaked, true)
-        const st = this.paramState.get(candidate.tweaked)
+    // The adaptive floor moves with this round's discoveries, so settle every
+    // candidate's verdict before attributing gains or picking the round best.
+    this.applyFidelityGuard()
+
+    const probedImproved = new Map<TunableKey, boolean>()
+    const probedSeen = new Set<TunableKey>()
+    let roundBest: ScoredCandidate | null = null
+    let roundClimb: ScoredCandidate | null = null
+    for (const scored of roundScored) {
+      if (scored.origin === 'step' && scored.tweaked) {
+        probedSeen.add(scored.tweaked)
+        const { improved, gain } = this.probeProgress(scored)
+        if (improved) probedImproved.set(scored.tweaked, true)
+        const st = this.paramState.get(scored.tweaked)
         if (st) {
-          const gain = scored.rejected ? 0 : Math.max(0, scored.score - this.pendingBaseScore)
           st.gain = GAIN_EMA * st.gain + (1 - GAIN_EMA) * gain
           st.lastRound = this.round
         }
       }
       if (!scored.rejected && (!roundBest || scored.score > roundBest.score)) roundBest = scored
+      if (
+        scored.rejected !== 'empty' &&
+        (!roundClimb || scored.utilities.fidelity > roundClimb.utilities.fidelity)
+      ) {
+        roundClimb = scored
+      }
     }
 
     this.adaptSteps(probedSeen, probedImproved)
-    this.updateIncumbent(roundBest)
+    // A raised floor can retro-reject the incumbent; re-seat on the best
+    // surviving candidate (or keep the barred one as a climb point when
+    // nothing is winnable yet).
+    if (this.incumbent?.rejected) this.incumbent = this.best() ?? this.incumbent
+    this.updateIncumbent(roundBest, roundClimb)
     this.round++
     if (this.phase === 'seed') {
       // Rank the first descent by how much each parameter moved the score across
@@ -479,7 +508,10 @@ export class TuneSearch {
    * deterministic (reads the deterministic ledger).
    */
   private seedSensitivity(): void {
-    const scored = this.ledger.filter((c) => !c.rejected)
+    // Fidelity-rejected seeds still carry real scores — keep them in the
+    // correlation so a wide seed scatter informs sensitivity; only empty
+    // results (score 0, meaningless metrics) are excluded.
+    const scored = this.ledger.filter((c) => c.rejected !== 'empty')
     if (scored.length < 3) return
     const specs = applicableParams(this.freeKeys, this.mode, this.incumbent?.settings ?? this.base)
     for (const spec of specs) {
@@ -519,20 +551,57 @@ export class TuneSearch {
     }
   }
 
-  private updateIncumbent(roundBest: ScoredCandidate | null): void {
-    if (!roundBest) {
-      // No usable candidate this round: still seed the incumbent from the baseline
-      // so descent has a point to step from.
-      this.incumbent ??= this.baselineCandidate()
-      this.stall++
+  /**
+   * Whether a step probe made progress over the incumbent it stepped from, and
+   * the gain to credit its parameter. In the normal regime that's a score
+   * improvement among winnable candidates. While the incumbent itself is barred
+   * by a fidelity floor, progress is a fidelity improvement instead — descent
+   * climbs toward the admissible region rather than going blind below it.
+   */
+  private probeProgress(scored: ScoredCandidate): { improved: boolean; gain: number } {
+    if (scored.rejected === 'empty') return { improved: false, gain: 0 }
+    if (!scored.rejected) {
+      const gain = Math.max(0, scored.score - this.pendingBase.score)
+      return { improved: scored.score > this.pendingBase.score + 1e-9, gain }
+    }
+    if (this.pendingBase.winnable) return { improved: false, gain: 0 }
+    const gain = Math.max(0, scored.utilities.fidelity - this.pendingBase.fidelity)
+    return { improved: scored.utilities.fidelity > this.pendingBase.fidelity + 1e-9, gain }
+  }
+
+  private updateIncumbent(
+    roundBest: ScoredCandidate | null,
+    roundClimb: ScoredCandidate | null,
+  ): void {
+    if (roundBest) {
+      if (
+        !this.incumbent ||
+        this.incumbent.rejected ||
+        roundBest.score > this.incumbent.score + 1e-9
+      ) {
+        this.incumbent = roundBest
+        this.stall = 0
+      } else {
+        this.stall++
+      }
       return
     }
-    if (!this.incumbent || roundBest.score > this.incumbent.score + 1e-9) {
-      this.incumbent = roundBest
+    // No winnable candidate this round. While the whole pool sits under a
+    // fidelity floor, the most faithful candidate still moves descent toward it.
+    if (
+      roundClimb &&
+      (!this.incumbent ||
+        (this.incumbent.rejected &&
+          roundClimb.utilities.fidelity > this.incumbent.utilities.fidelity + 1e-9))
+    ) {
+      this.incumbent = roundClimb
       this.stall = 0
-    } else {
-      this.stall++
+      return
     }
+    // Nothing usable at all: still seed the incumbent from the baseline so
+    // descent has a point to step from.
+    this.incumbent ??= this.baselineCandidate()
+    this.stall++
   }
 
   private baselineCandidate(): ScoredCandidate | null {
@@ -557,15 +626,38 @@ export class TuneSearch {
   ): ScoredCandidate {
     const empty = isEmptyResult(metrics)
     const { score, utilities } = scoreCandidate(metrics, anchor, this.opts.weights)
-    let rejected: ScoredCandidate['rejected']
-    if (empty) rejected = 'empty'
-    else if (
-      this.opts.minFidelity !== undefined &&
-      fidelityUtility(metrics.meanDeltaE) < this.opts.minFidelity
-    ) {
-      rejected = 'fidelity-floor'
+    // Fidelity floors are settled per round by applyFidelityGuard; only the
+    // empty verdict is final here. Non-empty candidates keep their computed
+    // score either way — rejection bars winning, it doesn't erase the measure.
+    const rejected: ScoredCandidate['rejected'] = empty ? 'empty' : undefined
+    return { ...candidate, metrics, utilities, score: empty ? 0 : score, rejected }
+  }
+
+  /**
+   * Re-mark the whole ledger against the fidelity floor: the caller's explicit
+   * `minFidelity`, raised adaptively to within `FIDELITY_DROP` of the best
+   * fidelity achieved so far (`fidelityFloor`). Retroactive on purpose — once a
+   * clearly more faithful result is known to be attainable, candidates far
+   * below it stop being presentable as winners, whatever their score.
+   */
+  private applyFidelityGuard(): void {
+    let bestFid = -1
+    for (const c of this.ledger) {
+      if (c.rejected === 'empty') continue
+      if (c.utilities.fidelity > bestFid) bestFid = c.utilities.fidelity
     }
-    return { ...candidate, metrics, utilities, score: rejected ? 0 : score, rejected }
+    if (bestFid < 0) return
+    const floor = fidelityFloor(bestFid, this.opts.minFidelity)
+    const explicit = this.opts.minFidelity ?? 0
+    for (const c of this.ledger) {
+      if (c.rejected === 'empty') continue
+      const fid = c.utilities.fidelity
+      if (fid < floor - 1e-9) {
+        c.rejected = fid < explicit - 1e-9 ? 'fidelity-floor' : 'fidelity-drop'
+      } else {
+        c.rejected = undefined
+      }
+    }
   }
 
   private record(scored: ScoredCandidate): void {

--- a/packages/tune/test/score.test.ts
+++ b/packages/tune/test/score.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import type { VectorizeWarning } from '@trazor/core'
 import {
   cleanlinessUtility,
+  FIDELITY_DROP,
+  fidelityFloor,
   fidelityUtility,
   isEmptyResult,
   scoreCandidate,
@@ -37,6 +39,23 @@ describe('fidelityUtility', () => {
     expect(fidelityUtility(0.25)).toBe(0)
     expect(fidelityUtility(0.5)).toBe(0)
     expect(fidelityUtility(0.0625)).toBeCloseTo(0.75, 6)
+  })
+
+  it('blends a measured p95 ΔE into the judged error (65/35)', () => {
+    expect(fidelityUtility(0.02, 0.1)).toBeCloseTo(1 - 4 * (0.65 * 0.02 + 0.35 * 0.1), 6)
+    // Local damage (high p95) lowers fidelity even when the mean barely moves.
+    expect(fidelityUtility(0.02, 0.4)).toBeLessThan(fidelityUtility(0.02, 0.1))
+    // A p95 below the mean cannot raise the utility above the mean-only value.
+    expect(fidelityUtility(0.1, 0.05)).toBeCloseTo(fidelityUtility(0.1), 6)
+  })
+})
+
+describe('fidelityFloor', () => {
+  it('is the explicit floor raised to within FIDELITY_DROP of the pool best', () => {
+    expect(fidelityFloor(0.9)).toBeCloseTo(0.9 - FIDELITY_DROP, 6)
+    expect(fidelityFloor(0.9, 0.5)).toBeCloseTo(0.9 - FIDELITY_DROP, 6)
+    expect(fidelityFloor(0.9, 0.85)).toBeCloseTo(0.85, 6)
+    expect(fidelityFloor(0.1)).toBe(0)
   })
 })
 
@@ -82,7 +101,7 @@ describe('isEmptyResult', () => {
 })
 
 describe('scoreCandidate', () => {
-  it('is the weight-normalized mean of the utilities', () => {
+  it('is the weight-normalized geometric mean of the utilities', () => {
     const base = metrics()
     const cand = metrics({ meanDeltaE: 0, nodeCount: 500 })
     const both: TuneWeights = {
@@ -93,13 +112,56 @@ describe('scoreCandidate', () => {
       cleanliness: 0,
     }
     const { score, utilities } = scoreCandidate(cand, base, both)
-    expect(score).toBeCloseTo((utilities.fidelity + utilities.simplicity) / 2, 6)
+    expect(score).toBeCloseTo(Math.sqrt(utilities.fidelity * utilities.simplicity), 6)
   })
 
   it('ignores zero-weight objectives', () => {
     const base = metrics()
     const cand = metrics({ meanDeltaE: 0 })
     expect(scoreCandidate(cand, base, ONLY('fidelity')).score).toBe(1)
+  })
+
+  it('does not let strong axes buy off a collapsed one', () => {
+    const base = metrics()
+    // Perfect simplicity/file-size, but fidelity has collapsed to 0.
+    const collapsed = metrics({ meanDeltaE: 0.3, nodeCount: 1, byteLength: 1 })
+    const weights: TuneWeights = {
+      fidelity: 1,
+      simplicity: 1,
+      fileSize: 1,
+      colorEconomy: 0,
+      cleanliness: 1,
+    }
+    expect(scoreCandidate(collapsed, base, weights).score).toBeLessThan(0.1)
+  })
+
+  it('prefers a faithful trace over a degenerate few-blob one at default-like weights', () => {
+    const base = metrics()
+    // A near-empty trace: superb simplicity/size, subject destroyed (high p95).
+    const degenerate = metrics({
+      meanDeltaE: 0.08,
+      p95DeltaE: 0.4,
+      nodeCount: 60,
+      byteLength: 500,
+      colorCount: 2,
+    })
+    // A real trace: close to the source everywhere, ordinary complexity.
+    const faithful = metrics({
+      meanDeltaE: 0.02,
+      p95DeltaE: 0.08,
+      nodeCount: 900,
+      byteLength: 7000,
+    })
+    const weights: TuneWeights = {
+      fidelity: 1,
+      simplicity: 0.5,
+      fileSize: 0.25,
+      colorEconomy: 0,
+      cleanliness: 0.25,
+    }
+    const good = scoreCandidate(faithful, base, weights).score
+    const bad = scoreCandidate(degenerate, base, weights).score
+    expect(good).toBeGreaterThan(bad)
   })
 
   it('returns 0 when all weights are zero', () => {

--- a/packages/tune/test/search.test.ts
+++ b/packages/tune/test/search.test.ts
@@ -200,6 +200,32 @@ describe('TuneSearch rejection and Pareto', () => {
     for (const c of emptyOnes) expect(c.rejected).toBe('empty')
   })
 
+  it('retroactively bars candidates far below the best attainable fidelity', () => {
+    // Fidelity tracks smoothing directly, so the pool spans 0..~1 fidelity.
+    const search = run(BASE, { ...CURVE_OPTS, iterations: 30 }, (s) => bowlMetric(s.smoothing))
+    const pool = search.results().filter((c) => c.rejected !== 'empty')
+    const bestFid = Math.max(...pool.map((c) => c.utilities.fidelity))
+    // The wide seed scatter guarantees low-fidelity candidates were scored…
+    expect(pool.some((c) => c.rejected === 'fidelity-drop')).toBe(true)
+    // …and none of them survives as a winnable candidate.
+    const winnable = pool.filter((c) => !c.rejected)
+    expect(winnable.length).toBeGreaterThan(0)
+    expect(winnable.filter((c) => c.utilities.fidelity < bestFid - 0.2 - 1e-9)).toEqual([])
+    expect(search.best()!.rejected).toBeUndefined()
+  })
+
+  it('marks candidates under an explicit minFidelity as fidelity-floor', () => {
+    const search = run(BASE, { ...CURVE_OPTS, iterations: 30, minFidelity: 0.9 }, (s) =>
+      bowlMetric(s.smoothing),
+    )
+    const under = search
+      .results()
+      .filter((c) => c.rejected !== 'empty' && c.utilities.fidelity < 0.9 - 1e-9)
+    expect(under.length).toBeGreaterThan(0)
+    expect(under.every((c) => c.rejected === 'fidelity-floor')).toBe(true)
+    expect(search.best()!.utilities.fidelity).toBeGreaterThanOrEqual(0.9)
+  })
+
   it('reports a non-dominated Pareto front', () => {
     const ideal = { smoothing: 0.7, optTolerance: 2.5 }
     // Trade fidelity against simplicity: fewer nodes near high smoothing.


### PR DESCRIPTION
## Summary

This change improves the tune search algorithm's handling of fidelity (rendering accuracy) by introducing an adaptive fidelity floor that rises with the pool's best discoveries, and switches the candidate scoring from arithmetic to geometric mean so that no single objective can compensate for collapse on another.

## Key Changes

- **Adaptive fidelity floor**: Candidates are now retroactively barred from winning if they fall more than `FIDELITY_DROP` (0.2) below the best fidelity achieved in the pool. This is applied per-round via `applyFidelityGuard()`, so a later high-fidelity discovery re-marks earlier candidates. Rejection reasons now distinguish `'fidelity-floor'` (explicit `minFidelity`) from `'fidelity-drop'` (adaptive floor).

- **P95 ΔE blending**: `fidelityUtility()` now accepts an optional `p95DeltaE` parameter and blends it with the mean (65/35 split) to detect localized damage that a whole-image mean would dilute. The `CandidateMetrics` interface adds optional `p95DeltaE` field.

- **Geometric scoring**: `scoreCandidate()` now computes the weighted geometric mean of utilities (via log-sum-exp) instead of arithmetic mean. This prevents strong performance on simplicity/file-size from compensating for collapsed fidelity, and ensures a candidate near zero on any weighted objective scores near zero overall.

- **Climb-toward-floor descent**: While the incumbent is barred by a fidelity floor, descent now climbs fidelity instead of going blind below the floor. `updateIncumbent()` tracks the best-fidelity candidate (`roundClimb`) separately from the best-score candidate (`roundBest`), and `probeProgress()` measures gain as fidelity improvement when the incumbent is rejected.

- **Ledger re-marking**: The entire ledger is re-evaluated against the fidelity floor each round via `applyFidelityGuard()`, so rejection verdicts are retroactive. Rejected candidates retain their computed scores (rejection bars winning, not measurement).

- **Seed sensitivity refinement**: `seedSensitivity()` now includes fidelity-rejected seeds in correlation analysis (only empty results are excluded), so a wide seed scatter informs parameter sensitivity even when some seeds fall below the floor.

## Notable Implementation Details

- `pendingBase` now tracks score, fidelity, and winnability of the incumbent when a round is proposed, enabling accurate gain attribution in both normal (score-climbing) and floor-climbing regimes.
- `UTILITY_FLOOR` (1e-4) prevents utilities from collapsing to zero in the geometric mean, keeping ranking among poor candidates informative.
- Tests verify that the adaptive floor prevents low-fidelity candidates from winning, that explicit `minFidelity` is respected, and that geometric scoring prefers faithful traces over degenerate few-blob ones.
- Documentation updated in `CONTRACTS.md` and `REFERENCES.md` to reflect the weighted product model and fidelity floor behavior.

https://claude.ai/code/session_01Rpm89fLbQn4bnUhAXvHUj8