### PR TITLE
feat(core,svg): native editable text layer on the document

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -483,6 +483,20 @@ export interface SvgShape {
 }
 // A gradient paint server plus the id a shape references it by (fill: 'url(#id)').
 export type SvgGradient = GradientPaint & { id: string }
+// A native <text> run, emitted after the shapes (drawn on top). App-produced
+// only — the engine never creates one; this lets a document carry & serialize
+// text a consumer recovered (the studio's OCR text layer). x/y/fontSize are user units.
+export interface SvgText {
+  content: string
+  x: number
+  y: number
+  fontSize: number
+  fontFamily: string
+  fontWeight: number // 100..900
+  fill: string // #rrggbb
+  anchor?: 'start' | 'middle' | 'end' // start when absent
+  angle?: number // degrees about (x,y) ⇒ rotate transform; absent ⇒ upright
+}
 export interface SvgDocument {
   width: number // px viewBox size
   height: number
@@ -492,6 +506,9 @@ export interface SvgDocument {
   desc?: string
   defs?: SvgGradient[] // gradient paint servers referenced by shape fills (emitted in <defs>)
   shapes: SvgShape[]
+  // Native text runs, emitted after the shapes. Absent or empty ⇒ no <text>, so a
+  // text-free document serializes byte-identically (the engine's own docs never set it).
+  texts?: SvgText[]
 }
 export interface SerializeOptions {
   precision: number // decimals 0..4
@@ -850,6 +867,21 @@ export interface VectorDocument {
   widthMm?: number
   shapes: VectorShape[]
   gradients?: VectorGradient[] // referenced by a shape's fill: 'url(#id)'
+  texts?: VectorText[] // optional recovered text runs, drawn after the shapes; App-produced, never set by the engine
+}
+// A recovered text run, serialized as a native <text> (see SvgText). App-produced
+// only — the deterministic engine never creates one; this type lets a document
+// carry text a consumer recovered. x/y/fontSize are in the document's user units.
+export interface VectorText {
+  content: string
+  x: number
+  y: number
+  fontSize: number
+  fontFamily: string
+  fontWeight: number // 100..900
+  fill: string // #rrggbb
+  anchor?: 'start' | 'middle' | 'end'
+  angle?: number // degrees about (x,y); absent ⇒ upright
 }
 export interface VectorShape {
   commands: PathCommand[]

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -493,6 +493,7 @@ export interface SvgText {
   fontSize: number
   fontFamily: string
   fontWeight: number // 100..900
+  fontStyle?: 'normal' | 'italic' // 'italic' ⇒ font-style="italic"; absent/normal ⇒ upright
   fill: string // #rrggbb
   anchor?: 'start' | 'middle' | 'end' // start when absent
   angle?: number // degrees about (x,y) ⇒ rotate transform; absent ⇒ upright
@@ -879,6 +880,7 @@ export interface VectorText {
   fontSize: number
   fontFamily: string
   fontWeight: number // 100..900
+  fontStyle?: 'normal' | 'italic' // 'italic' ⇒ slanted; absent/normal ⇒ upright
   fill: string // #rrggbb
   anchor?: 'start' | 'middle' | 'end'
   angle?: number // degrees about (x,y); absent ⇒ upright

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -43,6 +43,8 @@ export interface VectorText {
   fontFamily: string
   /** 100..900. */
   fontWeight: number
+  /** `italic` for slanted text; `normal` (or absent) upright. */
+  fontStyle?: 'normal' | 'italic'
   /** `#rrggbb`. */
   fill: string
   /** Text anchor; `start` when absent. */

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -28,6 +28,29 @@ export interface VectorGradient {
   stops: { offset: number; color: string; opacity?: number }[]
 }
 
+/**
+ * A recovered text run, emitted as a native `<text>` element drawn after the
+ * shapes. **App-produced only** — the deterministic engine never creates one;
+ * this type merely lets a document *carry and serialize* text a consumer
+ * recovered (e.g. the studio's on-device OCR text layer). `x`/`y`/`fontSize`
+ * are in the document's user units, matching {@link VectorDocument.width}.
+ */
+export interface VectorText {
+  content: string
+  x: number
+  y: number
+  fontSize: number
+  fontFamily: string
+  /** 100..900. */
+  fontWeight: number
+  /** `#rrggbb`. */
+  fill: string
+  /** Text anchor; `start` when absent. */
+  anchor?: 'start' | 'middle' | 'end'
+  /** Rotation in degrees about (`x`,`y`); absent ⇒ upright. */
+  angle?: number
+}
+
 /** The whole document: shapes in paint order, in user (px) coordinates, y-down. */
 export interface VectorDocument {
   /** viewBox width/height in px (user units). */
@@ -40,4 +63,9 @@ export interface VectorDocument {
   shapes: VectorShape[]
   /** Gradient paint servers referenced by `fill: 'url(#id)'`. */
   gradients?: VectorGradient[]
+  /**
+   * Optional recovered text runs, drawn after the shapes. Absent ⇒ no text —
+   * the engine's own output never sets it, so a traced document is unchanged.
+   */
+  texts?: VectorText[]
 }

--- a/packages/svg/src/index.ts
+++ b/packages/svg/src/index.ts
@@ -9,4 +9,11 @@ export { arcToCubics, fitArcs } from './arc'
 export { detectPrimitive } from './primitive'
 export type { Primitive } from './primitive'
 export { serializeSvg, shapeOut } from './serialize'
-export type { SerializeOptions, ShapeOut, SvgDocument, SvgGradient, SvgShape } from './serialize'
+export type {
+  SerializeOptions,
+  ShapeOut,
+  SvgDocument,
+  SvgGradient,
+  SvgShape,
+  SvgText,
+} from './serialize'

--- a/packages/svg/src/serialize.ts
+++ b/packages/svg/src/serialize.ts
@@ -46,6 +46,27 @@ export interface SvgShape {
  *  namespace these ids first, or every `url(#g0)` resolves to the first one. */
 export type SvgGradient = GradientPaint & { id: string }
 
+/**
+ * A native `<text>` element, drawn after every shape so it sits on top. The
+ * engine never produces one — this is carried in when a consumer (the studio's
+ * OCR text layer) recovers editable words. `x`/`y`/`fontSize` are user units.
+ */
+export interface SvgText {
+  content: string
+  x: number
+  y: number
+  fontSize: number
+  fontFamily: string
+  /** 100..900. */
+  fontWeight: number
+  /** `#rrggbb`. */
+  fill: string
+  /** Text anchor; `start` (the SVG default) when absent. */
+  anchor?: 'start' | 'middle' | 'end'
+  /** Rotation in degrees about (`x`,`y`); absent ⇒ upright. */
+  angle?: number
+}
+
 export interface SvgDocument {
   /** px viewBox size. */
   width: number
@@ -58,6 +79,12 @@ export interface SvgDocument {
   /** Gradient paint servers referenced by shape fills (`fill: 'url(#id)'`). */
   defs?: SvgGradient[]
   shapes: SvgShape[]
+  /**
+   * Native text runs, emitted after the shapes so they render on top. Absent or
+   * empty ⇒ no `<text>`, so a text-free document serializes byte-identically to
+   * before this field existed (the engine's own documents never set it).
+   */
+  texts?: SvgText[]
 }
 
 export interface SerializeOptions {
@@ -161,6 +188,27 @@ function primitiveElement(prim: Primitive, shape: SvgShape, precision: number): 
       return `<polygon points="${points}"${paint}/>`
     }
   }
+}
+
+/**
+ * A recovered text run as a `<text>` element. Content and `font-family` are
+ * XML-escaped; `fill` is asserted attribute-safe (it is a `#rrggbb` from the
+ * app). `text-anchor` is emitted only when not the `start` default; a non-zero
+ * `angle` becomes a `rotate(deg x y)` transform. Returns `''` for empty content
+ * so a stray word contributes nothing (mirroring empty shapes being skipped).
+ */
+function textElement(t: SvgText, precision: number): string {
+  if (t.content === '') return ''
+  const n = (v: number): string => formatNumber(v, precision)
+  let attrs = `x="${n(t.x)}" y="${n(t.y)}"`
+  if (t.angle !== undefined && Math.abs(t.angle) > 0.05) {
+    attrs += ` transform="rotate(${n(t.angle)} ${n(t.x)} ${n(t.y)})"`
+  }
+  attrs += ` font-family="${xmlEscape(t.fontFamily)}" font-size="${n(t.fontSize)}"`
+  attrs += ` font-weight="${formatNumber(t.fontWeight, 0)}"`
+  if (t.anchor !== undefined && t.anchor !== 'start') attrs += ` text-anchor="${t.anchor}"`
+  attrs += ` fill="${assertAttrSafe(t.fill, 'text fill')}"`
+  return `<text ${attrs}>${xmlEscape(t.content)}</text>`
 }
 
 /**
@@ -313,6 +361,16 @@ export function serializeSvg(
     const all = doc.shapes.map((_, i) => i)
     for (const child of foldShapes(doc.shapes, all, precision, optimize, roundPrimitives, parts)) {
       children.push(child)
+    }
+  }
+
+  // Recovered text runs render last so they sit on top of the traced geometry.
+  // No `texts` ⇒ this loop adds nothing and the output is byte-identical to a
+  // text-free document (the engine's own trace never sets the field).
+  if (doc.texts !== undefined) {
+    for (const t of doc.texts) {
+      const el = textElement(t, precision)
+      if (el !== '') children.push(el)
     }
   }
 

--- a/packages/svg/src/serialize.ts
+++ b/packages/svg/src/serialize.ts
@@ -59,6 +59,8 @@ export interface SvgText {
   fontFamily: string
   /** 100..900. */
   fontWeight: number
+  /** `italic` for slanted text; `normal` (or absent) upright. */
+  fontStyle?: 'normal' | 'italic'
   /** `#rrggbb`. */
   fill: string
   /** Text anchor; `start` (the SVG default) when absent. */
@@ -206,6 +208,7 @@ function textElement(t: SvgText, precision: number): string {
   }
   attrs += ` font-family="${xmlEscape(t.fontFamily)}" font-size="${n(t.fontSize)}"`
   attrs += ` font-weight="${formatNumber(t.fontWeight, 0)}"`
+  if (t.fontStyle === 'italic') attrs += ` font-style="italic"`
   if (t.anchor !== undefined && t.anchor !== 'start') attrs += ` text-anchor="${t.anchor}"`
   attrs += ` fill="${assertAttrSafe(t.fill, 'text fill')}"`
   return `<text ${attrs}>${xmlEscape(t.content)}</text>`

--- a/packages/svg/test/serialize.test.ts
+++ b/packages/svg/test/serialize.test.ts
@@ -333,6 +333,26 @@ describe('serializeSvg', () => {
     expect(mk('start', 0)).not.toContain('transform')
   })
 
+  it('emits font-style only for italic text', () => {
+    const t = {
+      content: 'Hi',
+      x: 1,
+      y: 1,
+      fontSize: 8,
+      fontFamily: 'Arial',
+      fontWeight: 400,
+      fill: '#000000',
+    }
+    const svg = (style?: 'normal' | 'italic'): string =>
+      serializeSvg(
+        { width: 4, height: 4, unit: 'px', shapes: [], texts: [{ ...t, fontStyle: style }] },
+        { precision: 2 },
+      )
+    expect(svg('italic')).toContain('font-style="italic"')
+    expect(svg('normal')).not.toContain('font-style')
+    expect(svg(undefined)).not.toContain('font-style')
+  })
+
   it('throws on an unsafe text fill instead of emitting broken XML', () => {
     const doc: SvgDocument = {
       width: 4,

--- a/packages/svg/test/serialize.test.ts
+++ b/packages/svg/test/serialize.test.ts
@@ -1,7 +1,7 @@
 import type { PathCommand } from '@trazor/core'
 import { describe, expect, it } from 'vitest'
 import { buildPathData, formatNumber, serializeSvg } from '../src/index'
-import type { SvgDocument } from '../src/index'
+import type { SvgDocument, SvgText } from '../src/index'
 
 const square = (x0: number, y0: number, x1: number, y1: number): PathCommand[] => [
   { type: 'M', x: x0, y: y0 },
@@ -250,6 +250,132 @@ describe('serializeSvg', () => {
     const green = /<g id="layer-2">.*?<\/g>/s.exec(svg)![0]
     expect((red.match(/<path /g) ?? []).length).toBe(2)
     expect((green.match(/<path /g) ?? []).length).toBe(1)
+  })
+
+  it('emits recovered <text> after the shapes, with escaped content and family', () => {
+    const doc: SvgDocument = {
+      ...goldenDoc(),
+      texts: [
+        {
+          content: 'Fish & Chips',
+          x: 3,
+          y: 20,
+          fontSize: 12,
+          fontFamily: 'Times New Roman',
+          fontWeight: 700,
+          fill: '#123456',
+        },
+      ],
+    }
+    const svg = serializeSvg(doc, { precision: 2 })
+    expect(svg).toContain(
+      '<text x="3" y="20" font-family="Times New Roman" font-size="12"' +
+        ' font-weight="700" fill="#123456">Fish &amp; Chips</text>',
+    )
+    // Text comes after both traced paths and before the closing tag.
+    expect(svg.indexOf('<text ')).toBeGreaterThan(svg.lastIndexOf('<path '))
+    expect(svg.indexOf('<text ')).toBeLessThan(svg.indexOf('</svg>'))
+  })
+
+  it('a text-free document serializes byte-identically to before the field existed', () => {
+    const base = serializeSvg(goldenDoc(), { precision: 2 })
+    expect(serializeSvg({ ...goldenDoc(), texts: undefined }, { precision: 2 })).toBe(base)
+    expect(serializeSvg({ ...goldenDoc(), texts: [] }, { precision: 2 })).toBe(base)
+    // A text whose content is empty contributes nothing either.
+    expect(
+      serializeSvg(
+        {
+          ...goldenDoc(),
+          texts: [
+            {
+              content: '',
+              x: 0,
+              y: 0,
+              fontSize: 10,
+              fontFamily: 'Arial',
+              fontWeight: 400,
+              fill: '#000000',
+            },
+          ],
+        },
+        { precision: 2 },
+      ),
+    ).toBe(base)
+  })
+
+  it('emits text-anchor only when not the start default, and angle as a rotate transform', () => {
+    const mk = (anchor: SvgText['anchor'], angle?: number): string =>
+      serializeSvg(
+        {
+          width: 40,
+          height: 20,
+          unit: 'px',
+          shapes: [],
+          texts: [
+            {
+              content: 'Hi',
+              x: 20,
+              y: 10,
+              fontSize: 8,
+              fontFamily: 'Arial',
+              fontWeight: 400,
+              fill: '#000000',
+              anchor,
+              angle,
+            },
+          ],
+        },
+        { precision: 2 },
+      )
+    expect(mk('start')).not.toContain('text-anchor')
+    expect(mk('middle')).toContain('text-anchor="middle"')
+    expect(mk('middle', 90)).toContain('transform="rotate(90 20 10)"')
+    expect(mk('start', 0)).not.toContain('transform')
+  })
+
+  it('throws on an unsafe text fill instead of emitting broken XML', () => {
+    const doc: SvgDocument = {
+      width: 4,
+      height: 4,
+      unit: 'px',
+      shapes: [],
+      texts: [
+        {
+          content: 'x',
+          x: 0,
+          y: 0,
+          fontSize: 4,
+          fontFamily: 'Arial',
+          fontWeight: 400,
+          fill: '"><script>',
+        },
+      ],
+    }
+    expect(() => serializeSvg(doc, { precision: 2 })).toThrow(/unsafe text fill/)
+  })
+
+  it('pretty mode puts each <text> on its own indented line after the shapes', () => {
+    const lines = serializeSvg(
+      {
+        ...goldenDoc(),
+        texts: [
+          {
+            content: 'A',
+            x: 1,
+            y: 1,
+            fontSize: 6,
+            fontFamily: 'Arial',
+            fontWeight: 400,
+            fill: '#000000',
+          },
+        ],
+      },
+      { precision: 2, pretty: true },
+    ).split('\n')
+    const textLine = lines.findIndex((l) => l.startsWith('  <text '))
+    const lastPath = lines.map((l) => l.trimStart().startsWith('<path ')).lastIndexOf(true)
+    expect(textLine).toBeGreaterThan(lastPath)
+    expect(lines[lines.length - 2]).toBe('</svg>')
   })
 
   it('folds a color layer to a single <path> when optimizing, and drops empty layers', () => {


### PR DESCRIPTION
Add an optional text layer to the vector document model, so a consumer (the
studio's OCR text tool) can carry recovered words as native, editable SVG
`<text>` alongside the traced geometry. Pure model + serialization; nothing in
the tracer changes and the default output is byte-identical to before.

## Changes

- **`packages/core`** — a `VectorText` interface (content, x, y, fontSize,
  fontFamily, fontWeight, optional `fontStyle: 'normal' | 'italic'`, fill,
  optional anchor and angle) and an optional `texts?: VectorText[]` on
  `VectorDocument`.
- **`packages/svg`** — a matching `SvgText` type and optional `texts?` on
  `SvgDocument`; `serializeSvg` emits a `<text>` element per run (XML-escaped
  content, `font-style="italic"` only when italic, `text-anchor` only when not
  `start`, an `angle` → `rotate(...)` transform). When `texts` is absent the
  serialized string is unchanged, so existing callers are unaffected. `SvgText`
  is re-exported from the package index.
- **`docs/CONTRACTS.md`** — records both new types.
- **Tests** — `serialize.test.ts` covers emission, escaping, the italic/anchor/
  rotate conditionals, and the byte-identical-when-absent guarantee.

## Why

The studio recovers words with on-device OCR and needs them as real `<text>` in
the exported SVG (selectable, restyleable, re-typable) rather than letter-shaped
paths. Keeping the model and serialization in the engine lets an injected run
and an engine-serialized one be identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QutknH5zFabAoVqHNgidag

---
_Generated by [Claude Code](https://claude.ai/code/session_01QutknH5zFabAoVqHNgidag)_