### PR TITLE
Rescue thin marker-less features as their own regions

### DIFF
--- a/packages/raster/src/segment.ts
+++ b/packages/raster/src/segment.ts
@@ -13,13 +13,16 @@
  *   1. Oklab gradient magnitude per pixel.
  *   2. Flat interiors (gradient below `flatThreshold`) are the markers — one
  *      region per 4-connected component, seeded with its mean color.
- *   2b. A feature too thin to hold a flat interior (a hairline glyph like an "&")
- *      gets no marker in step 2 and would be swallowed by the flood; each such
- *      enclosed, contrasting blob is rescued as its own marker first (see
+ *   2b. A feature too thin to hold a flat interior (a hairline glyph like an "&",
+ *      a fur stroke, a contour line) gets no marker in step 2 and would be
+ *      swallowed by the flood; each such blob that is a color extreme between
+ *      its sides is rescued as its own marker first (see
  *      {@link rescueMarkerlessFeatures}).
  *   3. A priority flood grows the markers over the remaining (edge/ramp) pixels,
  *      always claiming the cheapest pixel next (smallest Oklab distance to the
- *      claiming region's mean); the boundary settles on the ramp crest.
+ *      claiming region's mean); the boundary settles on the ramp crest. A region
+ *      then takes its color from its flat interior (`CORE_MIN_PIXELS`), so the
+ *      rim the flood attached never tints it toward a neighbor.
  *   4. A region-adjacency-graph merge folds near-duplicate neighbors and small
  *      regions together (agglomerative, closest pair first) down to the real
  *      colors, optionally capped at `maxRegions`.
@@ -82,6 +85,26 @@ const DEFAULT_MIN_AREA = 16
 const SRM_FLOOR = 0.03
 
 /**
+ * A region's palette color is the mean of its *flat interior* pixels — its core —
+ * when that core can speak for it: an anti-aliased rim is a mixture of two
+ * colors, and letting it into the mean tints every region toward its neighbors
+ * (a coral next to a black outline darkens, a white counter inside a glyph
+ * greys). The core speaks when it is at least `CORE_MIN_PIXELS` and at least
+ * `CORE_MIN_SHARE` of the region: a *shaded* region — a mouth's shadow, a
+ * gradient — is almost entirely non-flat (a few percent of it is flat), and its
+ * flattest patch is not its color; it keeps the mean over all its pixels, as does
+ * a rescued feature (no core at all). A flat region that compression has
+ * roughened keeps well over a tenth flat, so the share sits between the two.
+ */
+const CORE_MIN_PIXELS = 4
+const CORE_MIN_SHARE = 0.05
+
+/** Whether a flat core of `coreN` pixels speaks for a region of `size` pixels. */
+function coreSpeaks(coreN: number, size: number): boolean {
+  return coreN >= CORE_MIN_PIXELS && coreN >= CORE_MIN_SHARE * size
+}
+
+/**
  * Thin features (a hairline glyph like an "&", a dot, a thin serif) have no flat
  * interior, so step 2 gives them no marker and the flood dissolves them into the
  * regions around them. These knobs govern rescuing such a feature as its own
@@ -100,20 +123,26 @@ const RESCUE_COHERENCE = 0.2
 // pixel, for the marker on that side (the field). Only a feature's own rim lies
 // between it and its field; anything farther has no field to be enclosed by.
 const RESCUE_REACH = 24
-// Share of a blob's pixels that must meet the same color on *both* ends of an
-// axis for it to count as enclosed by that color. This is what tells a feature
-// from a ramp: a stroke has its field on opposite sides, while a sliver of a soft
-// edge has one color on one side and the other color on the other — however far
-// it sits from either, so no contrast threshold is needed to reject it.
-const RESCUE_ENCLOSURE = 0.8
-// Oklab ΔE within which two markers count as the same color when measuring the
-// surround (so a divider between two patches of one color still reads as enclosed,
-// and near-duplicate markers do not split the dominant). ~JND, the near-duplicate floor.
-const RESCUE_GROUP = SRM_FLOOR
-// Oklab ΔE a feature's color must exceed its enclosing field by to be rescued.
-// Ramps are rejected by enclosure, so this only screens a same-color halo the
-// flood absorbs anyway; a dark stroke on a mid-tone field (fur, a facial line,
-// ≈0.4) clears it, and a black glyph on white (≈0.9) easily.
+// A side of the blob's own color met within this many pixels is the region the
+// blob is the *edge of* — its anti-aliased rim, or a shade of it — so the pixel
+// is that region's, not a feature's. Met farther away, the same color is where a
+// line *ends* against an outline or a shadow, and says nothing about the line.
+const RESCUE_ADJACENT = 3
+// Share of a blob's pixels that must be a color *extreme* between the two sides
+// met on some axis. A mixture of its sides — a sliver of a soft edge — lies
+// between them in color, so ΔE(b,F1) + ΔE(b,F2) ≈ ΔE(F1,F2); a real feature lies
+// outside that segment: a glyph on one field (F1 = F2), a divider between two
+// patches of one color, or a contour line between two different colors is
+// farther from both sides than they are from each other. This is what tells a
+// feature from a ramp, at any contrast, so no ramp threshold is needed. A clear
+// majority is demanded: a clean line scores well above it, while a web that
+// mixes outline with the rims it drags along (a whole mouth's contour network)
+// scores just above half and must not be seeded as one muddy region.
+const RESCUE_ENCLOSURE = 0.7
+// Oklab ΔE a feature's color must exceed *each* side by, and the excess
+// ΔE(b,F1) + ΔE(b,F2) − ΔE(F1,F2) must reach, for a pixel to count as an extreme.
+// Screens a same-color halo the flood absorbs anyway; a dark stroke on a mid-tone
+// field (fur, a facial line, ≈0.4) clears it, a black glyph on white (≈0.9) easily.
 const RESCUE_MIN_CONTRAST = 0.25
 
 /** Oklab distance between interleaved-buffer index `i` and a mean triple. */
@@ -277,24 +306,42 @@ export function segmentRegions(image: RasterImage, opts: SegmentOptions = {}): S
   // ---- 3. Priority flood: grow markers over edge/ramp pixels ----
   floodRegions(ok, region, w, n, mask, mL, mA, mB)
 
-  // Recompute means/sizes over the grown regions (ramp pixels shifted them).
-  mL.fill(0, 0, regionCount)
-  mA.fill(0, 0, regionCount)
-  mB.fill(0, 0, regionCount)
+  // Recompute means/sizes over the grown regions, keeping both the sum over every
+  // pixel and the sum over the flat core: a region whose core speaks for it (see
+  // `coreSpeaks`) takes its color from the core alone — the rim the flood
+  // attached is a mixture that would tint it toward its neighbors — while a
+  // shaded region, or a rescued feature with no core, uses every pixel.
   size.fill(0, 0, regionCount)
+  const fullL = new Float64Array(regionCount)
+  const fullA = new Float64Array(regionCount)
+  const fullB = new Float64Array(regionCount)
+  const coreL = new Float64Array(regionCount)
+  const coreA = new Float64Array(regionCount)
+  const coreB = new Float64Array(regionCount)
+  const coreN = new Int32Array(regionCount)
   for (let p = 0; p < n; p++) {
     const r = region[p]
     if (r < 0) continue
-    mL[r] += ok[p * 3]
-    mA[r] += ok[p * 3 + 1]
-    mB[r] += ok[p * 3 + 2]
+    fullL[r] += ok[p * 3]
+    fullA[r] += ok[p * 3 + 1]
+    fullB[r] += ok[p * 3 + 2]
     size[r]++
+    if (grad[p] < flatThreshold) {
+      coreL[r] += ok[p * 3]
+      coreA[r] += ok[p * 3 + 1]
+      coreB[r] += ok[p * 3 + 2]
+      coreN[r]++
+    }
   }
   for (let r = 0; r < regionCount; r++) {
-    if (size[r] > 0) {
-      mL[r] /= size[r]
-      mA[r] /= size[r]
-      mB[r] /= size[r]
+    if (coreSpeaks(coreN[r], size[r])) {
+      mL[r] = coreL[r] / coreN[r]
+      mA[r] = coreA[r] / coreN[r]
+      mB[r] = coreB[r] / coreN[r]
+    } else if (size[r] > 0) {
+      mL[r] = fullL[r] / size[r]
+      mA[r] = fullA[r] / size[r]
+      mB[r] = fullB[r] / size[r]
     }
   }
 
@@ -308,6 +355,13 @@ export function segmentRegions(image: RasterImage, opts: SegmentOptions = {}): S
     mA,
     mB,
     size,
+    fullL,
+    fullA,
+    fullB,
+    coreL,
+    coreA,
+    coreB,
+    coreN,
     mergeThreshold,
     sizeBias,
     minArea,
@@ -499,14 +553,15 @@ interface RescuedFeature {
  * is a chain of small steps.
  *
  * A blob is rescued as its own marker (seeded with its mean color) when it spans
- * at least `minArea` pixels; its field — the first marker found walking out from
- * each pixel, over any unmarked pixel, in each of the four directions — is one
- * color on *both* ends of an axis for at least `RESCUE_ENCLOSURE` of its pixels
- * (same color on both sides of a divider counts, so a bar splitting a field is
- * rescued too); and its color differs from that field by at least
- * `RESCUE_MIN_CONTRAST`. A sliver of a genuine edge ramp has one color on one side
- * and the other color on the other, however far it sits from either, so it fails
- * enclosure and is left for the flood to split — the no-third-color guarantee holds.
+ * at least `minArea` pixels and, for at least `RESCUE_ENCLOSURE` of its pixels, it
+ * is a color extreme between the two sides met on some axis — the first markers
+ * found walking out from the pixel, over any unmarked pixel, in opposite
+ * directions: at least `RESCUE_MIN_CONTRAST` from each, and farther from both
+ * than they are from each other. That covers a glyph on one field, a divider
+ * between two patches of one color, and a contour line between two different
+ * colors. A sliver of a genuine edge ramp is a mixture of its two sides and lies
+ * between them in color, however far it sits from either, so it fails and is left
+ * for the flood to split — the no-third-color guarantee holds.
  *
  * Blobs are rescued most-contrasting first and each promotion is written into
  * `region`, so a feature's own rim — evaluated later, now bordered by the just-
@@ -528,8 +583,6 @@ function rescueMarkerlessFeatures(
   minArea: number,
 ): RescuedFeature[] {
   const coh2 = RESCUE_COHERENCE * RESCUE_COHERENCE
-  const contrast2 = RESCUE_MIN_CONTRAST * RESCUE_MIN_CONTRAST
-  const group2 = RESCUE_GROUP * RESCUE_GROUP
 
   // ---- 1. Carve color-tight blobs out of the unmarked web ----
   // `order` holds each blob's pixels contiguously in [start, start+len). A pixel
@@ -658,101 +711,101 @@ function rescueMarkerlessFeatures(
   const promL = new Float64Array(cand.length)
   const promA = new Float64Array(cand.length)
   const promB = new Float64Array(cand.length)
-  const total = regionCount + cand.length
-  const census = new Int32Array(total)
-  const seenList = new Int32Array(total)
-  // The field met on each side of every pixel of the blob under study (4 per pixel).
-  let maxLen = 0
-  for (const id of cand) if (blobLen[id] > maxLen) maxLen = blobLen[id]
-  const ends = new Int32Array(maxLen * 4)
-
-  /** The first marker met walking from (x, y) in direction (dx, dy), or -1 within `RESCUE_REACH`. */
+  /**
+   * The first marker met walking from (x, y) in direction (dx, dy), or -1 within
+   * `RESCUE_REACH`; `walked` is left holding how far it was.
+   */
+  let walked = 0
   const walk = (x: number, y: number, dx: number, dy: number): number => {
     for (let k = 1; k <= RESCUE_REACH; k++) {
       const xx = x + dx * k
       const yy = y + dy * k
       if (xx < 0 || yy < 0 || xx >= w || yy >= h) return -1
       const r = region[yy * w + xx]
-      if (r >= 0) return r
+      if (r >= 0) {
+        walked = k
+        return r
+      }
     }
     return -1
   }
 
   /**
-   * Find the field around blob `id` over the current `region`: the first marker
-   * met walking out of each pixel in each of the four directions. Returns the
-   * share of pixels that meet the dominant color (near-duplicates included) on
-   * *both* ends of an axis — enclosure by that color — and that color's ΔE² to
-   * the blob's mean.
+   * Judge blob `id` against the sides of its pixels over the current `region`:
+   * the first markers met walking out in opposite directions. A pixel is an
+   * *extreme* on an axis when its blob is at least `RESCUE_MIN_CONTRAST` from
+   * both sides and farther from both than they are from each other — a mixture
+   * of its sides (a ramp sliver) is not. Returns the share of pixels that are an
+   * extreme on some axis, and the mean distance to the nearer side (for ordering).
    */
-  const surround = (id: number): { enclosure: number; contrast2: number; dom: number } => {
+  const judge = (id: number): { extreme: number; contrast: number } => {
     const start = blobStart[id]
     const len = blobLen[id]
+    const bL = cmL[id]
+    const bA = cmA[id]
+    const bB = cmB[id]
+    const toBlob = (r: number): number => {
+      const dl = markerColor(r, promL, mL) - bL
+      const da = markerColor(r, promA, mA) - bA
+      const db = markerColor(r, promB, mB) - bB
+      return Math.sqrt(dl * dl + da * da + db * db)
+    }
+    const apart = (r1: number, r2: number): number => {
+      const dl = markerColor(r1, promL, mL) - markerColor(r2, promL, mL)
+      const da = markerColor(r1, promA, mA) - markerColor(r2, promA, mA)
+      const db = markerColor(r1, promB, mB) - markerColor(r2, promB, mB)
+      return Math.sqrt(dl * dl + da * da + db * db)
+    }
+    let extreme = 0
+    let sum = 0
     let seen = 0
-    let mass = 0
     for (let k = 0; k < len; k++) {
       const p = order[start + k]
       const px = p - ((p / w) | 0) * w
       const py = (p / w) | 0
-      const e = k * 4
-      ends[e] = walk(px, py, -1, 0)
-      ends[e + 1] = walk(px, py, 1, 0)
-      ends[e + 2] = walk(px, py, 0, -1)
-      ends[e + 3] = walk(px, py, 0, 1)
-      for (let d = 0; d < 4; d++) {
-        const r = ends[e + d]
-        if (r < 0) continue
-        mass++
-        if (census[r]++ === 0) seenList[seen++] = r
+      // Each axis with both sides found says one of four things. A side of the
+      // blob's own color met within RESCUE_ADJACENT is the region this pixel is
+      // the edge of — it vetoes the pixel. The same color met farther away is
+      // where a line ends against an outline or a shadow, and that axis says
+      // nothing. Otherwise the blob is either an extreme between the two sides
+      // or a mixture of them (a rim), and one mixture axis vetoes the pixel: a
+      // rim ring is given away by its across-axis whatever its along-axis says,
+      // while a real line has no axis that calls it a mixture.
+      let tested = 0
+      let agreed = 0
+      let edge = false
+      for (let axis = 0; axis < 2; axis++) {
+        const f1 = axis === 0 ? walk(px, py, -1, 0) : walk(px, py, 0, -1)
+        const k1 = walked
+        const f2 = axis === 0 ? walk(px, py, 1, 0) : walk(px, py, 0, 1)
+        const k2 = walked
+        if (f1 < 0 || f2 < 0) continue
+        const d1 = toBlob(f1)
+        const d2 = toBlob(f2)
+        const near = d1 < d2 ? d1 : d2
+        sum += near
+        seen++
+        if (near < RESCUE_MIN_CONTRAST) {
+          if ((d1 <= d2 ? k1 : k2) <= RESCUE_ADJACENT) edge = true
+          continue
+        }
+        tested++
+        if (d1 + d2 - apart(f1, f2) >= RESCUE_MIN_CONTRAST) agreed++
       }
+      if (!edge && tested > 0 && agreed === tested) extreme++
     }
-    if (mass === 0) return { enclosure: 0, contrast2: 0, dom: -1 }
-    let dom = -1
-    let domCnt = 0
-    for (let t = 0; t < seen; t++) {
-      const r = seenList[t]
-      if (census[r] > domCnt) {
-        domCnt = census[r]
-        dom = r
-      }
-      census[r] = 0
-    }
-    const dL = markerColor(dom, promL, mL)
-    const dA = markerColor(dom, promA, mA)
-    const dB = markerColor(dom, promB, mB)
-    const isField = (r: number): boolean => {
-      if (r < 0) return false
-      const el = markerColor(r, promL, mL) - dL
-      const ea = markerColor(r, promA, mA) - dA
-      const eb = markerColor(r, promB, mB) - dB
-      return el * el + ea * ea + eb * eb < group2
-    }
-    let twoSided = 0
-    for (let k = 0; k < len; k++) {
-      const e = k * 4
-      if (
-        (isField(ends[e]) && isField(ends[e + 1])) ||
-        (isField(ends[e + 2]) && isField(ends[e + 3]))
-      ) {
-        twoSided++
-      }
-    }
-    const bl = cmL[id] - dL
-    const ba = cmA[id] - dA
-    const bb = cmB[id] - dB
-    return { enclosure: twoSided / len, contrast2: bl * bl + ba * ba + bb * bb, dom }
+    return { extreme: extreme / len, contrast: seen > 0 ? sum / seen : 0 }
   }
 
-  // Extremeness for ordering: contrast to the surround over the original markers.
+  // Order most-contrasting first (judged against the original markers).
   const ext = new Float64Array(blobs)
-  for (const id of cand) ext[id] = surround(id).contrast2
+  for (const id of cand) ext[id] = judge(id).contrast
   cand.sort((x, y) => ext[y] - ext[x] || x - y)
 
   // ---- 3. Promote each qualifying blob, writing it into `region` as it goes ----
   const out: RescuedFeature[] = []
   for (const id of cand) {
-    const s = surround(id)
-    if (s.dom < 0 || s.enclosure < RESCUE_ENCLOSURE || s.contrast2 < contrast2) continue
+    if (judge(id).extreme < RESCUE_ENCLOSURE) continue
     const newId = regionCount + out.length
     const start = blobStart[id]
     const end = start + blobLen[id]
@@ -768,10 +821,17 @@ function rescueMarkerlessFeatures(
 /**
  * Agglomerative region-adjacency-graph merge. Union-find over regions; each
  * round folds every adjacent pair whose mean-color ΔE is under `mergeThreshold`
- * or where either side is below `minArea`, closest pair first, updating the
- * surviving mean as a size-weighted average. A final pass enforces `maxRegions`
- * by merging the globally closest adjacent pair until the cap is met. Returns
- * the parent array (each region's representative root).
+ * or where either side is below `minArea`, closest pair first. Adjacent pairs
+ * are judged on their means over *every* pixel, rims included: a sliver the
+ * flood grew from a lone flat pixel is rim material (a chroma-bled speck of
+ * black along a pupil), and what folds it into the region it lies against is
+ * the tint of that region's own rim — which its flat core would hide. The
+ * surviving *color* is that of the merged flat cores when they speak for the
+ * region (see `coreSpeaks` — so the rims a region gathers never tint it, and a
+ * white counter split into specks by compression still reads white), else the
+ * mean over every pixel; consolidation and the `maxRegions` cap compare those
+ * rendered colors, so two regions that would paint the same become one palette
+ * entry. Returns the parent array (each region's representative root).
  */
 function mergeRegions(
   region: Int32Array,
@@ -782,6 +842,13 @@ function mergeRegions(
   mA: Float64Array,
   mB: Float64Array,
   size: Float64Array,
+  fullL: Float64Array,
+  fullA: Float64Array,
+  fullB: Float64Array,
+  coreL: Float64Array,
+  coreA: Float64Array,
+  coreB: Float64Array,
+  coreN: Int32Array,
   mergeThreshold: number,
   sizeBias: number,
   minArea: number,
@@ -799,10 +866,19 @@ function mergeRegions(
     }
     return r
   }
+  // ΔE between the colors two regions are rendered with.
   const meanDelta = (a: number, b: number): number => {
     const dl = mL[a] - mL[b]
     const da = mA[a] - mA[b]
     const db = mB[a] - mB[b]
+    return Math.sqrt(dl * dl + da * da + db * db)
+  }
+  // ΔE between two regions' means over every pixel, rims included — what the
+  // adjacency rounds merge on.
+  const fullDelta = (a: number, b: number): number => {
+    const dl = fullL[a] / size[a] - fullL[b] / size[b]
+    const da = fullA[a] / size[a] - fullA[b] / size[b]
+    const db = fullB[a] / size[a] - fullB[b] / size[b]
     return Math.sqrt(dl * dl + da * da + db * db)
   }
   // Size-aware merge tolerance (Nock & Nielsen 2004). Off (`sizeBias === 0`) it
@@ -820,10 +896,22 @@ function mergeRegions(
     const keep = size[a] >= size[b] ? a : b
     const drop = keep === a ? b : a
     const nn = size[a] + size[b]
-    if (nn > 0) {
-      mL[keep] = (mL[a] * size[a] + mL[b] * size[b]) / nn
-      mA[keep] = (mA[a] * size[a] + mA[b] * size[b]) / nn
-      mB[keep] = (mB[a] * size[a] + mB[b] * size[b]) / nn
+    fullL[keep] += fullL[drop]
+    fullA[keep] += fullA[drop]
+    fullB[keep] += fullB[drop]
+    coreL[keep] += coreL[drop]
+    coreA[keep] += coreA[drop]
+    coreB[keep] += coreB[drop]
+    coreN[keep] += coreN[drop]
+    if (coreSpeaks(coreN[keep], nn)) {
+      // The merged flat interior speaks for the region; the rims it gathered do not.
+      mL[keep] = coreL[keep] / coreN[keep]
+      mA[keep] = coreA[keep] / coreN[keep]
+      mB[keep] = coreB[keep] / coreN[keep]
+    } else if (nn > 0) {
+      mL[keep] = fullL[keep] / nn
+      mA[keep] = fullA[keep] / nn
+      mB[keep] = fullB[keep] / nn
     }
     size[keep] = nn
     parent[drop] = keep
@@ -875,7 +963,7 @@ function mergeRegions(
     const edges = collectEdges()
     // Candidates ordered by ΔE, then region ids, for a deterministic sequence.
     const cand = edges
-      .map(([a, b]): [number, number, number] => [a, b, meanDelta(a, b)])
+      .map(([a, b]): [number, number, number] => [a, b, fullDelta(a, b)])
       .toSorted((p, q) => p[2] - q[2] || p[0] - q[0] || p[1] - q[1])
     let merged = false
     for (const [a, b, d] of cand) {

--- a/packages/raster/src/segment.ts
+++ b/packages/raster/src/segment.ts
@@ -89,31 +89,32 @@ const SRM_FLOOR = 0.03
  * disturbing genuine anti-aliased edges — which sit *between two* colors and must
  * still split.
  */
-// Oklab ΔE two neighboring unmarked pixels must be within to grow the same
-// feature. Anti-aliasing/compression 4-connects every edge in the image into one
-// web; growing only through near-equal colors carves the coherent glyph strokes
-// (a near-uniform dark blob) back out of it, cut off at the ramp to the field.
+// Oklab ΔE an unmarked pixel must be within of a growing blob's *running mean*
+// to join it. Anti-aliasing/compression 4-connects every edge in the image into
+// one web, and a soft rim (navy → teal → blue) is a chain of small steps, so a
+// step-to-step bound would drift right across it; bounding to the mean instead
+// keeps a blob color-tight — a glyph's strokes come out as one near-uniform
+// blob, cut off where the rim begins.
 const RESCUE_COHERENCE = 0.2
-// Chebyshev radius the enclosing color is censused over. A feature carries a thin
-// transition rim of its own, so its flat neighbor is a pixel or two out, not
-// strictly 4-adjacent; this reaches past the rim without reaching other features.
-const RESCUE_DILATE = 2
-// Fraction of that surround that must be a single color for the blob to count as
-// a starved feature rather than a two-sided ramp. A ramp borders its two colors
-// in ~equal measure; an enclosed feature is surrounded almost entirely by one.
-const RESCUE_ENCLOSURE = 0.85
+// Farthest a pixel looks, in each of the four directions and over any unmarked
+// pixel, for the marker on that side (the field). Only a feature's own rim lies
+// between it and its field; anything farther has no field to be enclosed by.
+const RESCUE_REACH = 24
+// Share of a blob's pixels that must meet the same color on *both* ends of an
+// axis for it to count as enclosed by that color. This is what tells a feature
+// from a ramp: a stroke has its field on opposite sides, while a sliver of a soft
+// edge has one color on one side and the other color on the other — however far
+// it sits from either, so no contrast threshold is needed to reject it.
+const RESCUE_ENCLOSURE = 0.8
 // Oklab ΔE within which two markers count as the same color when measuring the
 // surround (so a divider between two patches of one color still reads as enclosed,
 // and near-duplicate markers do not split the dominant). ~JND, the near-duplicate floor.
 const RESCUE_GROUP = SRM_FLOOR
-// Oklab ΔE a feature's color must exceed its enclosing color by to be rescued.
-// A soft edge assigns each pixel to its nearer side at an error up to about half
-// the edge's ΔE (≈0.5 for the hardest black↔white edge), so a sliver of a ramp
-// can sit this far from the one side it is enclosed by; the gate is set past that
-// band. A real detail against its field (black glyph on white ≈ 0.9) clears it
-// easily; only low-contrast thin features (which the flood renders acceptably)
-// are left alone.
-const RESCUE_MIN_CONTRAST = 0.5
+// Oklab ΔE a feature's color must exceed its enclosing field by to be rescued.
+// Ramps are rejected by enclosure, so this only screens a same-color halo the
+// flood absorbs anyway; a dark stroke on a mid-tone field (fur, a facial line,
+// ≈0.4) clears it, and a black glyph on white (≈0.9) easily.
+const RESCUE_MIN_CONTRAST = 0.25
 
 /** Oklab distance between interleaved-buffer index `i` and a mean triple. */
 function distToMean(ok: Float32Array, i: number, mL: number, mA: number, mB: number): number {
@@ -491,18 +492,21 @@ interface RescuedFeature {
  *
  * Finding those features is not just a matter of connected components: on an
  * anti-aliased or compressed image every edge in the picture is 4-connected into
- * one unmarked web, so the "&" is not an island. Growing only through *near-equal*
- * colors (`RESCUE_COHERENCE`) carves each coherent feature — a glyph's near-uniform
- * strokes — back out of that web, stopping where the color ramps toward the field.
+ * one unmarked web, so the "&" is not an island. Each blob is grown color-tight —
+ * a pixel joins only while within `RESCUE_COHERENCE` of the blob's running mean —
+ * which carves a coherent feature (a glyph's near-uniform strokes) back out of
+ * that web and stops where the color ramps toward the field, even when the ramp
+ * is a chain of small steps.
  *
  * A blob is rescued as its own marker (seeded with its mean color) when it spans
- * at least `minArea` pixels; a single color fills at least `RESCUE_ENCLOSURE` of
- * the markers around it (censused over a `RESCUE_DILATE` window, since a feature
- * carries its own thin rim — same color on both sides of a divider counts as one
- * enclosure, so a bar splitting a field is rescued too); and its color differs
- * from that enclosing color by at least `RESCUE_MIN_CONTRAST`. A genuine edge ramp
- * fails the enclosure test (it borders its two colors in ~equal measure) and is
- * left for the flood to split — the no-third-color guarantee holds.
+ * at least `minArea` pixels; its field — the first marker found walking out from
+ * each pixel, over any unmarked pixel, in each of the four directions — is one
+ * color on *both* ends of an axis for at least `RESCUE_ENCLOSURE` of its pixels
+ * (same color on both sides of a divider counts, so a bar splitting a field is
+ * rescued too); and its color differs from that field by at least
+ * `RESCUE_MIN_CONTRAST`. A sliver of a genuine edge ramp has one color on one side
+ * and the other color on the other, however far it sits from either, so it fails
+ * enclosure and is left for the flood to split — the no-third-color guarantee holds.
  *
  * Blobs are rescued most-contrasting first and each promotion is written into
  * `region`, so a feature's own rim — evaluated later, now bordered by the just-
@@ -526,10 +530,10 @@ function rescueMarkerlessFeatures(
   const coh2 = RESCUE_COHERENCE * RESCUE_COHERENCE
   const contrast2 = RESCUE_MIN_CONTRAST * RESCUE_MIN_CONTRAST
   const group2 = RESCUE_GROUP * RESCUE_GROUP
-  const R = RESCUE_DILATE
 
-  // ---- 1. Carve color-coherent blobs out of the unmarked web ----
-  // `order` holds each blob's pixels contiguously in [start, start+len).
+  // ---- 1. Carve color-tight blobs out of the unmarked web ----
+  // `order` holds each blob's pixels contiguously in [start, start+len). A pixel
+  // joins a blob only while within RESCUE_COHERENCE of the blob's running mean.
   const blobId = new Int32Array(n).fill(-1)
   const order = new Int32Array(n)
   const stack = new Int32Array(n)
@@ -551,23 +555,30 @@ function rescueMarkerlessFeatures(
     }
     const id = blobs++
     const start = pos
+    let sumL = 0
+    let sumA = 0
+    let sumB = 0
     let sp = 0
     stack[sp++] = s
     blobId[s] = id
     while (sp > 0) {
       const p = stack[--sp]
       order[pos++] = p
-      const pL = ok[p * 3]
-      const pA = ok[p * 3 + 1]
-      const pB = ok[p * 3 + 2]
+      sumL += ok[p * 3]
+      sumA += ok[p * 3 + 1]
+      sumB += ok[p * 3 + 2]
+      const count = pos - start
+      const bL = sumL / count
+      const bA = sumA / count
+      const bB = sumB / count
       const x = p - ((p / w) | 0) * w
-      // Grow to an unmarked in-mask neighbor within RESCUE_COHERENCE of this pixel.
+      // Grow to an unmarked in-mask neighbor within RESCUE_COHERENCE of the running mean.
       if (x > 0) {
         const q = p - 1
         if (blobId[q] === -1 && region[q] === -1 && (mask === null || mask[q] !== 0)) {
-          const dl = ok[q * 3] - pL
-          const da = ok[q * 3 + 1] - pA
-          const db = ok[q * 3 + 2] - pB
+          const dl = ok[q * 3] - bL
+          const da = ok[q * 3 + 1] - bA
+          const db = ok[q * 3 + 2] - bB
           if (dl * dl + da * da + db * db < coh2) {
             blobId[q] = id
             stack[sp++] = q
@@ -577,9 +588,9 @@ function rescueMarkerlessFeatures(
       if (x < w - 1) {
         const q = p + 1
         if (blobId[q] === -1 && region[q] === -1 && (mask === null || mask[q] !== 0)) {
-          const dl = ok[q * 3] - pL
-          const da = ok[q * 3 + 1] - pA
-          const db = ok[q * 3 + 2] - pB
+          const dl = ok[q * 3] - bL
+          const da = ok[q * 3 + 1] - bA
+          const db = ok[q * 3 + 2] - bB
           if (dl * dl + da * da + db * db < coh2) {
             blobId[q] = id
             stack[sp++] = q
@@ -589,9 +600,9 @@ function rescueMarkerlessFeatures(
       if (p >= w) {
         const q = p - w
         if (blobId[q] === -1 && region[q] === -1 && (mask === null || mask[q] !== 0)) {
-          const dl = ok[q * 3] - pL
-          const da = ok[q * 3 + 1] - pA
-          const db = ok[q * 3 + 2] - pB
+          const dl = ok[q * 3] - bL
+          const da = ok[q * 3 + 1] - bA
+          const db = ok[q * 3 + 2] - bB
           if (dl * dl + da * da + db * db < coh2) {
             blobId[q] = id
             stack[sp++] = q
@@ -601,9 +612,9 @@ function rescueMarkerlessFeatures(
       if (p < n - w) {
         const q = p + w
         if (blobId[q] === -1 && region[q] === -1 && (mask === null || mask[q] !== 0)) {
-          const dl = ok[q * 3] - pL
-          const da = ok[q * 3 + 1] - pA
-          const db = ok[q * 3 + 2] - pB
+          const dl = ok[q * 3] - bL
+          const da = ok[q * 3 + 1] - bA
+          const db = ok[q * 3 + 2] - bB
           if (dl * dl + da * da + db * db < coh2) {
             blobId[q] = id
             stack[sp++] = q
@@ -650,38 +661,52 @@ function rescueMarkerlessFeatures(
   const total = regionCount + cand.length
   const census = new Int32Array(total)
   const seenList = new Int32Array(total)
+  // The field met on each side of every pixel of the blob under study (4 per pixel).
+  let maxLen = 0
+  for (const id of cand) if (blobLen[id] > maxLen) maxLen = blobLen[id]
+  const ends = new Int32Array(maxLen * 4)
+
+  /** The first marker met walking from (x, y) in direction (dx, dy), or -1 within `RESCUE_REACH`. */
+  const walk = (x: number, y: number, dx: number, dy: number): number => {
+    for (let k = 1; k <= RESCUE_REACH; k++) {
+      const xx = x + dx * k
+      const yy = y + dy * k
+      if (xx < 0 || yy < 0 || xx >= w || yy >= h) return -1
+      const r = region[yy * w + xx]
+      if (r >= 0) return r
+    }
+    return -1
+  }
 
   /**
-   * Census the markers in a `RESCUE_DILATE` window around blob `id` over the
-   * current `region`, then return the mass fraction held by the dominant color
-   * (same-color markers summed) and that color's ΔE² to the blob's mean.
+   * Find the field around blob `id` over the current `region`: the first marker
+   * met walking out of each pixel in each of the four directions. Returns the
+   * share of pixels that meet the dominant color (near-duplicates included) on
+   * *both* ends of an axis — enclosure by that color — and that color's ΔE² to
+   * the blob's mean.
    */
   const surround = (id: number): { enclosure: number; contrast2: number; dom: number } => {
     const start = blobStart[id]
-    const end = start + blobLen[id]
+    const len = blobLen[id]
     let seen = 0
     let mass = 0
-    for (let k = start; k < end; k++) {
-      const p = order[k]
+    for (let k = 0; k < len; k++) {
+      const p = order[start + k]
       const px = p - ((p / w) | 0) * w
       const py = (p / w) | 0
-      for (let dy = -R; dy <= R; dy++) {
-        const yy = py + dy
-        if (yy < 0 || yy >= h) continue
-        for (let dx = -R; dx <= R; dx++) {
-          const xx = px + dx
-          if (xx < 0 || xx >= w) continue
-          const r = region[yy * w + xx]
-          if (r < 0) continue
-          mass++
-          if (census[r]++ === 0) seenList[seen++] = r
-        }
+      const e = k * 4
+      ends[e] = walk(px, py, -1, 0)
+      ends[e + 1] = walk(px, py, 1, 0)
+      ends[e + 2] = walk(px, py, 0, -1)
+      ends[e + 3] = walk(px, py, 0, 1)
+      for (let d = 0; d < 4; d++) {
+        const r = ends[e + d]
+        if (r < 0) continue
+        mass++
+        if (census[r]++ === 0) seenList[seen++] = r
       }
     }
-    if (mass === 0) {
-      for (let t = 0; t < seen; t++) census[seenList[t]] = 0
-      return { enclosure: 0, contrast2: 0, dom: -1 }
-    }
+    if (mass === 0) return { enclosure: 0, contrast2: 0, dom: -1 }
     let dom = -1
     let domCnt = 0
     for (let t = 0; t < seen; t++) {
@@ -690,24 +715,32 @@ function rescueMarkerlessFeatures(
         domCnt = census[r]
         dom = r
       }
+      census[r] = 0
     }
     const dL = markerColor(dom, promL, mL)
     const dA = markerColor(dom, promA, mA)
     const dB = markerColor(dom, promB, mB)
-    let sameColor = 0
-    for (let t = 0; t < seen; t++) {
-      const r = seenList[t]
-      const c = census[r]
-      census[r] = 0
+    const isField = (r: number): boolean => {
+      if (r < 0) return false
       const el = markerColor(r, promL, mL) - dL
       const ea = markerColor(r, promA, mA) - dA
       const eb = markerColor(r, promB, mB) - dB
-      if (el * el + ea * ea + eb * eb < group2) sameColor += c
+      return el * el + ea * ea + eb * eb < group2
+    }
+    let twoSided = 0
+    for (let k = 0; k < len; k++) {
+      const e = k * 4
+      if (
+        (isField(ends[e]) && isField(ends[e + 1])) ||
+        (isField(ends[e + 2]) && isField(ends[e + 3]))
+      ) {
+        twoSided++
+      }
     }
     const bl = cmL[id] - dL
     const ba = cmA[id] - dA
     const bb = cmB[id] - dB
-    return { enclosure: sameColor / mass, contrast2: bl * bl + ba * ba + bb * bb, dom }
+    return { enclosure: twoSided / len, contrast2: bl * bl + ba * ba + bb * bb, dom }
   }
 
   // Extremeness for ordering: contrast to the surround over the original markers.

--- a/packages/raster/src/segment.ts
+++ b/packages/raster/src/segment.ts
@@ -13,6 +13,10 @@
  *   1. Oklab gradient magnitude per pixel.
  *   2. Flat interiors (gradient below `flatThreshold`) are the markers — one
  *      region per 4-connected component, seeded with its mean color.
+ *   2b. A feature too thin to hold a flat interior (a hairline glyph like an "&")
+ *      gets no marker in step 2 and would be swallowed by the flood; each such
+ *      enclosed, contrasting blob is rescued as its own marker first (see
+ *      {@link rescueMarkerlessFeatures}).
  *   3. A priority flood grows the markers over the remaining (edge/ramp) pixels,
  *      always claiming the cheapest pixel next (smallest Oklab distance to the
  *      claiming region's mean); the boundary settles on the ramp crest.
@@ -76,6 +80,40 @@ const DEFAULT_MIN_AREA = 16
  * dominant-color difference above it always survives.
  */
 const SRM_FLOOR = 0.03
+
+/**
+ * Thin features (a hairline glyph like an "&", a dot, a thin serif) have no flat
+ * interior, so step 2 gives them no marker and the flood dissolves them into the
+ * regions around them. These knobs govern rescuing such a feature as its own
+ * marker before the flood (see {@link rescueMarkerlessFeatures}), without
+ * disturbing genuine anti-aliased edges — which sit *between two* colors and must
+ * still split.
+ */
+// Oklab ΔE two neighboring unmarked pixels must be within to grow the same
+// feature. Anti-aliasing/compression 4-connects every edge in the image into one
+// web; growing only through near-equal colors carves the coherent glyph strokes
+// (a near-uniform dark blob) back out of it, cut off at the ramp to the field.
+const RESCUE_COHERENCE = 0.2
+// Chebyshev radius the enclosing color is censused over. A feature carries a thin
+// transition rim of its own, so its flat neighbor is a pixel or two out, not
+// strictly 4-adjacent; this reaches past the rim without reaching other features.
+const RESCUE_DILATE = 2
+// Fraction of that surround that must be a single color for the blob to count as
+// a starved feature rather than a two-sided ramp. A ramp borders its two colors
+// in ~equal measure; an enclosed feature is surrounded almost entirely by one.
+const RESCUE_ENCLOSURE = 0.85
+// Oklab ΔE within which two markers count as the same color when measuring the
+// surround (so a divider between two patches of one color still reads as enclosed,
+// and near-duplicate markers do not split the dominant). ~JND, the near-duplicate floor.
+const RESCUE_GROUP = SRM_FLOOR
+// Oklab ΔE a feature's color must exceed its enclosing color by to be rescued.
+// A soft edge assigns each pixel to its nearer side at an error up to about half
+// the edge's ΔE (≈0.5 for the hardest black↔white edge), so a sliver of a ramp
+// can sit this far from the one side it is enclosed by; the gate is set past that
+// band. A real detail against its field (black glyph on white ≈ 0.9) clears it
+// easily; only low-contrast thin features (which the flood renders acceptably)
+// are left alone.
+const RESCUE_MIN_CONTRAST = 0.5
 
 /** Oklab distance between interleaved-buffer index `i` and a mean triple. */
 function distToMean(ok: Float32Array, i: number, mL: number, mA: number, mB: number): number {
@@ -207,6 +245,32 @@ export function segmentRegions(image: RasterImage, opts: SegmentOptions = {}): S
   // caller always gets a usable label map.
   if (regionCount === 0) {
     return singleRegion(image, mask, n)
+  }
+
+  // ---- 2b. Rescue marker-less features (thin glyphs, dots) as their own markers ----
+  // A feature too thin to hold a flat core would otherwise be dissolved by the
+  // flood into the field around it; give each such isolated component its own
+  // marker, seeded with its own mean color, so the flood grows it as itself.
+  const rescued = rescueMarkerlessFeatures(
+    ok,
+    region,
+    w,
+    h,
+    n,
+    mask,
+    mL,
+    mA,
+    mB,
+    regionCount,
+    Math.max(1, minArea),
+  )
+  for (const f of rescued) {
+    const id = regionCount++
+    grow(id)
+    mL[id] = f.mL
+    mA[id] = f.mA
+    mB[id] = f.mB
+    size[id] = f.size
   }
 
   // ---- 3. Priority flood: grow markers over edge/ramp pixels ----
@@ -407,6 +471,265 @@ function floodRegions(
   for (let p = 0; p < n; p++) {
     if (region[p] === -1 && (mask === null || mask[p] !== 0)) region[p] = 0
   }
+}
+
+/** A rescued feature: the mean color to seed its new marker with, and its pixel count. */
+interface RescuedFeature {
+  mL: number
+  mA: number
+  mB: number
+  size: number
+}
+
+/**
+ * Rescue marker-less features as their own markers, before the flood.
+ *
+ * Step 2 only seeds a marker inside a *flat* interior, so a feature too thin to
+ * hold one — a hairline glyph like an ampersand, a dot, a thin serif — gets no
+ * marker at all. The priority flood then has nothing to grow it as and hands its
+ * pixels to the regions around it: the feature dissolves.
+ *
+ * Finding those features is not just a matter of connected components: on an
+ * anti-aliased or compressed image every edge in the picture is 4-connected into
+ * one unmarked web, so the "&" is not an island. Growing only through *near-equal*
+ * colors (`RESCUE_COHERENCE`) carves each coherent feature — a glyph's near-uniform
+ * strokes — back out of that web, stopping where the color ramps toward the field.
+ *
+ * A blob is rescued as its own marker (seeded with its mean color) when it spans
+ * at least `minArea` pixels; a single color fills at least `RESCUE_ENCLOSURE` of
+ * the markers around it (censused over a `RESCUE_DILATE` window, since a feature
+ * carries its own thin rim — same color on both sides of a divider counts as one
+ * enclosure, so a bar splitting a field is rescued too); and its color differs
+ * from that enclosing color by at least `RESCUE_MIN_CONTRAST`. A genuine edge ramp
+ * fails the enclosure test (it borders its two colors in ~equal measure) and is
+ * left for the flood to split — the no-third-color guarantee holds.
+ *
+ * Blobs are rescued most-contrasting first and each promotion is written into
+ * `region`, so a feature's own rim — evaluated later, now bordered by the just-
+ * promoted glyph as well as the field — no longer reads as enclosed and is left
+ * to the flood. Deterministic: blobs are discovered in row-major order and ties
+ * in contrast break by that order.
+ */
+function rescueMarkerlessFeatures(
+  ok: Float32Array,
+  region: Int32Array,
+  w: number,
+  h: number,
+  n: number,
+  mask: Uint8Array | null,
+  mL: Float64Array,
+  mA: Float64Array,
+  mB: Float64Array,
+  regionCount: number,
+  minArea: number,
+): RescuedFeature[] {
+  const coh2 = RESCUE_COHERENCE * RESCUE_COHERENCE
+  const contrast2 = RESCUE_MIN_CONTRAST * RESCUE_MIN_CONTRAST
+  const group2 = RESCUE_GROUP * RESCUE_GROUP
+  const R = RESCUE_DILATE
+
+  // ---- 1. Carve color-coherent blobs out of the unmarked web ----
+  // `order` holds each blob's pixels contiguously in [start, start+len).
+  const blobId = new Int32Array(n).fill(-1)
+  const order = new Int32Array(n)
+  const stack = new Int32Array(n)
+  let cap = 64
+  let blobStart = new Int32Array(cap)
+  let blobLen = new Int32Array(cap)
+  let blobs = 0
+  let pos = 0
+  for (let s = 0; s < n; s++) {
+    if (blobId[s] !== -1 || region[s] !== -1 || (mask !== null && mask[s] === 0)) continue
+    if (blobs === cap) {
+      cap *= 2
+      const ns = new Int32Array(cap)
+      ns.set(blobStart)
+      blobStart = ns
+      const nl = new Int32Array(cap)
+      nl.set(blobLen)
+      blobLen = nl
+    }
+    const id = blobs++
+    const start = pos
+    let sp = 0
+    stack[sp++] = s
+    blobId[s] = id
+    while (sp > 0) {
+      const p = stack[--sp]
+      order[pos++] = p
+      const pL = ok[p * 3]
+      const pA = ok[p * 3 + 1]
+      const pB = ok[p * 3 + 2]
+      const x = p - ((p / w) | 0) * w
+      // Grow to an unmarked in-mask neighbor within RESCUE_COHERENCE of this pixel.
+      if (x > 0) {
+        const q = p - 1
+        if (blobId[q] === -1 && region[q] === -1 && (mask === null || mask[q] !== 0)) {
+          const dl = ok[q * 3] - pL
+          const da = ok[q * 3 + 1] - pA
+          const db = ok[q * 3 + 2] - pB
+          if (dl * dl + da * da + db * db < coh2) {
+            blobId[q] = id
+            stack[sp++] = q
+          }
+        }
+      }
+      if (x < w - 1) {
+        const q = p + 1
+        if (blobId[q] === -1 && region[q] === -1 && (mask === null || mask[q] !== 0)) {
+          const dl = ok[q * 3] - pL
+          const da = ok[q * 3 + 1] - pA
+          const db = ok[q * 3 + 2] - pB
+          if (dl * dl + da * da + db * db < coh2) {
+            blobId[q] = id
+            stack[sp++] = q
+          }
+        }
+      }
+      if (p >= w) {
+        const q = p - w
+        if (blobId[q] === -1 && region[q] === -1 && (mask === null || mask[q] !== 0)) {
+          const dl = ok[q * 3] - pL
+          const da = ok[q * 3 + 1] - pA
+          const db = ok[q * 3 + 2] - pB
+          if (dl * dl + da * da + db * db < coh2) {
+            blobId[q] = id
+            stack[sp++] = q
+          }
+        }
+      }
+      if (p < n - w) {
+        const q = p + w
+        if (blobId[q] === -1 && region[q] === -1 && (mask === null || mask[q] !== 0)) {
+          const dl = ok[q * 3] - pL
+          const da = ok[q * 3 + 1] - pA
+          const db = ok[q * 3 + 2] - pB
+          if (dl * dl + da * da + db * db < coh2) {
+            blobId[q] = id
+            stack[sp++] = q
+          }
+        }
+      }
+    }
+    blobStart[id] = start
+    blobLen[id] = pos - start
+  }
+
+  // ---- 2. Candidate blobs (big enough to matter), ordered most-contrasting first ----
+  const cand: number[] = []
+  for (let id = 0; id < blobs; id++) if (blobLen[id] >= minArea) cand.push(id)
+  if (cand.length === 0) return []
+
+  // Blob mean colors (candidates only).
+  const cmL = new Float64Array(blobs)
+  const cmA = new Float64Array(blobs)
+  const cmB = new Float64Array(blobs)
+  for (const id of cand) {
+    const start = blobStart[id]
+    const end = start + blobLen[id]
+    let sL = 0
+    let sA = 0
+    let sB = 0
+    for (let k = start; k < end; k++) {
+      const o = order[k] * 3
+      sL += ok[o]
+      sA += ok[o + 1]
+      sB += ok[o + 2]
+    }
+    cmL[id] = sL / blobLen[id]
+    cmA[id] = sA / blobLen[id]
+    cmB[id] = sB / blobLen[id]
+  }
+
+  // Marker means, extended as blobs are promoted (ids `regionCount + k`).
+  const markerColor = (r: number, c: Float64Array, base: Float64Array): number =>
+    r < regionCount ? base[r] : c[r - regionCount]
+  const promL = new Float64Array(cand.length)
+  const promA = new Float64Array(cand.length)
+  const promB = new Float64Array(cand.length)
+  const total = regionCount + cand.length
+  const census = new Int32Array(total)
+  const seenList = new Int32Array(total)
+
+  /**
+   * Census the markers in a `RESCUE_DILATE` window around blob `id` over the
+   * current `region`, then return the mass fraction held by the dominant color
+   * (same-color markers summed) and that color's ΔE² to the blob's mean.
+   */
+  const surround = (id: number): { enclosure: number; contrast2: number; dom: number } => {
+    const start = blobStart[id]
+    const end = start + blobLen[id]
+    let seen = 0
+    let mass = 0
+    for (let k = start; k < end; k++) {
+      const p = order[k]
+      const px = p - ((p / w) | 0) * w
+      const py = (p / w) | 0
+      for (let dy = -R; dy <= R; dy++) {
+        const yy = py + dy
+        if (yy < 0 || yy >= h) continue
+        for (let dx = -R; dx <= R; dx++) {
+          const xx = px + dx
+          if (xx < 0 || xx >= w) continue
+          const r = region[yy * w + xx]
+          if (r < 0) continue
+          mass++
+          if (census[r]++ === 0) seenList[seen++] = r
+        }
+      }
+    }
+    if (mass === 0) {
+      for (let t = 0; t < seen; t++) census[seenList[t]] = 0
+      return { enclosure: 0, contrast2: 0, dom: -1 }
+    }
+    let dom = -1
+    let domCnt = 0
+    for (let t = 0; t < seen; t++) {
+      const r = seenList[t]
+      if (census[r] > domCnt) {
+        domCnt = census[r]
+        dom = r
+      }
+    }
+    const dL = markerColor(dom, promL, mL)
+    const dA = markerColor(dom, promA, mA)
+    const dB = markerColor(dom, promB, mB)
+    let sameColor = 0
+    for (let t = 0; t < seen; t++) {
+      const r = seenList[t]
+      const c = census[r]
+      census[r] = 0
+      const el = markerColor(r, promL, mL) - dL
+      const ea = markerColor(r, promA, mA) - dA
+      const eb = markerColor(r, promB, mB) - dB
+      if (el * el + ea * ea + eb * eb < group2) sameColor += c
+    }
+    const bl = cmL[id] - dL
+    const ba = cmA[id] - dA
+    const bb = cmB[id] - dB
+    return { enclosure: sameColor / mass, contrast2: bl * bl + ba * ba + bb * bb, dom }
+  }
+
+  // Extremeness for ordering: contrast to the surround over the original markers.
+  const ext = new Float64Array(blobs)
+  for (const id of cand) ext[id] = surround(id).contrast2
+  cand.sort((x, y) => ext[y] - ext[x] || x - y)
+
+  // ---- 3. Promote each qualifying blob, writing it into `region` as it goes ----
+  const out: RescuedFeature[] = []
+  for (const id of cand) {
+    const s = surround(id)
+    if (s.dom < 0 || s.enclosure < RESCUE_ENCLOSURE || s.contrast2 < contrast2) continue
+    const newId = regionCount + out.length
+    const start = blobStart[id]
+    const end = start + blobLen[id]
+    for (let k = start; k < end; k++) region[order[k]] = newId
+    promL[out.length] = cmL[id]
+    promA[out.length] = cmA[id]
+    promB[out.length] = cmB[id]
+    out.push({ mL: cmL[id], mA: cmA[id], mB: cmB[id], size: blobLen[id] })
+  }
+  return out
 }
 
 /**

--- a/packages/raster/test/segment.test.ts
+++ b/packages/raster/test/segment.test.ts
@@ -166,6 +166,23 @@ describe('segmentRegions — rescuing marker-less thin features', () => {
     expect(paletteL(seg, corner)).toBeGreaterThan(0.45)
   })
 
+  it('keeps a dark contour line between two different colors', () => {
+    // A 2px black line where a red field meets a blue one — a cartoon outline,
+    // a tooth separator. It is not a mixture of its two sides (it is farther from
+    // both than they are from each other), so it must survive as its own dark
+    // region instead of being split between red and blue and vanishing.
+    const RED: Rgba = [220, 30, 30, 255]
+    const BLUE: Rgba = [40, 60, 220, 255]
+    const w = 40
+    const img = rasterOf(w, 40, (x) => (x === 19 || x === 20 ? BLACK : x < 19 ? RED : BLUE))
+    const seg = segmentRegions(img)
+    expect(seg.labels.count).toBe(3)
+    const line = seg.labels.data[20 * w + 19]
+    expect(line).not.toBe(seg.labels.data[0])
+    expect(line).not.toBe(seg.labels.data[w - 1])
+    expect(paletteL(seg, line)).toBeLessThan(0.2)
+  })
+
   it('leaves a low-contrast thin feature to the flood (only high-contrast is rescued)', () => {
     // A faint bar (ΔE well under the rescue contrast gate) is one the flood
     // renders acceptably; it must not be seeded as its own region.
@@ -176,6 +193,28 @@ describe('segmentRegions — rescuing marker-less thin features', () => {
       y === mid || y === mid + 1 ? [232, 232, 232, 255] : WHITE,
     )
     expect(segmentRegions(faint).labels.count).toBe(1)
+  })
+})
+
+describe('segmentRegions — palette colors come from flat interiors', () => {
+  it('does not let an absorbed rim tint a region toward its neighbor', () => {
+    // A white square on black with a 1px anti-aliased rim (the 50% mixture every
+    // rim pixel of a real edge is). The rim has no flat interior, so the flood
+    // hands it to the nearer region (white) — correct, no third color — but the
+    // square's palette entry must stay white, taken from its flat interior, not
+    // a rim-darkened grey.
+    const GREY: Rgba = [128, 128, 128, 255]
+    const w = 60
+    const img = rasterOf(w, 60, (x, y) => {
+      const inSquare = x >= 20 && x < 40 && y >= 20 && y < 40
+      const inRim = x >= 19 && x < 41 && y >= 19 && y < 41
+      return inSquare ? WHITE : inRim ? GREY : BLACK
+    })
+    const seg = segmentRegions(img)
+    expect(seg.labels.count).toBe(2)
+    const square = seg.labels.data[30 * w + 30]
+    expect(paletteL(seg, square)).toBeGreaterThan(0.98)
+    expect(paletteL(seg, seg.labels.data[0])).toBeLessThan(0.02)
   })
 })
 

--- a/packages/raster/test/segment.test.ts
+++ b/packages/raster/test/segment.test.ts
@@ -84,6 +84,76 @@ describe('segmentRegions — region growing', () => {
   })
 })
 
+const WHITE: Rgba = [255, 255, 255, 255]
+
+/** Perceptual lightness (Oklab L) of a palette entry, from its RGB bytes. */
+function paletteL(seg: ReturnType<typeof segmentRegions>, label: number): number {
+  const r = seg.paletteRgb[label * 3] / 255
+  const g = seg.paletteRgb[label * 3 + 1] / 255
+  const b = seg.paletteRgb[label * 3 + 2] / 255
+  // Rec. 601 luma is enough to tell "dark" from "light" here.
+  return 0.299 * r + 0.587 * g + 0.114 * b
+}
+
+describe('segmentRegions — rescuing marker-less thin features', () => {
+  // A 2px black bar across a white field: too thin to hold a flat core, so it
+  // gets no marker of its own. Without the rescue pass the flood dissolves it
+  // into the white on either side and it vanishes (one region); the rescue pass
+  // seeds it as its own marker so it survives as a distinct dark region.
+  function thinBarImage(w = 40, h = 40): ReturnType<typeof rasterOf> {
+    const mid = h >> 1
+    return rasterOf(w, h, (_x, y) => (y === mid || y === mid + 1 ? BLACK : WHITE))
+  }
+
+  it('keeps a thin coreless bar instead of dissolving it into the field', () => {
+    const w = 40
+    const h = 40
+    const seg = segmentRegions(thinBarImage(w, h))
+    expect(seg.labels.count).toBe(2)
+    const corner = seg.labels.data[0]
+    const bar = seg.labels.data[(h >> 1) * w + (w >> 1)]
+    expect(bar).not.toBe(corner) // the bar is not painted with the background
+    expect(paletteL(seg, bar)).toBeLessThan(0.2) // and it stays dark
+    expect(paletteL(seg, corner)).toBeGreaterThan(0.8)
+  })
+
+  it('rescues the feature as one region (deterministically)', () => {
+    const img = thinBarImage()
+    const a = segmentRegions(img)
+    const b = segmentRegions(img)
+    expect(b.labels.count).toBe(a.labels.count)
+    expect(Array.from(b.labels.data)).toEqual(Array.from(a.labels.data))
+  })
+
+  it('does not invent a third color on a genuine black↔white ramp', () => {
+    // The mirror case: a two-sided ramp borders two different colors and must
+    // still split between them — the rescue pass must not seed the mid-gray band
+    // as its own region. Checked across ramp widths (a wide, hard edge is the
+    // case whose near-endpoint sliver most tempts the rescue).
+    for (const width of [2, 4, 6, 8]) {
+      const w = 60
+      const ramp = rasterOf(w, 20, (x) => {
+        const t = Math.min(1, Math.max(0, (x - (w / 2 - width / 2)) / width))
+        const v = Math.round(t * 255)
+        return [v, v, v, 255] as Rgba
+      })
+      expect(segmentRegions(ramp).labels.count).toBe(2)
+    }
+  })
+
+  it('leaves a low-contrast thin feature to the flood (only high-contrast is rescued)', () => {
+    // A faint bar (ΔE well under the rescue contrast gate) is one the flood
+    // renders acceptably; it must not be seeded as its own region.
+    const w = 40
+    const h = 40
+    const mid = h >> 1
+    const faint = rasterOf(w, h, (_x, y) =>
+      y === mid || y === mid + 1 ? [232, 232, 232, 255] : WHITE,
+    )
+    expect(segmentRegions(faint).labels.count).toBe(1)
+  })
+})
+
 /** An Oklab color as an 8-bit clamped RGBA pixel. */
 function okPixel(L: number, a: number, b: number): Rgba {
   const [r, g, bl] = oklabToRgb(L, a, b)

--- a/packages/raster/test/segment.test.ts
+++ b/packages/raster/test/segment.test.ts
@@ -141,6 +141,31 @@ describe('segmentRegions — rescuing marker-less thin features', () => {
     }
   })
 
+  it('rescues thin line-art on a colored field despite its soft rim (fur, facial strokes)', () => {
+    // A 2px navy stroke on a mid-blue field, wrapped in an anti-aliased rim: the
+    // rim is a chain of small color steps that joins the stroke to the field's
+    // edge web, and navy-on-blue is far below black-on-white contrast. The stroke
+    // must still come out as its own dark region, with the field on both sides.
+    const FIELD: Rgba = [70, 150, 200, 255]
+    const STROKE: Rgba = [20, 40, 70, 255]
+    const RIM: Rgba = [58, 122, 168, 255] // 25% stroke / 75% field
+    const w = 40
+    const h = 40
+    const mid = h >> 1
+    const img = rasterOf(w, h, (_x, y) => {
+      if (y === mid || y === mid + 1) return STROKE
+      if (y === mid - 1 || y === mid + 2) return RIM
+      return FIELD
+    })
+    const seg = segmentRegions(img)
+    expect(seg.labels.count).toBe(2)
+    const corner = seg.labels.data[0]
+    const stroke = seg.labels.data[mid * w + (w >> 1)]
+    expect(stroke).not.toBe(corner)
+    expect(paletteL(seg, stroke)).toBeLessThan(0.3) // navy, not a rim-diluted teal
+    expect(paletteL(seg, corner)).toBeGreaterThan(0.45)
+  })
+
   it('leaves a low-contrast thin feature to the flood (only high-contrast is rescued)', () => {
     // A faint bar (ΔE well under the rescue contrast gate) is one the flood
     // renders acceptably; it must not be seeded as its own region.


### PR DESCRIPTION
## Summary

Add a pre-flood pass to rescue thin features (hairline glyphs, fur strokes, contour lines, tooth outlines) that have no flat interior and would otherwise be dissolved into the regions around them, and take each region's palette color from its flat interior rather than from the anti-aliased rim the flood attaches to it.

## Changes

- **Rescue pass (step 2b)**, between flat-interior marker detection and the priority flood:
  - Carves color-tight blobs out of the unmarked edge web with a running-mean coherence bound (`RESCUE_COHERENCE = 0.2`), so a soft rim (navy → teal → blue) cannot chain a blob across itself.
  - Judges each blob pixel on its two axes: walk out in both directions to the first marker (`RESCUE_REACH = 24`). The pixel is an **extreme** on an axis when the blob is at least `RESCUE_MIN_CONTRAST = 0.25` from both sides *and* farther from both than they are from each other (`ΔE(b,F1) + ΔE(b,F2) − ΔE(F1,F2) ≥ 0.25`). A mixture of its sides — a sliver of a soft edge — fails that whatever its contrast, so no ramp threshold is needed; a glyph on one field, a divider between two patches of one color and a contour line between two colors all pass.
  - A side of the blob's own color met within `RESCUE_ADJACENT = 3` px is the region the blob is the edge of and vetoes the pixel; the same color met farther away is where a line *ends* against an outline or a shadow and says nothing (this is what keeps a brow stroke that rests on the nose shadow).
  - A blob is promoted as a marker when `RESCUE_ENCLOSURE = 0.7` of its pixels are extrema, most-contrasting blobs first, each promotion written into the region map so later blobs are judged against it. A clean line scores near 1.0; a web that mixes outline with the rims it drags along (a whole mouth's contour network) scores about half and is not seeded as one muddy region.
- **Palette colors from flat cores**: after the flood, a region whose flat core is at least `CORE_MIN_PIXELS = 4` and `CORE_MIN_SHARE = 5 %` of its pixels takes its color from that core; the rim the flood attached is a mixture that would tint it toward its neighbors (a white counter to grey, a tooth to tan). A shaded region or a rescued feature with no core keeps its mean over every pixel, so a mouth's shadow does not snap to a tiny highlight. Full and core sums are carried through the merge so the choice is re-made per merged region.
- **Merge decisions unchanged**: the adjacency rounds still merge on the means over every pixel, rims included — a sliver the flood grows from a lone flat pixel (a chroma-bled speck of black along a pupil) is rim material, and only the tint of the neighbouring region's own rim, hidden by its core, folds it back in. Consolidation and the `maxRegions` cap compare the rendered colors, so two regions that would paint the same become one palette entry.
- **Tests**: thin bars survive instead of dissolving; black↔white ramps of width 2–8 still give exactly two colors; a low-contrast bar is left to the flood; a soft-rimmed stroke on a colored field is rescued; a dark contour line between two colors is kept; a white square with a 1-px grey rim stays white; determinism.

## Evidence

Numbers come from the repo's own harness (`npm run eval:ab`, i.e. `scripts/eval/tracer-compare.ts` → `scripts/eval/ab-report.ts`); primary metrics are mean ΔE and spurious hue (a color invented at a seam), lower is better.

### The reported image (Lilo & Stitch banner — lossy WebP, auto settings → `illustration` + `segmentation: regions`)

| detail | `main` | this PR |
|---|---|---|
| **"&"** — hairline script ampersand, 291 px, no flat interior | **0 %** of its pixels traced dark: it dissolved into background / grey | **93 %** dark, a crisp black glyph with a **100 % white** counter |
| **Belly fur** — navy line-art squiggle on the light-blue belly, 144 px | **57 %** fused into one teal blob | **94 %** deep navy, three distinct strokes |
| **Teeth** — black outlines and separators between the teeth | rims averaged into the teeth; outlines lost | outlines and separators dark again, teeth white |
| **Brow strokes / nose / eyes** | one brow stroke lost | both brow strokes kept, nose contour smooth, no stray stroke under either eye |

Whole image: mean ΔE 0.0167 → 0.0109 (**−34 %**), spurious hue 0.0124 → 0.0096 (**−22 %**), nodes 3090 → 2850 (−8 %).

### Corpus A/B — this PR (`2c014a9`) vs `main` (`05d2bde`)

`tracer-compare --json` on each commit, diffed with `ab-report`.

**Auto settings, `scripts/eval/corpus-vtracer` (6 real images) — VERDICT: PASS**

| family | ΔE | spurious | band | nodes |
|---|---|---|---|---|
| illustration (4) | 0.0159 → 0.0148 (**−6.9 %**) | 0.0092 → 0.0089 (−3.2 %) | 0.0322 → 0.0307 (−4.7 %) | 10146 → 10015 (−1.3 %) |
| lineart (1) / photo (1) | unchanged | unchanged | unchanged | unchanged |
| overall (6) | 0.0244 → 0.0237 (**−3.0 %**) | 0.0124 → 0.0122 (−1.6 %) | 0.0481 → 0.0471 (−2.1 %) | −0.3 % |

Per image: `vectorstock_31191940` ΔE **−15.3 %**, spurious −3.4 %, nodes −2.8 %; `Gum Tree Vector` ΔE −6.1 %, spurious −7.3 %, nodes +0.4 %; the other four are byte-identical — line art and the photo never reach region growing, which is the intended gate.

**Auto settings, same corpus + the banner (7 images) — VERDICT: PASS**

| family | ΔE | spurious | band | nodes |
|---|---|---|---|---|
| illustration (5) | 0.0160 → 0.0140 (**−12.6 %**) | 0.0098 → 0.0090 (**−8.1 %**) | 0.0389 → 0.0353 (−9.3 %) | 8735 → 8582 (−1.7 %) |
| lineart (1) / photo (1) | unchanged | unchanged | unchanged | unchanged |
| overall (7) | 0.0233 → 0.0219 (**−6.2 %**) | 0.0124 → 0.0118 (**−4.5 %**) | 0.0507 → 0.0481 (−5.1 %) | −0.4 % |

**`--set segmentation=regions` forced on every image (the routing this change lives in, per `AGENTS.md`) — VERDICT: MIXED**

| family | ΔE | spurious | band | nodes |
|---|---|---|---|---|
| illustration (4) | 0.0285 → 0.0269 (**−5.6 %**) | 0.0158 → 0.0139 (**−12.0 %**) | 0.0407 → 0.0390 (−4.2 %) | 8847 → 8689 (−1.8 %) |
| lineart (1) | unchanged | unchanged | unchanged | unchanged |
| photo (1) | 0.1093 → 0.1102 (+0.8 %, held) | 0.0334 → 0.0350 (**+4.7 %**) | 0.0969 → 0.1002 (+3.4 %) | 11451 → 12465 (**+8.9 %**) |
| overall (6) | 0.0464 → 0.0454 (−2.0 %) | 0.0203 → 0.0193 (**−4.9 %**) | −1.0 % | +0.6 % |

Per image: `tank-unit-preview` spurious −19.2 %, nodes −10.6 %; `Cityscape Sunset` spurious −10.8 %; `vectorstock_31191940` ΔE −15.3 %; `Gum Tree Vector` ΔE −6.1 %, spurious −7.3 %.

**The trade-off, stated plainly:** a photo pushed through region growing by a manual override picks up a few more rescued specks (+4.7 % spurious hue, +8.9 % nodes, ΔE within tolerance). The recommender never routes a photo to region growing, so auto settings never hit this; every illustration under the same forced routing improves on both primary metrics. Accepted by the author as the trade-off to ship.

<details>
<summary>Per-commit A/B (each commit against the previous head, working tree vs HEAD via <code>npm run eval:ab</code>)</summary>

- `c378b97` ("&" rescue) and `34e2eef` (contour lines): whole-PR-so-far vs `main` was PASS on both corpora (illustration ΔE −4.0 % / −5.2 %, nodes +5–6 %).
- `2c014a9` (extremum judge, adjacency veto, core-color palette, full-mean merge decisions) vs `34e2eef`:
  - auto, 6 images — MIXED in name only: every image improves or is byte-identical (`vectorstock` ΔE −5.0 %, nodes −13.1 %; `Gum Tree` ΔE −6.0 %, spurious −7.4 %) and nothing regresses; the illustration family's ΔE drop (0.0153 → 0.0148) lands exactly on the report's 0.0005 absolute noise floor, so it scores "held" and the report cannot say PASS.
  - `segmentation=regions` forced — MIXED: illustration ΔE −3.9 %, spurious −13.4 %, nodes −8.0 %; photo spurious +4.7 %, nodes +7.7 %.
  - corpus + banner — PASS: banner ΔE −27.4 %, spurious −17.4 %, nodes −9.4 %; illustration (5) ΔE −7.8 %, spurious −6.8 %.

</details>

The source image is kept as a private A/B corpus (`PhenX/Trazor-private` → `fixtures/corpus/`, PR #18) so future changes are measured against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmZ4mY78Bqvw2BLSyqYZEs